### PR TITLE
Put most useful languages in the top of language dropdowns

### DIFF
--- a/app/app_controller.php
+++ b/app/app_controller.php
@@ -320,7 +320,7 @@ class AppController extends Controller
      * with a 'preferred languages' list.
      */
     public function addLastUsedLang($code) {
-        if (!CurrentUser::isMember()) {
+        if (!CurrentUser::isMember() && LanguagesLib::languageExists($code)) {
             $current = (array)$this->Session->read('last_used_lang');
             if (!in_array($code, $current)) {
                 $current[] = $code;

--- a/app/app_controller.php
+++ b/app/app_controller.php
@@ -313,5 +313,20 @@ class AppController extends Controller
     {
         return array_intersect_key($array, array_flip($allowedKeys));
     }
+
+    /**
+     * Adds a language to the list of last used languages.
+     * This list is used to provide guests (non logged-in users)
+     * with a 'preferred languages' list.
+     */
+    public function addLastUsedLang($code) {
+        if (!CurrentUser::isMember()) {
+            $current = (array)$this->Session->read('last_used_lang');
+            if (!in_array($code, $current)) {
+                $current[] = $code;
+                $this->Session->write('last_used_lang', $current);
+            }
+        }
+    }
 }
 ?>

--- a/app/controllers/activities_controller.php
+++ b/app/controllers/activities_controller.php
@@ -172,6 +172,7 @@ class ActivitiesController extends AppController
         );
         if (!empty($lang)) {
             $conditions['lang'] = $lang;
+            $this->addLastUsedLang($lang);
         }
 
         $this->paginate = array(

--- a/app/controllers/activities_controller.php
+++ b/app/controllers/activities_controller.php
@@ -172,7 +172,6 @@ class ActivitiesController extends AppController
         );
         if (!empty($lang)) {
             $conditions['lang'] = $lang;
-            $this->addLastUsedLang($lang);
         }
 
         $this->paginate = array(

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -183,6 +183,7 @@ class SentencesController extends AppController
             // here only to make things clearer as "id" is not a number
             if (array_key_exists($id, LanguagesLib::languagesInTatoeba())) {
                 $lang = $id;
+                $this->addLastUsedLang($lang);
             } else {
                 $lang = null;
             }
@@ -613,6 +614,10 @@ class SentencesController extends AppController
             $lang = null;
         }
 
+        $this->addLastUsedLang($lang);
+        $this->addLastUsedLang($translationLang);
+        $this->addLastUsedLang($notTranslatedInto);
+
         $pagination = array(
             'Sentence' => array(
                 'fields' => array(
@@ -779,6 +784,7 @@ class SentencesController extends AppController
             // default language when coming from "show more..."
             $lang = $this->Session->read('random_lang_selected');
         }
+        $this->addLastUsedLang($lang);
 
         $type = null ;
         // to avoid "petit malin"

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -512,6 +512,8 @@ class SentencesController extends AppController
         $this->Session->write('search_query', $query);
         $this->Session->write('search_from', $from);
         $this->Session->write('search_to', $to);
+        $this->addLastUsedLang($from);
+        $this->addLastUsedLang($to);
 
         // replace strange space
         $query = str_replace(

--- a/app/controllers/users_controller.php
+++ b/app/controllers/users_controller.php
@@ -272,6 +272,7 @@ class UsersController extends AppController
     public function logout()
     {
         $this->RememberMe->delete();
+        $this->Session->delete('last_used_lang');
         $this->redirect($this->Auth->logout());
     }
 

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -127,7 +127,6 @@ class User extends AppModel
         'lang' => null,
         'use_most_recent_list' => false,
         'collapsible_translations' => false,
-        'restrict_search_langs' => false,
     );
 
     public function afterFind($results, $primary = false) {

--- a/app/vendors/languages_lib.php
+++ b/app/vendors/languages_lib.php
@@ -448,4 +448,10 @@ class LanguagesLib
             array_flip($languageCodes)
         );
     }
+
+    public static function languageExists($code)
+    {
+        $available =& self::languagesInTatoeba();
+        return isset($available[$code]);
+    }
 }

--- a/app/views/elements/search_bar.ctp
+++ b/app/views/elements/search_bar.ctp
@@ -34,17 +34,7 @@ if (isset($this->params['lang'])) {
 
 <?php
 
-$restrictSearchLangsEnabled = CurrentUser::get('settings.restrict_search_langs');
-if ($restrictSearchLangsEnabled) {
-    $langArray = $languages->profileLanguagesArray(false, false, true);
-    $currentUserLanguages = CurrentUser::getProfileLanguages();
-}
-
-if (!$restrictSearchLangsEnabled || empty($currentUserLanguages)) {
-    $langs = $languages->getSearchableLanguagesArray();
-} else {
-    $langs = $langArray;
-}
+$langs = $languages->getSearchableLanguagesArray();
 
 if ($selectedLanguageFrom == null) {
     $selectedLanguageFrom = 'und';

--- a/app/views/helpers/languages.php
+++ b/app/views/helpers/languages.php
@@ -98,7 +98,7 @@ class LanguagesHelper extends AppHelper
         );
     }
 
-    public function onlyLanguagesArray()
+    public function onlyLanguagesArray($split = true)
     {
         if (!$this->__languages_alone) {
             $this->__languages_alone = array_map(
@@ -108,7 +108,11 @@ class LanguagesHelper extends AppHelper
             $this->localizedAsort($this->__languages_alone);
         }
 
-        return $this->separatePreferredLanguages($this->__languages_alone);
+        $languages = $this->__languages_alone;
+        if ($split) {
+            $languages = $this->separatePreferredLanguages($languages);
+        }
+        return $languages;
     }
 
 
@@ -146,7 +150,7 @@ class LanguagesHelper extends AppHelper
     public function profileLanguagesArray($withAutoDetection, $withOther, $withAny)
     {
         $languages = array_intersect_key(
-            $this->onlyLanguagesArray(),
+            $this->onlyLanguagesArray(false),
             array_flip(CurrentUser::getProfileLanguages())
         );
 

--- a/app/views/helpers/languages.php
+++ b/app/views/helpers/languages.php
@@ -39,7 +39,7 @@ App::import('Vendor', 'LanguagesLib');
  */
 class LanguagesHelper extends AppHelper
 {
-    public $helpers = array('Html');
+    public $helpers = array('Html', 'Session');
 
     /* Memoization of languages code and their localized names */
     private $__languages_alone;
@@ -70,16 +70,27 @@ class LanguagesHelper extends AppHelper
         }
     }
 
+    public function preferredLanguageFilter() {
+        if (CurrentUser::isMember()) {
+            $filter = CurrentUser::getProfileLanguages();
+        } else {
+            $filter = $this->Session->read('last_used_lang');
+        }
+        return $filter;
+    }
+
     private function separatePreferredLanguages($languages)
     {
-        $filter = CurrentUser::getProfileLanguages();
+        $filter = $this->preferredLanguageFilter();
         if (!$filter) {
             return $languages;
         }
         $preferred = array();
         foreach ($filter as $prefLang) {
-            $preferred[$prefLang] = $languages[$prefLang];
-            unset($languages[$prefLang]);
+            if (isset($languages[$prefLang])) {
+                $preferred[$prefLang] = $languages[$prefLang];
+                unset($languages[$prefLang]);
+            }
         }
         return array(
             __('Preferred languages', true) => $preferred,

--- a/app/views/helpers/languages.php
+++ b/app/views/helpers/languages.php
@@ -199,7 +199,7 @@ class LanguagesHelper extends AppHelper
         // Can't use 'any' as it's the code for anyin language.
         // Only 'und' is used for "undefined".
         // TODO xxx to be remplace by the code for 'unknown'
-        array_unshift($languages, array('unknown' => __('unknown language', true)));
+        array_push($languages, array('unknown' => __('unknown language', true)));
 
         return $languages;
     }

--- a/app/views/helpers/languages.php
+++ b/app/views/helpers/languages.php
@@ -72,11 +72,10 @@ class LanguagesHelper extends AppHelper
 
     public function preferredLanguageFilter() {
         if (CurrentUser::isMember()) {
-            $filter = CurrentUser::getProfileLanguages();
+            return CurrentUser::getProfileLanguages();
         } else {
-            $filter = $this->Session->read('last_used_lang');
+            return $this->Session->read('last_used_lang');
         }
-        return $filter;
     }
 
     private function separatePreferredLanguages($languages)
@@ -92,6 +91,7 @@ class LanguagesHelper extends AppHelper
                 unset($languages[$prefLang]);
             }
         }
+        $this->localizedAsort($preferred);
         return array(
             __('Preferred languages', true) => $preferred,
             __('Other languages', true)     => $languages,

--- a/app/views/helpers/languages.php
+++ b/app/views/helpers/languages.php
@@ -70,6 +70,23 @@ class LanguagesHelper extends AppHelper
         }
     }
 
+    private function separatePreferredLanguages($languages)
+    {
+        $filter = CurrentUser::getProfileLanguages();
+        if (!$filter) {
+            return $languages;
+        }
+        $preferred = array();
+        foreach ($filter as $prefLang) {
+            $preferred[$prefLang] = $languages[$prefLang];
+            unset($languages[$prefLang]);
+        }
+        return array(
+            __('Preferred languages', true) => $preferred,
+            __('Other languages', true)     => $languages,
+        );
+    }
+
     public function onlyLanguagesArray()
     {
         if (!$this->__languages_alone) {
@@ -79,7 +96,8 @@ class LanguagesHelper extends AppHelper
             );
             $this->localizedAsort($this->__languages_alone);
         }
-        return $this->__languages_alone;
+
+        return $this->separatePreferredLanguages($this->__languages_alone);
     }
 
 

