### PR TITLE
database/updates: Add command to drop table 'languages' if it exists

### DIFF
--- a/docs/database/updates/2014-05-25.sql
+++ b/docs/database/updates/2014-05-25.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS languages;
 RENAME TABLE langStats TO languages;
 ALTER TABLE languages MODIFY COLUMN id SMALLINT(3) FIRST;
 ALTER TABLE languages CHANGE lang code VARCHAR(4) COLLATE utf8_general_ci;


### PR DESCRIPTION
In update 2014-05-25.sql the first command tries to rename table
langStats to languages. But if the update scripts are run on an
existing database, it throws an error that stating table languages
already exists. This fix prevents it by dropping table languages
if it exists.
