### PR TITLE
Favorites pagination

### DIFF
--- a/app/controllers/favorites_controller.php
+++ b/app/controllers/favorites_controller.php
@@ -40,7 +40,7 @@ class FavoritesController extends AppController
 
     public $name = 'Favorites' ;
     public $paginate = array('limit' => 50);
-    public $helpers = array('Navigation', 'Html', 'Menu');
+    public $helpers = array('Navigation', 'Html', 'Menu', 'CommonModules', 'Pagination');
     public $uses = array('Favorite', 'User');
 
     /**
@@ -65,9 +65,36 @@ class FavoritesController extends AppController
     public function of_user($username)
     {
         $userId = $this->User->getIdFromUsername($username);
-        $favorites = $this->Favorite->getAllFavoritesOfUser($userId);
-        $this->set('favorites', $favorites);
+        $backLink = $this->referer(array('action'=>'index'), true);
+
+        $this->set('backLink', $backLink);
+        $data = $this->Favorite->getAllFavoritesOfUser($userId);
         $this->set('username', $username);
+        if (empty($userId)) {
+
+            $this->set("userExists", false);
+            return;
+        }
+        $this->paginate = array(
+                'fields' => array(
+                    'favorite_id'
+                ),
+                'conditions' => array(
+                    'Favorite.user_id' => $userId
+                ),
+                'limit' => 20,
+                'contain' => array(
+                    'Sentence' => array(
+                        'Transcription' => array(
+                            'User' => array('fields' => 'username'),
+                        ),
+                    )
+                )
+            );
+        $favorites = $this->paginate('Favorite');
+        $this->set('favorites', $favorites);
+        $this->set('data', $data);
+        $this->set("userExists", true);
     }
 
     /**

--- a/app/controllers/favorites_controller.php
+++ b/app/controllers/favorites_controller.php
@@ -68,7 +68,6 @@ class FavoritesController extends AppController
         $backLink = $this->referer(array('action'=>'index'), true);
 
         $this->set('backLink', $backLink);
-        $data = $this->Favorite->numberOfFavoritesOfUser($userId);
         $this->set('username', $username);
         if (empty($userId)) {
 
@@ -78,7 +77,6 @@ class FavoritesController extends AppController
         $this->paginate = $this->Favorite->getPaginatedFavoritesOfUser($userId);
         $favorites = $this->paginate('Favorite');
         $this->set('favorites', $favorites);
-        $this->set('data', $data);
         $this->set("userExists", true);
     }
 

--- a/app/controllers/favorites_controller.php
+++ b/app/controllers/favorites_controller.php
@@ -68,29 +68,14 @@ class FavoritesController extends AppController
         $backLink = $this->referer(array('action'=>'index'), true);
 
         $this->set('backLink', $backLink);
-        $data = $this->Favorite->getAllFavoritesOfUser($userId);
+        $data = $this->Favorite->numberOfFavoritesOfUser($userId);
         $this->set('username', $username);
         if (empty($userId)) {
 
             $this->set("userExists", false);
             return;
         }
-        $this->paginate = array(
-                'fields' => array(
-                    'favorite_id'
-                ),
-                'conditions' => array(
-                    'Favorite.user_id' => $userId
-                ),
-                'limit' => 20,
-                'contain' => array(
-                    'Sentence' => array(
-                        'Transcription' => array(
-                            'User' => array('fields' => 'username'),
-                        ),
-                    )
-                )
-            );
+        $this->paginate = $this->Favorite->getPaginatedFavoritesOfUser($userId);
         $favorites = $this->paginate('Favorite');
         $this->set('favorites', $favorites);
         $this->set('data', $data);

--- a/app/models/favorite.php
+++ b/app/models/favorite.php
@@ -78,23 +78,21 @@ class Favorite extends AppModel
      * @return array
      */
 
