### PR TITLE
app/config: Add a value for location of pid file for sphinx

### DIFF
--- a/app/config/database.php.template
+++ b/app/config/database.php.template
@@ -106,7 +106,7 @@ class DATABASE_CONFIG {
         'indexdir' => '{{sphinx_index_dir}}',
         'socket' => '{{sphinx_sql_socket}}',
         'logdir' => '{{sphinx_log_dir}}',
-        'pidfile' => '{{sphinx_pd_file}}'
+        'pidfile' => '{{sphinx_pid_file}}'
     );
 }
 ?>

--- a/docs/sphinx/generate_sphinx_conf.php
+++ b/docs/sphinx/generate_sphinx_conf.php
@@ -434,7 +434,7 @@ searchd
     read_timeout            = 5
     max_children            = 30
 
-    pid_file                = <?php echo $configs['sphinx']['pidfile']; echo "\n"; ?>
+    pid_file                = <?php echo $configs['sphinx']['pidfile'] . "\n"; ?>
     max_matches             = 1000
     seamless_rotate         = 1
     preopen_indexes         = 1


### PR DESCRIPTION
The init script provided with sphinxsearch debian package requires
correct location of pid file of sphinx, so that it can run on system
start-up. So this value is now initialized with a variable `sphinx_pid_file`
in database.php.template so that it can be used to set the location
of pid file in sphinx's init script as well
