### PR TITLE
corrected label on buttons for hidden comments #592

### DIFF
--- a/app/views/helpers/comments.php
+++ b/app/views/helpers/comments.php
@@ -226,8 +226,7 @@ class CommentsHelper extends AppHelper
             }
 
             $menu[] = array(
-                'text' => format(__('{text}', true),
-                    array('text' => $hiddenLinkText)),
+                'text' => $hiddenLinkText,
                 'url' => array(
                     "controller" => "sentence_comments",
                     "action" => $hiddenLinkAction,

--- a/app/views/helpers/comments.php
+++ b/app/views/helpers/comments.php
@@ -226,7 +226,8 @@ class CommentsHelper extends AppHelper
             }
 
             $menu[] = array(
-                'text' => __('hide', true),
+                'text' => format(__('{text}', true),
+                    array('text' => $hiddenLinkText)),
                 'url' => array(
                     "controller" => "sentence_comments",
                     "action" => $hiddenLinkAction,


### PR DESCRIPTION
Button now reads 'unhide' when comment is hidden. 