-    public function getAllFavoritesOfUser($userId)
+    public function getPaginatedFavoritesOfUser($userId)
     {
-        $favorites = $this->find(
-            'all',
-            array(
-                'fields' => array(
-                    'favorite_id'
-                ),
-                'conditions' => array(
-                    'Favorite.user_id' => $userId
-                ),
-                'contain' => array(
-                    'Sentence' => array(
-                        'Transcription' => array(
-                            'User' => array('fields' => 'username'),
-                        ),
-                    )
+
+        $favorites = array(
+            'fields' => array(
+                'favorite_id'
+            ),
+            'conditions' => array(
+                'Favorite.user_id' => $userId
+            ),
+            'contain' => array(
+                'Sentence' => array(
+                    'Transcription' => array(
+                        'User' => array('fields' => 'username'),
+                    ),
                 )
             )
         );

--- a/app/views/favorites/of_user.ctp
+++ b/app/views/favorites/of_user.ctp
@@ -105,7 +105,6 @@ $this->set('title_for_layout', $pages->formatTitle($title));
 
         } else {
             __('This user does not have any favorites.');
-            echo $html->link(__('Go back to previous page', true), $backLink);
         }
     }
     ?>

--- a/app/views/favorites/of_user.ctp
+++ b/app/views/favorites/of_user.ctp
@@ -40,7 +40,7 @@ if ($userExists === true) {
 }
 
 $this->set('title_for_layout', $pages->formatTitle($title));
-$numberOfSentences = count($data);
+$numberOfSentences = $data;
 ?>
 
 <div id="annexe_content">

--- a/app/views/favorites/of_user.ctp
+++ b/app/views/favorites/of_user.ctp
@@ -40,7 +40,6 @@ if ($userExists === true) {
 }
 
 $this->set('title_for_layout', $pages->formatTitle($title));
-$numberOfSentences = $data;
 ?>
 
 <div id="annexe_content">
@@ -59,9 +58,12 @@ $numberOfSentences = $data;
     if ($userExists === false) {
         $commonModules->displayNoSuchUser($username, $backLink);
     } else {
-        echo '<h2>';
-        echo $title . ' ('. $numberOfSentences.')';
-        echo '</h2>';
+        $title = $paginator->counter(
+            array(
+                'format' => $title . ' ' . __("(total %count%)", true)
+            )
+        );
+        echo $html->tag('h2', $title);
         if ($numberOfSentences > 0) {
 
             $paginationUrl = array($username);

--- a/app/views/favorites/of_user.ctp
+++ b/app/views/favorites/of_user.ctp
@@ -26,9 +26,21 @@
  */
 
 $username = Sanitize::paranoid($username, array("_"));
-$title = format(__("{user}'s favorite sentences", true), array('user' => $username));
+
+if ($userExists === true) {
+    $numberOfSentences = (int) $paginator->counter(
+        array(
+            "format" => "%count%"
+        )
+    );
+
+    $title = format(__("{user}'s favorite sentences", true), array('user' => $username));
+} else {
+    $title = format(__("There's no user called {username}", true), array('username' => $username));
+}
+
 $this->set('title_for_layout', $pages->formatTitle($title));
-$numberOfSentences = count($favorites);
+$numberOfSentences = count($data);
 ?>
 
 <div id="annexe_content">
@@ -43,45 +55,56 @@ $numberOfSentences = count($favorites);
 <div id="main_content">
     <div class="module">
     
-    <h2><?php echo $title . ' ('. $numberOfSentences.')'; ?></h2>
-    
     <?php
-    
-    if ($numberOfSentences > 0) {
-        $type = 'mainSentence';
-        $parentId = null;
-        $withAudio = false;
-        $ownerName = null;
-        foreach ($favorites as $favorite) {
-            if (empty($favorite['Sentence']['text'])) {
-                $sentenceId = $favorite['Favorite']['favorite_id'];
-                $linkToSentence = $html->link(
-                    '#'.$sentenceId,
-                    array(
-                        'controller' => 'sentences',
-                        'action' => 'show',
-                        $sentenceId
-                    )
-                );
-
-                echo $html->div('sentence deleted',
-                    format(
-                        __('Sentence {id} has been deleted.', true),
-                        array('id' => $linkToSentence)
-                    )
-                );
-            } else {
-                $sentences->displayGenericSentence(
-                    $favorite['Sentence'],
-                    $favorite['Sentence']['Transcription'],
-                    $type,
-                    $parentId,
-                    $withAudio
-                );
-            }
-        }
+    if ($userExists === false) {
+        $commonModules->displayNoSuchUser($username, $backLink);
     } else {
-        __('This user does not have any favorites.');
+        echo '<h2>';
+        echo $title . ' ('. $numberOfSentences.')';
+        echo '</h2>';
+        if ($numberOfSentences > 0) {
+
+            $paginationUrl = array($username);
+            $pagination->display($paginationUrl);
+
+            $type = 'mainSentence';
+            $parentId = null;
+            $withAudio = false;
+            $ownerName = null;
+            foreach ($favorites as $favorite) {
+                if (empty($favorite['Sentence']['text'])) {
+                    $sentenceId = $favorite['Favorite']['favorite_id'];
+                    $linkToSentence = $html->link(
+                        '#'.$sentenceId,
+                        array(
+                            'controller' => 'sentences',
+                            'action' => 'show',
+                            $sentenceId
+                        )
+                    );
+
+                    echo $html->div('sentence deleted',
+                        format(
+                            __('Sentence {id} has been deleted.', true),
+                            array('id' => $linkToSentence)
+                        )
+                    );
+                } else {
+                    $sentences->displayGenericSentence(
+                        $favorite['Sentence'],
+                        $favorite['Sentence']['Transcription'],
+                        $type,
+                        $parentId,
+                        $withAudio
+                    );
+                }
+            }
+            $pagination->display($paginationUrl);
+
+        } else {
+            __('This user does not have any favorites.');
+            echo $html->link(__('Go back to previous page', true), $backLink);
+        }
     }
     ?>
     </div>


### PR DESCRIPTION
This pull introduces pagination in a user's favorites, as requested in Issue #970. It also fixes a bug where if a non existent user's favorites were requested, it would say that the user had no favorites instead of saying that the user does not exist.