### PR TITLE
Use relative links for alternate languages

### DIFF
--- a/app/views/elements/seo_international_targeting.ctp
+++ b/app/views/elements/seo_international_targeting.ctp
@@ -44,7 +44,7 @@ foreach ($uiLanguages as $langs) {
     if ($newUrl[0] == '/') {
         $newUrl = substr($newUrl, 1);
     }
-    $alternateURL = "http://".TATOEBA_DOMAIN.'/'.$newUrl;
+    $alternateURL = '/'.$newUrl;
     $hreflang = LanguagesLib::languageTag($langs[0], $langs[1]);
     ?>
     <link rel="alternate" 

--- a/app/views/layouts/default.ctp
+++ b/app/views/layouts/default.ctp
@@ -113,7 +113,7 @@
     ?>
 
     <link rel="search" type="application/opensearchdescription+xml"
-          href="http://tatoeba.org/opensearch.xml" title="Tatoeba" />
+          href="/opensearch.xml" title="Tatoeba" />
 </head>
 <body>
     <div id="audioPlayer"></div>


### PR DESCRIPTION
This makes users go directly to the HTTPS version.