### PR TITLE
Extensible options

### DIFF
--- a/app/app_controller.php
+++ b/app/app_controller.php
@@ -226,9 +226,6 @@ class AppController extends Controller
         $mostRecentList = $this->Cookie->read('most_recent_list');
         $this->Session->write('most_recent_list', $mostRecentList);
 
-        $restrictSearchLangsEnabled = $this->Cookie->read('restrict_search_langs_enabled');
-        $this->Session->write('restrict_search_langs_enabled', $restrictSearchLangsEnabled);
-
         $jqueryChosen = $this->Cookie->read('jquery_chosen');
         $this->Session->write('jquery_chosen', $jqueryChosen);
     }

--- a/app/app_controller.php
+++ b/app/app_controller.php
@@ -226,9 +226,6 @@ class AppController extends Controller
         $mostRecentList = $this->Cookie->read('most_recent_list');
         $this->Session->write('most_recent_list', $mostRecentList);
 
-        $collapsibleTranslationsEnabled = $this->Cookie->read('collapsible_translations_enabled');
-        $this->Session->write('collapsible_translations_enabled', $collapsibleTranslationsEnabled);
-
         $restrictSearchLangsEnabled = $this->Cookie->read('restrict_search_langs_enabled');
         $this->Session->write('restrict_search_langs_enabled', $restrictSearchLangsEnabled);
 

--- a/app/app_controller.php
+++ b/app/app_controller.php
@@ -226,11 +226,6 @@ class AppController extends Controller
         $mostRecentList = $this->Cookie->read('most_recent_list');
         $this->Session->write('most_recent_list', $mostRecentList);
 
-        // This controls whether to use the most_recent_list cookie, or simply
-        // to choose the first list in alphabetical order.
-        $useMostRecentList = $this->Cookie->read('use_most_recent_list');
-        $this->Session->write('use_most_recent_list', $useMostRecentList);
-
         $collapsibleTranslationsEnabled = $this->Cookie->read('collapsible_translations_enabled');
         $this->Session->write('collapsible_translations_enabled', $collapsibleTranslationsEnabled);
 

--- a/app/controllers/user_controller.php
+++ b/app/controllers/user_controller.php
@@ -124,7 +124,7 @@ class UserController extends AppController
 
         $isPublic = ($user['settings']['is_public'] == 1);
         $isDisplayed = ($isPublic || CurrentUser::isMember());
-        $notificationsEnabled = ($user['settings']['send_notifications'] == 1);
+        $notificationsEnabled = ($user['send_notifications'] == 1);
 
         $this->set('userStats', $userStats);
         $this->set('user', $user);

--- a/app/controllers/user_controller.php
+++ b/app/controllers/user_controller.php
@@ -376,9 +376,6 @@ class UserController extends AppController
             $jqueryChosen = $this->data['User']['jquery_chosen'];
             $this->Cookie->write('jquery_chosen', $jqueryChosen, false, "+1 month");;
 
-            $collapsibleTranslationsEnabled = $this->data['User']['collapsible_translations_enabled'];
-            $this->Cookie->write('collapsible_translations_enabled', $collapsibleTranslationsEnabled, false, "+1 month");;
-
             $restrictSearchLangsEnabled = $this->data['User']['restrict_search_langs_enabled'];
             $this->Cookie->write('restrict_search_langs_enabled', $restrictSearchLangsEnabled, false, "+1 month");;
 
@@ -553,9 +550,6 @@ class UserController extends AppController
         $this->data['User']['jquery_chosen'] 
           = $this->Cookie->read('jquery_chosen');
         
-        $this->data['User']['collapsible_translations_enabled']
-            = $this->Cookie->read('collapsible_translations_enabled');
-
         $this->data['User']['restrict_search_langs_enabled']
             = $this->Cookie->read('restrict_search_langs_enabled');
         