--- a/app/views/helpers/languages.php
+++ b/app/views/helpers/languages.php
@@ -148,12 +148,11 @@ class LanguagesHelper extends AppHelper
      *
      * @param bool   $withAutoDetection Set to true if "Auto detect" should be one of the options.
      * @param bool   $withOther Set to true if "Other language" should be one of the options.
-     * @param bool   $withAny Set to true if "Any" should be one of the options.
      *
      * @return void
      */
 
-    public function profileLanguagesArray($withAutoDetection, $withOther, $withAny)
+    public function profileLanguagesArray($withAutoDetection, $withOther)
     {
         $languages = array_intersect_key(
             $this->onlyLanguagesArray(false),
@@ -163,9 +162,6 @@ class LanguagesHelper extends AppHelper
         $numLanguages = count(CurrentUser::getProfileLanguages());
         if (count($languages) > 1 && $withAutoDetection) {
             array_unshift($languages, array('auto' => __('Auto detect', true)));
-        }
-        if ($withAny) {
-            array_unshift($languages, array('und' => __('Any', true)));
         }
         if ($withOther) {
             array_unshift($languages, array('' => __('other language', true)));

--- a/app/views/helpers/languages.php
+++ b/app/views/helpers/languages.php
@@ -92,9 +92,15 @@ class LanguagesHelper extends AppHelper
             }
         }
         $this->localizedAsort($preferred);
+
+        if (CurrentUser::isMember()) {
+            $filterName = __('Profile languages', true);
+        } else {
+            $filterName = __('Last used languages', true);
+        }
         return array(
-            __('Preferred languages', true) => $preferred,
-            __('Other languages', true)     => $languages,
+            $filterName                 => $preferred,
+            __('Other languages', true) => $languages,
         );
     }
 

