### PR TITLE
Optimization of "not translated into" filter

### DIFF
--- a/app/models/link.php
+++ b/app/models/link.php
@@ -252,5 +252,18 @@ class Link extends AppModel
         ));
         return Set::classicExtract($links, '{n}.0.translation_id');
     }
+
+    public function updateLanguage($sentenceId, $lang)
+    {
+        $this->updateAll(
+            array('sentence_lang' => "'$lang'"),
+            array('sentence_id' => $sentenceId)
+        );
+
+        $this->updateAll(
+            array('translation_lang' => "'$lang'"),
+            array('translation_id' => $sentenceId)
+        );
+    }
 }
 ?>

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -802,6 +802,7 @@ class Sentence extends AppModel
             $this->id = $sentenceId;
             $this->save($data);
 
+            $this->Link->updateLanguage($sentenceId, $newLang);
             $this->Contribution->updateLanguage($sentenceId, $newLang);
             $this->Language->incrementCountForLanguage($newLang);
             $this->Language->decrementCountForLanguage($prevLang);

--- a/app/models/sentence_not_translated_into.php
+++ b/app/models/sentence_not_translated_into.php
@@ -102,10 +102,9 @@ class SentenceNotTranslatedInto extends AppModel
             WHERE Sentence.lang = '$source' $filterAudio
               AND Sentence.id NOT IN
               (
-                SELECT DISTINCT s.id FROM sentences s
-                  JOIN sentences_translations st ON ( s.id = st.sentence_id )
-                  JOIN sentences t on ( st.translation_id = t.id )
-                WHERE s.lang = '$source' AND t.lang = '$target'
+                SELECT sentence_id FROM sentences_translations
+                WHERE sentence_lang = '$source'
+                  AND translation_lang = '$target'
               )
             ORDER BY Sentence.id DESC
             LIMIT $limitLow,$limit;
@@ -149,19 +148,18 @@ class SentenceNotTranslatedInto extends AppModel
             // we want only untranslated sentences
             $sql
                 = "
-                SELECT count(distinct Sentence.id) as Count FROM sentences as Sentence
-                  JOIN sentences_translations st ON ( Sentence.id = st.sentence_id )
-                WHERE Sentence.lang = '$source'
+                SELECT count(DISTINCT sentence_id) as Count
+                FROM sentences_translations
+                WHERE sentence_lang = '$source'
                 $filterAudio
                 ";
         } else {
             $sql
                 = "
-            SELECT count(DISTINCT Sentence.id) as Count FROM sentences as Sentence
-              JOIN sentences_translations st ON ( Sentence.id = st.sentence_id )
-              JOIN sentences t on ( st.translation_id = t.id )
-            WHERE Sentence.lang = '$source'
-            AND t.lang = '$target'
+            SELECT count(DISTINCT sentence_id) as Count
+            FROM sentences_translations
+            WHERE sentence_lang = '$source'
+            AND translation_lang = '$target'
             $filterAudio
             " ;
         }

--- a/docs/database/scripts/fix_sentences_translations.sql
+++ b/docs/database/scripts/fix_sentences_translations.sql
@@ -1,0 +1,33 @@
+-- Make sure there's no empty string but null for unsupported languages
+UPDATE sentences_translations
+SET sentence_lang = null WHERE sentence_lang = '';
+
+UPDATE sentences_translations
+SET translation_lang = null WHERE translation_lang = '';
+
+-- Update sentence_lang and translation_lang fields where lang is null.
+UPDATE sentences_translations st, sentences s
+SET st.sentence_lang = s.lang
+WHERE st.sentence_id = s.id AND st.sentence_lang IS NULL;
+
+UPDATE sentences_translations st, sentences s
+SET st.translation_lang = s.lang
+WHERE st.translation_id = s.id AND st.translation_lang IS NULL;
+
+-- Update sentence_lang and translation_lang where lang is different than in sentences table.
+UPDATE sentences_translations st, sentences s
+SET st.sentence_lang = s.lang
+WHERE st.sentence_id = s.id AND st.sentence_lang != s.lang;
+
+UPDATE sentences_translations st, sentences s
+SET st.translation_lang = s.lang
+WHERE st.translation_id = s.id AND st.translation_lang != s.lang;
+
+-- Delete links of deleted sentences
+DELETE st FROM sentences_translations st
+LEFT JOIN sentences s ON st.sentence_id = s.id
+WHERE s.id IS NULL;
+
+DELETE st FROM sentences_translations st
+LEFT JOIN sentences s ON st.translation_id = s.id
+WHERE s.id IS NULL;


### PR DESCRIPTION
The query that is executed when users displayed sentences not translated into XXX contains a several joins.
<pre>
SELECT DISTINCT s.id FROM sentences s
  JOIN sentences_translations st ON ( s.id = st.sentence_id )
  JOIN sentences t on ( st.translation_id = t.id )
WHERE s.lang = '$source' AND t.lang = '$target'
</pre>

We could do without these JOINs because we have the required fields already in the `sentences_translations` table, in the `sentence_lang` and `translation_lang` fields.

<pre>
SELECT sentence_id FROM sentences_translations
WHERE sentence_lang = '$source'
AND translation_lang = '$target'
</pre>

For a comparison, on my machine, searching for
- English sentences not translated into French: takes 5 minutes... vs 1.49 s.
- Spanish sentences not translated into English: takes 40 seconds vs. 1.13 s. 
https://gist.github.com/trang/928652c1a56fd9b8bdb8

Now the problem when selecting from the `sentences_translations` table is that we need to make sure the `sentence_lang` and `translation_lang` fields are in sync with the language in the `sentences` table.

When a user changes the language of a sentence, it doesn't update the `sentences_translations` table accordingly. I didn't take care of this yet.

I have only added a file containing the queries to fix the `sentences_translations` table but the last queries are really, really slow to execute. I don't know if there's a solution to make them faster, or if it's better to just retrieve the id's to delete and generate a script with a bunch of `DELETE FROM sentences_translations WHERE sentence_id = XXX`.

So there are at least 2 things to do before this pull request can be merged:
1) Update the `sentences_translations` when the language of a sentence changes.
2) Find a faster way to sync the languages in `sentences_translations` with the languages in `sentences`.