--- a/app/controllers/user_controller.php
+++ b/app/controllers/user_controller.php
@@ -376,11 +376,6 @@ class UserController extends AppController
             $jqueryChosen = $this->data['User']['jquery_chosen'];
             $this->Cookie->write('jquery_chosen', $jqueryChosen, false, "+1 month");;
 
-            // Remember the last sentence list to which user assigned a sentence
-            // and bring it up as the default.
-            $useMostRecentList = $this->data['User']['use_most_recent_list'];
-            $this->Cookie->write('use_most_recent_list', $useMostRecentList, false, "+1 month");
-
             $collapsibleTranslationsEnabled = $this->data['User']['collapsible_translations_enabled'];
             $this->Cookie->write('collapsible_translations_enabled', $collapsibleTranslationsEnabled, false, "+1 month");;
 
@@ -557,9 +552,6 @@ class UserController extends AppController
         // Whether to use advanced selectors for language selection
         $this->data['User']['jquery_chosen'] 
           = $this->Cookie->read('jquery_chosen');
-        // Whether to select by default the last list to which user assigned a sentence
-        $this->data['User']['use_most_recent_list']
-          = $this->Cookie->read('use_most_recent_list');
         
         $this->data['User']['collapsible_translations_enabled']
             = $this->Cookie->read('collapsible_translations_enabled');

--- a/app/controllers/user_controller.php
+++ b/app/controllers/user_controller.php
@@ -387,11 +387,12 @@ class UserController extends AppController
             $restrictSearchLangsEnabled = $this->data['User']['restrict_search_langs_enabled'];
             $this->Cookie->write('restrict_search_langs_enabled', $restrictSearchLangsEnabled, false, "+1 month");;
 
+            $this->data['User']['settings']['lang'] = $this->_language_settings(
+                $this->data['User']['settings']['lang']
+            );
             $dataToSave = array(
                 'id' => $currentUserId,
-                'lang' => $this->_language_settings($this->data['User']['lang']),
-                'send_notifications' => $this->data['User']['send_notifications'],
-                'is_public' => $this->data['User']['is_public'],
+                'settings' => $this->data['User']['settings'],
             );
             if ($this->User->save($dataToSave)) {
                 // Needed so that the information is updated for the Auth component.

--- a/app/controllers/user_controller.php
+++ b/app/controllers/user_controller.php
@@ -381,6 +381,7 @@ class UserController extends AppController
             );
             $dataToSave = array(
                 'id' => $currentUserId,
+                'send_notifications' => $this->data['User']['send_notifications'],
                 'settings' => $this->data['User']['settings'],
             );
             if ($this->User->save($dataToSave)) {

--- a/app/controllers/user_controller.php
+++ b/app/controllers/user_controller.php
@@ -122,9 +122,9 @@ class UserController extends AppController
         $userStats = $this->_stats($userId);
         $userLanguages = $this->UsersLanguages->getLanguagesOfUser($userId);
 
-        $isPublic = ($user['is_public'] == 1);
+        $isPublic = ($user['settings']['is_public'] == 1);
         $isDisplayed = ($isPublic || CurrentUser::isMember());
-        $notificationsEnabled = ($user['send_notifications'] == 1);
+        $notificationsEnabled = ($user['settings']['send_notifications'] == 1);
 
         $this->set('userStats', $userStats);
         $this->set('user', $user);

--- a/app/controllers/user_controller.php
+++ b/app/controllers/user_controller.php
@@ -376,9 +376,6 @@ class UserController extends AppController
             $jqueryChosen = $this->data['User']['jquery_chosen'];
             $this->Cookie->write('jquery_chosen', $jqueryChosen, false, "+1 month");;
 
-            $restrictSearchLangsEnabled = $this->data['User']['restrict_search_langs_enabled'];
-            $this->Cookie->write('restrict_search_langs_enabled', $restrictSearchLangsEnabled, false, "+1 month");;
-
             $this->data['User']['settings']['lang'] = $this->_language_settings(
                 $this->data['User']['settings']['lang']
             );
@@ -546,13 +543,10 @@ class UserController extends AppController
         }
 
         $this->data = $this->User->getSettings($currentUserId);
