### PR TITLE
Kill ultimate query

### DIFF
--- a/app/models/translation.php
+++ b/app/models/translation.php
@@ -44,22 +44,22 @@ class Translation extends AppModel
     {
         $translations = $this->_getTranslationsOf($sentenceId, $languages);
 
-        // Calling manually the trigger for afterFind of Transcriptable behavior
-        // because the query to retrieve the translations is a custom query
-        $results['Translation'] = $this->Behaviors->trigger(
-            $this,
-            'afterFind',
-            array($translations['Translation'], false), 
-            array('modParams' => true)
+        $orderedTranslations = array(
+            'Translation' => array(),
+            'IndirectTranslation' => array()
         );
-        $results['IndirectTranslation'] = $this->Behaviors->trigger(
-            $this,
-            'afterFind',
-            array($translations['IndirectTranslation'], false),
-            array('modParams' => true)
+        $map = array(
+            '0' => 'Translation',
+            '1' => 'IndirectTranslation',
         );
+        foreach ($translations as $record) {
+            $distance = $record['AllTranslations']['type'];
+            $orderedTranslations[ $map[$distance] ][] = array(
+                'Translation' => $record['Translation']
+            );
+        };
 
-        return $results;
+        return $orderedTranslations;
     }
 
 
@@ -73,96 +73,83 @@ class Translation extends AppModel
      */
     private function _getTranslationsOf($id, $langs)
     {
-        if (empty($langs)) {
-            $langConditions = "";
-        } else {
-            $langs = "'".implode("','",$langs)."'";
-            $langConditions = "AND p2.lang IN ($langs)";
-        }
-
-        // DA ultimate Query
-        $direcTranslationsQuery = "
-            SELECT
-              p2.text AS translation_text,
-              p2.hasaudio AS hasaudio,
-              p2.id   AS translation_id,
-              p2.lang AS translation_lang,
-              p2.user_id AS translation_user_id,
-              p2.correctness AS correctness,
-              'Translation' as distance
-            FROM sentences_translations AS t
-              LEFT  JOIN sentences AS p2 ON t.translation_id = p2.id
-            WHERE
-                t.sentence_id IN ($id) $langConditions
-        ";
-
-        // query use to retrieve sentence which are already direct
-        // translations
-        $subQuery = "
-            SELECT sentences_translations.translation_id
-            FROM sentences_translations
-            WHERE sentences_translations.sentence_id IN ( $id )
-        ";
-
-        $indirectTranslationQuery = "
-         SELECT
-              p2.text AS translation_text,
-              p2.hasaudio AS hasaudio,
-              p2.id   AS translation_id,
-              p2.lang AS translation_lang,
-              p2.user_id AS translation_user_id,
-              p2.correctness AS correctness,
-              'IndirectTranslation'  as distance
-            FROM sentences_translations AS t
-                LEFT JOIN sentences_translations AS t2
-                    ON t2.sentence_id = t.translation_id
-                LEFT JOIN sentences AS p2
-                    ON t2.translation_id = p2.id
-            WHERE
-                t.sentence_id != p2.id
-                AND p2.id NOT IN ( $subQuery )
-                AND t.sentence_id IN ( $id )
-                $langConditions
-            ORDER BY 4
-        ";
-
-        $query = "
-            $direcTranslationsQuery
-            UNION
-            $indirectTranslationQuery
-        ";
-
-        $results = $this->query($query);
-
-        $orderedResults = array(
-            "Translation" => array(),
-            "IndirectTranslation" => array()
+        /**
+         * This query is constructed with a subquery, which finds the
+         * translations ids and report the type (direct or indirect).
+         * Then, we’re join()'ing with this subquery in order to get
+         * all the sentences with these ids, along with the type.
+         * In SQL terms, it looks like this:
+         *
+         *   SELECT AllTranslations.type, Translation.*
+         *   FROM
+         *     sentences AS Translation,
+         *     (
+         *       SELECT IF(Link.sentence_id = IndirectLink.translation_id,
+         *                IndirectLink.sentence_id, IndirectLink.translation_id)
+         *                AS translation_id,
+         *              MIN(Link.sentence_id <> IndirectLink.translation_id)
+         *                AS 'type'
+         *       FROM sentences_translations AS Link
+         *       INNER JOIN sentences_translations AS IndirectLink
+         *             ON (Link.translation_id = IndirectLink.sentence_id)
+         *       WHERE Link.sentence_id = $id
+         *       GROUP BY translation_id
+         *     ) AS AllTranslations
+         *   WHERE Translation.id = AllTranslations.translation_id
+         *   ORDER BY Translation.lang;
+         */
+        $dbo = $this->getDataSource();
+        $subQuery = $dbo->buildStatement(
+            array(
+                'fields' => array(
+                    "IF(Link.sentence_id = IndirectLink.translation_id, "
+                        ."IndirectLink.sentence_id, "
+                        ."IndirectLink.translation_id) "
+                        ."AS translation_id",
+                    "MIN(Link.sentence_id <> IndirectLink.translation_id) "
+                        ."AS 'type'",
+                ),
+                'table' => 'sentences_translations',
+                'alias' => 'Link',
+                'limit' => null,
+                'offset' => null,
+                'joins' => array(array(
+                    'table' => 'sentences_translations',
+                    'alias' => 'IndirectLink',
+                    'type' => 'inner',
+                    'conditions' => array(
+                        'Link.translation_id = IndirectLink.sentence_id'
+                    ),
+                )),
+                'conditions' => array('Link.sentence_id' => $id),
+                'order' => null,
+                'group' => 'translation_id',
+            ),
+            $this
         );
-        foreach ($results as $result) {
-            $result = $result[0] ;
-            if ($result['translation_id']) { // need to check this because
-                // for sentences without translations it would otherwise
-                // return an empty translation array.
 
-                $translation = array(
-                    'Translation' => array(
-                        'id' => $result['translation_id'],
-                        'text' => $result['translation_text'],
-                        'user_id' => $result['translation_user_id'],
-                        'lang' => $result['translation_lang'],
-                        'hasaudio' => $result['hasaudio'],
-                        'correctness' => $result['correctness']
-                    )
-                );
-
-                array_push(
-                    $orderedResults[$result['distance']],
-                    $translation
-                );
-            }
-        }
-
-        return $orderedResults;
+        $conditions = $langs ? array('Translation.lang' => $langs) : array();
+        return parent::find('all', array(
+            'joins' => array(
+                array(
+                    'table' => "($subQuery)",
+                    'alias' => 'AllTranslations',
+                    'conditions' => array('Translation.id = AllTranslations.translation_id'),
+                )
+            ),
+            'conditions' => $conditions,
+            'fields' => array(
+                'AllTranslations.type',
+                'Translation.id',
+                'Translation.text',
+                'Translation.user_id',
+                'Translation.lang',
+                'Translation.hasaudio',
+                'Translation.correctness',
+            ),
+            'order' => array('Translation.lang'),
+            'contain' => array(),
+        ));
     }
 }
 ?>

--- a/app/tests/cases/models/translation.test.php
+++ b/app/tests/cases/models/translation.test.php
@@ -1,0 +1,101 @@
+<?php
+App::import('Model', 'Translation');
+
+class TranslationTestCase extends CakeTestCase {
+    var $fixtures = array(
+        'app.sentence',
+        'app.user',
+        'app.group',
+        'app.country',
+        'app.sentence_comment',
+        'app.contribution',
+        'app.sentences_list',
+        'app.sentences_sentences_list',
+        'app.wall',
+        'app.wall_thread',
+        'app.favorites_user',
+        'app.tag',
+        'app.tags_sentence',
+        'app.language',
+        'app.link',
+        'app.sentence_annotation',
+    );
+
+    function startTest() {
+        Configure::write('AutoTranscriptions.enabled', false);
+        $this->Translation =& ClassRegistry::init('Translation');
+    }
+
+    function endTest() {
+        unset($this->Translation);
+        ClassRegistry::flush();
+    }
+
+    function testFindCheckAllFields() {
+        $result = $this->Translation->find(5, array());
+        $expected = array(
+            'Translation' => array(
+                array('Translation' => array(
+                    'id' => "2",
+                    'text' => "问题的根源是，在当今世界，愚人充满了自信，而智者充满了怀疑。",
+                    'user_id' => "7",
+                    'lang' => "cmn",
+                    'hasaudio' => "no",
+                    'correctness' => "0",
+                    'script' => null,
+                )),
+            ),
+            'IndirectTranslation' => array(
+                array('Translation' => array(
+                    'id' => "1",
+                    'text' => "The fundamental cause of the problem is that in the modern world, idiots are full of confidence, while the intelligent are full of doubt.",
+                    'user_id' => "7",
+                    'lang' => "eng",
+                    'hasaudio' => "no",
+                    'correctness' => "0",
+                    'script' => null,
+                )),
+                array('Translation' => array(
+                    'id' => "4",
+                    'text' => "La cause fondamentale du problème est que dans le monde moderne, les imbéciles sont plein d'assurance, alors que les gens intelligents sont pleins de doute.",
+                    'user_id' => "7",
+                    'lang' => "fra",
+                    'hasaudio' => "no",
+                    'correctness' => "0",
+                    'script' => null,
+                )),
+            ),
+        );
+        $this->assertEqual($expected, $result);
+    }
+
+    function _assertFind($sentenceId, $langs, $expectedTranslationIds, $expectedIndirectTranslationIds) {
+        $result = $this->Translation->find($sentenceId, $langs);
+        $result = Set::classicExtract($result, '{}.{n}.Translation.id');
+        $expected = array(
+            'Translation' => $expectedTranslationIds,
+            'IndirectTranslation' => $expectedIndirectTranslationIds,
+        );
+        $this->assertEqual($expected, $result);
+    }
+
+    function testFindCheckIds() {
+        $this->_assertFind(1, array(), array(2, 4, 3), array(5, 6));
+    }
+
+    function testFindWithFilteredDirectTranslation() {
+        $this->_assertFind(1, array('cmn'), array(2), array());
+    }
+
+    function testFindWithFilteredIndirectTranslation() {
+        $this->_assertFind(1, array('jpn'), array(), array(6));
+    }
+
+    function testFindWithFilteredMultipleLang() {
+        $this->_assertFind(1, array('spa', 'deu'), array(3), array(5));
+    }
+
+    function testFindWithoutTranslation() {
+        $this->_assertFind(7, array(), array(), array());
+    }
+}


### PR DESCRIPTION
This PR replaces the infamous SQL query of the Translation model with a CakePHP find(). Since it’s a very critical part of the code, I’d like people to review it carefully.

As explained in the commit message:
> According to personal tests, the new query itself is rather faster than the old one. I can’t tell how much because there is so much noise, but at least, the worst benchmark of the new outran the best benchmark of the old query.

But this is to be balanced with the overhead CakePHP’s find(), which I don’t know, but I’m confident it won’t hurt much.