### PR TITLE
Fix #266 (language list collation).

### DIFF
--- a/app/views/helpers/languages.php
+++ b/app/views/helpers/languages.php
@@ -237,7 +237,13 @@ class LanguagesHelper extends AppHelper
             'guj' => __('Gujarati',true), //@lang 
             );
             
-            asort($this->__languages);
+            if (class_exists('Collator')) {
+                $i18nLang = Configure::read('Config.language');
+                $coll = new Collator($this->i18nCodeToISO($i18nLang));
+                $coll->asort($this->__languages);
+            } else {
+                asort($this->__languages);
+            }
         }
         
         return $this->__languages;
@@ -383,7 +389,6 @@ class LanguagesHelper extends AppHelper
     public function getSearchableLanguagesArray()
     {
         $languages = $this->onlyLanguagesArray();
-        natcasesort($languages);
         array_unshift($languages, array('und' => __('Any', true)));
 
         return $languages;


### PR DESCRIPTION
If available, use ICU to sort language lists according to the interface
language locale collation rules. One must install the intl PHP extension
to get that working.

From what I can tell, it's doing a good job for:
• German: Dänish goes before Deutsch instead of the opposite
• French: éwé is now at the end of the E’s instead of an the end of the whole list
• Spanish: Árabe is in the middle of the A’s
• Japanese kanjis are ordered differently but I can’t tell the logic; it can’t be as clumsy as PHP’s natcasesort() anyway