+
         // Whether to use advanced selectors for language selection
         $this->data['User']['jquery_chosen'] 
           = $this->Cookie->read('jquery_chosen');
-        
-        $this->data['User']['restrict_search_langs_enabled']
-            = $this->Cookie->read('restrict_search_langs_enabled');
-        
     }
 
 

--- a/app/controllers/users_controller.php
+++ b/app/controllers/users_controller.php
@@ -87,7 +87,7 @@ class UsersController extends AppController
             'limit' => 50,
             'order' => 'group_id',
             'fields' => array(
-                'id', 'email', 'username', 'since', 'lang', 'level'
+                'id', 'email', 'username', 'since', 'level'
             ),
             'contain' => array(
                 "Group" => array(

--- a/app/models/current_user.php
+++ b/app/models/current_user.php
@@ -301,7 +301,7 @@ class CurrentUser extends AppModel
      */
     public function getLanguages()
     {
-        $lang = CurrentUser::get('lang');
+        $lang = CurrentUser::get('settings.lang');
 
         if (empty($lang)) {
             return null;

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -122,6 +122,27 @@ class User extends AppModel
         )
     );
 
+    public function afterFind($results, $primary = false) {
+        static $defaultSettings = array(
+            'send_notifications' => true,
+            'is_public' => false,
+            'lang' => null,
+        );
+
+        foreach ($results as &$result) {
+            if (array_key_exists('settings', $result['User'])) {
+                $result['User']['settings'] = (array)json_decode(
+                    $result['User']['settings']
+                );
+                $result['User']['settings'] = array_merge(
+                    $defaultSettings,
+                    $result['User']['settings']
+                );
+            }
+        }
+        return $results;
+    }
+
     /**
      * ?
      *
@@ -206,13 +227,11 @@ class User extends AppModel
                     'image',
                     'homepage',
                     'since',
-                    'send_notifications',
                     'description',
+                    'settings',
                     'username',
                     'birthday',
-                    'is_public',
                     'group_id',
-                    'lang',
                     'level',
                     'country_id'
                 )

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -254,10 +254,8 @@ class User extends AppModel
             array(
                 'conditions' => array('id' => $userId),
                 'fields' => array(
-                    'is_public',
-                    'send_notifications',
+                    'settings',
                     'email',
-                    'lang'
                 )
             )
         );

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -126,8 +126,8 @@ class User extends AppModel
         'is_public' => false,
         'lang' => null,
         'use_most_recent_list' => null,
-        'collapsible_translations_enabled' => false,
-        'restrict_search_langs_enabled' => false,
+        'collapsible_translations' => false,
+        'restrict_search_langs' => false,
     );
 
     public function afterFind($results, $primary = false) {

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -124,7 +124,6 @@ class User extends AppModel
 
     public function afterFind($results, $primary = false) {
         static $defaultSettings = array(
-            'send_notifications' => true,
             'is_public' => false,
             'lang' => null,
         );
@@ -242,6 +241,7 @@ class User extends AppModel
                     'username',
                     'birthday',
                     'group_id',
+                    'send_notifications',
                     'level',
                     'country_id'
                 )

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -122,22 +122,22 @@ class User extends AppModel
         )
     );
 
-    public function afterFind($results, $primary = false) {
-        static $defaultSettings = array(
-            'is_public' => false,
-            'lang' => null,
-            'use_most_recent_list' => null,
-            'collapsible_translations_enabled' => false,
-            'restrict_search_langs_enabled' => false,
-        );
+    private $defaultSettings = array(
+        'is_public' => false,
+        'lang' => null,
+        'use_most_recent_list' => null,
+        'collapsible_translations_enabled' => false,
+        'restrict_search_langs_enabled' => false,
+    );
 
+    public function afterFind($results, $primary = false) {
         foreach ($results as &$result) {
             if (isset($result['User']) && array_key_exists('settings', $result['User'])) {
                 $result['User']['settings'] = (array)json_decode(
                     $result['User']['settings']
                 );
                 $result['User']['settings'] = array_merge(
-                    $defaultSettings,
+                    $this->defaultSettings,
                     $result['User']['settings']
                 );
             }
@@ -148,10 +148,10 @@ class User extends AppModel
     public function beforeSave($options = array()) {
         if (array_key_exists('settings', $this->data['User'])
             && is_array($this->data['User']['settings'])) {
-            $current = $this->field('settings', array('id' => $this->id));
-            $this->data['User']['settings'] = json_encode(
-                array_merge($current, $this->data['User']['settings'])
-            );
+            $settings = $this->field('settings', array('id' => $this->id));
+            $settings = array_merge($settings, $this->data['User']['settings']);
+            $settings = array_intersect_key($settings, $this->defaultSettings);
+            $this->data['User']['settings'] = json_encode($settings);
         }
         return true;
     }

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -268,6 +268,7 @@ class User extends AppModel
             array(
                 'conditions' => array('id' => $userId),
                 'fields' => array(
+                    'send_notifications',
                     'settings',
                     'email',
                 )

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -127,6 +127,7 @@ class User extends AppModel
             'is_public' => false,
             'lang' => null,
             'use_most_recent_list' => null,
+            'collapsible_translations_enabled' => false,
         );
 
         foreach ($results as &$result) {

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -128,6 +128,7 @@ class User extends AppModel
             'lang' => null,
             'use_most_recent_list' => null,
             'collapsible_translations_enabled' => false,
+            'restrict_search_langs_enabled' => false,
         );
 
         foreach ($results as &$result) {

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -126,6 +126,7 @@ class User extends AppModel
         static $defaultSettings = array(
             'is_public' => false,
             'lang' => null,
+            'use_most_recent_list' => null,
         );
 
         foreach ($results as &$result) {

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -240,12 +240,12 @@ class User extends AppModel
                     'image',
                     'homepage',
                     'since',
+                    'send_notifications',
                     'description',
                     'settings',
                     'username',
                     'birthday',
                     'group_id',
-                    'send_notifications',
                     'level',
                     'country_id'
                 )

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -125,7 +125,7 @@ class User extends AppModel
     private $defaultSettings = array(
         'is_public' => false,
         'lang' => null,
-        'use_most_recent_list' => null,
+        'use_most_recent_list' => false,
         'collapsible_translations' => false,
         'restrict_search_langs' => false,
     );

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -145,8 +145,9 @@ class User extends AppModel
     public function beforeSave($options = array()) {
         if (array_key_exists('settings', $this->data['User'])
             && is_array($this->data['User']['settings'])) {
+            $current = $this->field('settings', array('id' => $this->id));
             $this->data['User']['settings'] = json_encode(
-                $this->data['User']['settings']
+                array_merge($current, $this->data['User']['settings'])
             );
         }
         return true;

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -143,6 +143,16 @@ class User extends AppModel
         return $results;
     }
 
+    public function beforeSave($options = array()) {
+        if (array_key_exists('settings', $this->data['User'])
+            && is_array($this->data['User']['settings'])) {
+            $this->data['User']['settings'] = json_encode(
+                $this->data['User']['settings']
+            );
+        }
+        return true;
+    }
+
     /**
      * ?
      *

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -130,7 +130,7 @@ class User extends AppModel
         );
 
         foreach ($results as &$result) {
-            if (array_key_exists('settings', $result['User'])) {
+            if (isset($result['User']) && array_key_exists('settings', $result['User'])) {
                 $result['User']['settings'] = (array)json_decode(
                     $result['User']['settings']
                 );

--- a/app/views/elements/search_bar.ctp
+++ b/app/views/elements/search_bar.ctp
@@ -34,7 +34,7 @@ if (isset($this->params['lang'])) {
 
 <?php
 
-$restrictSearchLangsEnabled = CurrentUser::get('settings.restrict_search_langs_enabled');
+$restrictSearchLangsEnabled = CurrentUser::get('settings.restrict_search_langs');
 if ($restrictSearchLangsEnabled) {
     $langArray = $languages->profileLanguagesArray(false, false, true);
     $currentUserLanguages = CurrentUser::getProfileLanguages();

--- a/app/views/elements/search_bar.ctp
+++ b/app/views/elements/search_bar.ctp
@@ -34,7 +34,7 @@ if (isset($this->params['lang'])) {
 
 <?php
 
-$restrictSearchLangsEnabled = $session->read('restrict_search_langs_enabled');
+$restrictSearchLangsEnabled = CurrentUser::get('settings.restrict_search_langs_enabled');
 if ($restrictSearchLangsEnabled) {
     $langArray = $languages->profileLanguagesArray(false, false, true);
     $currentUserLanguages = CurrentUser::getProfileLanguages();

--- a/app/views/helpers/menu.php
+++ b/app/views/helpers/menu.php
@@ -353,7 +353,7 @@ class MenuHelper extends AppHelper
      */
     public function addToListButton($sentenceId, $isLogged)
     {
-        $useMostRecentList = $this->Session->read('use_most_recent_list');
+        $useMostRecentList = CurrentUser::get('settings.use_most_recent_list');
         if ($useMostRecentList != null && $useMostRecentList) {
             $mostRecentList = $this->Session->read('most_recent_list');
         } else {

--- a/app/views/helpers/sentences.php
+++ b/app/views/helpers/sentences.php
@@ -133,7 +133,7 @@ class SentencesHelper extends AppHelper
             $showButton = true;
 
             //if only 1 hidden sentence then show all
-            $collapsibleTranslationsEnabled = !CurrentUser::isMember() || CurrentUser::get('settings.collapsible_translations_enabled');
+            $collapsibleTranslationsEnabled = !CurrentUser::isMember() || CurrentUser::get('settings.collapsible_translations');
             if ($totalTranslations <= 6 || !$collapsibleTranslationsEnabled) {
                 $initiallyDisplayedTranslations = $totalTranslations;
                 $showButton = false;

--- a/app/views/helpers/sentences.php
+++ b/app/views/helpers/sentences.php
@@ -133,7 +133,7 @@ class SentencesHelper extends AppHelper
             $showButton = true;
 
             //if only 1 hidden sentence then show all
-            $collapsibleTranslationsEnabled = $this->Session->read('collapsible_translations_enabled') || !CurrentUser::isMember();
+            $collapsibleTranslationsEnabled = !CurrentUser::isMember() || CurrentUser::get('settings.collapsible_translations_enabled');
             if ($totalTranslations <= 6 || !$collapsibleTranslationsEnabled) {
                 $initiallyDisplayedTranslations = $totalTranslations;
                 $showButton = false;

--- a/app/views/layouts/default.ctp
+++ b/app/views/layouts/default.ctp
@@ -135,7 +135,7 @@
                 'time' => is_null($session->read('search_from'))
                           && is_null($session->read('search_to'))
                           && is_null($session->read('search_query'))
-                          && !CurrentUser::get('settings.restrict_search_langs_enabled')
+                          && !CurrentUser::get('settings.restrict_search_langs')
                           ? '+1 day' : false,
                 'key' => Configure::read('Config.language')
             )

--- a/app/views/layouts/default.ctp
+++ b/app/views/layouts/default.ctp
@@ -135,7 +135,7 @@
                 'time' => is_null($session->read('search_from'))
                           && is_null($session->read('search_to'))
                           && is_null($session->read('search_query'))
-                          && is_null($session->read('restrict_search_langs_enabled'))
+                          && !CurrentUser::get('settings.restrict_search_langs_enabled')
                           ? '+1 day' : false,
                 'key' => Configure::read('Config.language')
             )

--- a/app/views/user/profile.ctp
+++ b/app/views/user/profile.ctp
@@ -47,7 +47,7 @@ $userSince = $user['since'];
 $userStatus = $members->groupName($groupId);
 $statusClass = 'status'.$groupId;
 $currentMember = CurrentUser::get('username');
-$languagesSettings = $user['lang'];
+$languagesSettings = $user['settings']['lang'];
 $level = $user['level'];
 $countryName = $this->Countries->getCountryNameByCode($user['country_id']);
 

--- a/app/views/user/settings.ctp
+++ b/app/views/user/settings.ctp
@@ -49,7 +49,7 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
         ?>
         
         <div>
-            <?php echo $form->checkbox('settings.send_notifications'); ?>
+            <?php echo $form->checkbox('send_notifications'); ?>
             <label for="UserSendNotifications">
                 <?php __('Email notifications'); ?>
             </label>

--- a/app/views/user/settings.ctp
+++ b/app/views/user/settings.ctp
@@ -49,14 +49,14 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
         ?>
         
         <div>
-            <?php echo $form->checkbox('send_notifications'); ?>
+            <?php echo $form->checkbox('settings.send_notifications'); ?>
             <label for="UserSendNotifications">
                 <?php __('Email notifications'); ?>
             </label>
         </div>
         
         <div>
-            <?php echo $form->checkbox('is_public'); ?>
+            <?php echo $form->checkbox('settings.is_public'); ?>
             <label for="UserIsPublic">
                 <?php __('Set your profile public?'); ?>
             </label>
@@ -112,7 +112,7 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
             'languages.', true
         );
         echo $form->input(
-            'lang', 
+            'settings.lang',
             array(
                 'label' => __('Languages', true),
                 'after' => '<div>'.$tip.'</div>'

--- a/app/views/user/settings.ctp
+++ b/app/views/user/settings.ctp
@@ -84,7 +84,7 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
         </div>
 
         <div>
-            <?php echo $form->checkbox('collapsible_translations_enabled'); ?>
+            <?php echo $form->checkbox('settings.collapsible_translations_enabled'); ?>
             <label for="UserCollapsibleTranslationsEnabled">
                 <?php __(
                     'Display a link to expand/collapse translations '.

--- a/app/views/user/settings.ctp
+++ b/app/views/user/settings.ctp
@@ -94,7 +94,7 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
         </div>
         
         <div>
-            <?php echo $form->checkbox('restrict_search_langs_enabled'); ?>
+            <?php echo $form->checkbox('settings.restrict_search_langs_enabled'); ?>
             <label for="RestrictSearchLangsEnabled">
                 <?php __(
                     'Restrict languages listed in the search bar '.

--- a/app/views/user/settings.ctp
+++ b/app/views/user/settings.ctp
@@ -57,7 +57,7 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
         
         <div>
             <?php echo $form->checkbox('settings.is_public'); ?>
-            <label for="UserIsPublic">
+            <label for="UserSettingsIsPublic">
                 <?php __('Set your profile public?'); ?>
             </label>
         </div>
@@ -75,7 +75,7 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
         
         <div>
             <?php echo $form->checkbox('settings.use_most_recent_list'); ?>
-            <label for="UserUseMostRecentList">
+            <label for="UserSettingsUseMostRecentList">
                 <?php __(
                     'Remember the last list to which you assigned a '.
                     'sentence, and select it by default.'
@@ -85,7 +85,7 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
 
         <div>
             <?php echo $form->checkbox('settings.collapsible_translations'); ?>
-            <label for="UserCollapsibleTranslationsEnabled">
+            <label for="UserSettingsCollapsibleTranslations">
                 <?php __(
                     'Display a link to expand/collapse translations '.
                     'when there are too many translations.'
@@ -95,7 +95,7 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
         
         <div>
             <?php echo $form->checkbox('settings.restrict_search_langs'); ?>
-            <label for="RestrictSearchLangsEnabled">
+            <label for="UserSettingsRestrictSearchLangs">
                 <?php __(
                     'Restrict languages listed in the search bar '.
                     'to the ones in your profile.'

--- a/app/views/user/settings.ctp
+++ b/app/views/user/settings.ctp
@@ -84,7 +84,7 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
         </div>
 
         <div>
-            <?php echo $form->checkbox('settings.collapsible_translations_enabled'); ?>
+            <?php echo $form->checkbox('settings.collapsible_translations'); ?>
             <label for="UserCollapsibleTranslationsEnabled">
                 <?php __(
                     'Display a link to expand/collapse translations '.
@@ -94,7 +94,7 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
         </div>
         
         <div>
-            <?php echo $form->checkbox('settings.restrict_search_langs_enabled'); ?>
+            <?php echo $form->checkbox('settings.restrict_search_langs'); ?>
             <label for="RestrictSearchLangsEnabled">
                 <?php __(
                     'Restrict languages listed in the search bar '.

--- a/app/views/user/settings.ctp
+++ b/app/views/user/settings.ctp
@@ -74,7 +74,7 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
         </div>
         
         <div>
-            <?php echo $form->checkbox('use_most_recent_list'); ?>
+            <?php echo $form->checkbox('settings.use_most_recent_list'); ?>
             <label for="UserUseMostRecentList">
                 <?php __(
                     'Remember the last list to which you assigned a '.

--- a/app/views/users/edit.ctp
+++ b/app/views/users/edit.ctp
@@ -90,7 +90,7 @@ $form->create('User'); // But we still need to call $form->create()
     echo $form->input('id',       array('label' => __d('admin', 'Id', true)));
     echo $form->input('username', array('label' => __d('admin', 'Username', true)));
     echo $form->input('email',    array('label' => __d('admin', 'Email', true)));
-    echo $form->input('lang',     array('label' => __d('admin', 'Lang', true)));
+    echo $form->input('settings.lang',     array('label' => __d('admin', 'Lang', true)));
     echo $form->input('group_id', array('label' => __d('admin', 'Group', true)));
     echo $form->input(
         'level', 

--- a/docs/database/tables/users.sql
+++ b/docs/database/tables/users.sql
@@ -15,7 +15,7 @@
 -- level             Currently not in use. I wanted to integrate some game mechanics
 --                     in Tatoeba, but it's obviously not easy...
 -- group_id          Id of the group in which the user is.
---- send_notifiations Indicates whether the user wants to receive email notifications.
+-- send_notifiations Indicates whether the user wants to receive email notifications.
 -- name              Real name of the user.
 -- birthday          Birthday of the user.
 -- description       User's description of himself or herself.

--- a/docs/database/tables/users.sql
+++ b/docs/database/tables/users.sql
@@ -15,6 +15,7 @@
 -- level             Currently not in use. I wanted to integrate some game mechanics
 --                     in Tatoeba, but it's obviously not easy...
 -- group_id          Id of the group in which the user is.
+--- send_notifiations Indicates whether the user wants to receive email notifications.
 -- name              Real name of the user.
 -- birthday          Birthday of the user.
 -- description       User's description of himself or herself.
@@ -35,6 +36,7 @@ CREATE TABLE `users` (
   `last_time_active` int(11) NOT NULL DEFAULT '0',
   `level` tinyint(2) NOT NULL DEFAULT '0',
   `group_id` tinyint(4) NOT NULL,
+  `send_notifications` tinyint(1) NOT NULL DEFAULT '1',
   `name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `birthday` datetime DEFAULT NULL,
   `description` blob NOT NULL,

--- a/docs/database/tables/users.sql
+++ b/docs/database/tables/users.sql
@@ -10,22 +10,18 @@
 -- username          Username of the user.
 -- password          Password of the user.
 -- email             Email of the user.
--- lang              Language of the user. It's not necessarily their mother tongue,
---                     but it's a language in which they can communicate. This field
---                     was no more used since Tatoeba v2.
 -- since             Date of registration.
 -- last_time_active  Timestamp of the last time the user logged in.
 -- level             Currently not in use. I wanted to integrate some game mechanics
 --                     in Tatoeba, but it's obviously not easy...
 -- group_id          Id of the group in which the user is.
--- send_notifiations Indicates whether the user wants to receive email notifications.
 -- name              Real name of the user.
 -- birthday          Birthday of the user.
 -- description       User's description of himself or herself.
+-- settings          User's settings serialized in JSON.
 -- homepage          User's personal website.
 -- image             User's profile picture.
 -- country_id        Country in which the user lives.
--- is_public         Indicates whether the profile can be seen by other people than
 --                     members of Tatoeba.
 --
 
@@ -35,19 +31,17 @@ CREATE TABLE `users` (
   `username` varchar(20) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   `password` varchar(50) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `email` varchar(100) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `lang` varchar(100) DEFAULT NULL,
   `since` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `last_time_active` int(11) NOT NULL DEFAULT '0',
   `level` tinyint(2) NOT NULL DEFAULT '0',
   `group_id` tinyint(4) NOT NULL,
-  `send_notifications` tinyint(1) NOT NULL DEFAULT '1',
   `name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `birthday` datetime DEFAULT NULL,
   `description` blob NOT NULL,
+  `settings` blob NOT NULL,
   `homepage` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `image` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `country_id` varchar(2) DEFAULT NULL,
-  `is_public` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `login` (`username`),
   UNIQUE KEY `email` (`email`)

--- a/docs/database/updates/2015-05-24.sql
+++ b/docs/database/updates/2015-05-24.sql
@@ -1,0 +1,12 @@
+ALTER TABLE users ADD settings BLOB NOT NULL AFTER `description`;
+
+UPDATE users SET settings = CONCAT('{',
+    '"is_public":',          IF(is_public,'true','false'),          ',',
+    '"send_notifications":', IF(send_notifications,'true','false'), ',',
+    '"lang":',               '"',COALESCE(lang,''),'"',
+'}');
+
+ALTER TABLE users DROP is_public;
+ALTER TABLE users DROP send_notifications;
+ALTER TABLE users DROP lang;
+

--- a/docs/database/updates/2015-05-24.sql
+++ b/docs/database/updates/2015-05-24.sql
@@ -2,11 +2,9 @@ ALTER TABLE users ADD settings BLOB NOT NULL AFTER `description`;
 
 UPDATE users SET settings = CONCAT('{',
     '"is_public":',          IF(is_public,'true','false'),          ',',
-    '"send_notifications":', IF(send_notifications,'true','false'), ',',
     '"lang":',               '"',COALESCE(lang,''),'"',
 '}');
 
 ALTER TABLE users DROP is_public;
-ALTER TABLE users DROP send_notifications;
 ALTER TABLE users DROP lang;
 

--- a/docs/database/updates/2015-05-24.sql
+++ b/docs/database/updates/2015-05-24.sql
@@ -1,8 +1,8 @@
 ALTER TABLE users ADD settings BLOB NOT NULL AFTER `description`;
 
 UPDATE users SET settings = CONCAT('{',
-    '"is_public":',          IF(is_public,'true','false'),          ',',
-    '"lang":',               '"',COALESCE(lang,''),'"',
+    '"is_public":',          IF(is_public,'1','0'),',',
+    '"lang":',               IF(lang is null,'null', CONCAT('"',lang,'"')),
 '}');
 
 ALTER TABLE users DROP is_public;


### PR DESCRIPTION
This PR improves the handling of settings. It moves the existing settings `lang` (displayed translations languages), `is_public` (profile showed to guest) and various settings stored in cookies into a unique multi-purpose JSON-encoded field in the database.

Settings previously stored in cookies are now permanently stored. Besides, it makes it easy to add and remove settings with very little code change.

The experimental Chosen-based language drop-down setting is still stored in a cookie because it makes more sense this way.

Note that there is a database update script to run!