--- a/app/views/helpers/sentence_buttons.php
+++ b/app/views/helpers/sentence_buttons.php
@@ -227,7 +227,7 @@ class SentenceButtonsHelper extends AppHelper
                 $langArray = $this->Languages->otherLanguagesArray();
             } else {
                 $langArray = $this->Languages->profileLanguagesArray(
-                    false, true, false
+                    false, true
                 );
             }
 

--- a/app/views/helpers/sentences.php
+++ b/app/views/helpers/sentences.php
@@ -266,7 +266,7 @@ class SentencesHelper extends AppHelper
      */
     private function _displayNewTranslationForm($id)
     {
-        $langArray = $this->Languages->profileLanguagesArray(true, false, false);
+        $langArray = $this->Languages->profileLanguagesArray(true, false);
 
         ?>
         <div id="translation_for_<?php echo $id; ?>" class="addTranslations">

--- a/app/views/layouts/default.ctp
+++ b/app/views/layouts/default.ctp
@@ -135,7 +135,7 @@
                 'time' => is_null($session->read('search_from'))
                           && is_null($session->read('search_to'))
                           && is_null($session->read('search_query'))
-                          && !CurrentUser::getProfileLanguages()
+                          && !$languages->preferredLanguageFilter()
                           ? '+1 day' : false,
                 'key' => Configure::read('Config.language')
             )

--- a/app/views/layouts/default.ctp
+++ b/app/views/layouts/default.ctp
@@ -135,7 +135,7 @@
                 'time' => is_null($session->read('search_from'))
                           && is_null($session->read('search_to'))
                           && is_null($session->read('search_query'))
-                          && !CurrentUser::get('settings.restrict_search_langs')
+                          && !CurrentUser::getProfileLanguages()
                           ? '+1 day' : false,
                 'key' => Configure::read('Config.language')
             )

--- a/app/views/sentences/add.ctp
+++ b/app/views/sentences/add.ctp
@@ -89,7 +89,7 @@ echo $javascript->link(JS_PATH . 'sentences.contribute.js', true);
         <div class="sentences_set">
             <div class="new">
             <?php
-            $langArray = $this->Languages->profileLanguagesArray(true, false, false);
+            $langArray = $this->Languages->profileLanguagesArray(true, false);
             $currentUserLanguages = CurrentUser::getProfileLanguages();
             if (empty($currentUserLanguages)) {
 

--- a/app/views/user/language.ctp
+++ b/app/views/user/language.ctp
@@ -49,7 +49,7 @@ $this->set('title_for_layout', Sanitize::html($pages->formatTitle($title)));
         <?php
         echo $html->tag('h2', $title);
 
-        $languagesList = $languages->onlyLanguagesArray();
+        $languagesList = $languages->onlyLanguagesArray(false);
 
         echo $form->create('UsersLanguages', array('action' => 'save', 'class' => 'form'));
 

--- a/app/views/user/settings.ctp
+++ b/app/views/user/settings.ctp
@@ -94,16 +94,6 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
         </div>
         
         <div>
-            <?php echo $form->checkbox('settings.restrict_search_langs'); ?>
-            <label for="UserSettingsRestrictSearchLangs">
-                <?php __(
-                    'Restrict languages listed in the search bar '.
-                    'to the ones in your profile.'
-                ); ?>
-            </label>
-        </div>
-        
-        <div>
         <?php
         $tip = __(
             'Enter ISO 639-3 codes, separated with a comma (e.g.: jpn,epo,ara,deu). '.


### PR DESCRIPTION
This PR separates all the language drop downs into two parts: the useful ones on the top and the others. The useful ones are the profile languages for logged-in users, or the last selected languages for guests. This last selected language list is built up by recording what languages are selected in some key forms: search (from and to), “browse by language” (language, translated into and not translated into) and random sentences. Since this PR renders the “restrict languages in search” option quite useless, I removed it.