### PR TITLE
Keyword highlight in search results and refactoring

### DIFF
--- a/app/app_model.php
+++ b/app/app_model.php
@@ -17,6 +17,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 class AppModel extends Model {
+
+    public $recursive = -1;
+
     /**
      * Function to be used in beforeSave().
      * Checks if the save() is about to update any of the provided $fields.

--- a/app/controllers/activities_controller.php
+++ b/app/controllers/activities_controller.php
@@ -196,7 +196,6 @@ class ActivitiesController extends AppController
         );
 
         $results = $this->paginate('Sentence');
-        $this->Sentence->addTranslationsToSentences($results);
 
         $this->set('results', $results);
         $this->set('lang', $lang);

--- a/app/controllers/activities_controller.php
+++ b/app/controllers/activities_controller.php
@@ -187,27 +187,16 @@ class ActivitiesController extends AppController
 
         $this->paginate = array(
             'Sentence' => array(
-                'fields' => array(
-                    'id',
-                ),
+                'fields' => $this->Sentence->fields(),
                 'conditions' => $conditions,
-                'contain' => array(),
+                'contain' => $this->Sentence->contain(),
                 'limit' => CurrentUser::getSetting('sentences_per_page'),
                 'order' => 'created DESC'
             )
         );
 
-        $paginationResults = $this->paginate('Sentence');
-
-        $sentenceIds = array();
-
-        foreach ($paginationResults as $i=>$sentence) {
-            $sentenceIds[$i] = $sentence['Sentence']['id'];
-        }
-
-        $results = $this->CommonSentence->getAllNeededForSentences(
-            $sentenceIds
-        );
+        $results = $this->paginate('Sentence');
+        $this->Sentence->addTranslationsToSentences($results);
 
         $this->set('results', $results);
         $this->set('lang', $lang);

--- a/app/controllers/activities_controller.php
+++ b/app/controllers/activities_controller.php
@@ -182,7 +182,7 @@ class ActivitiesController extends AppController
             'user_id' => $userId
         );
         if (!empty($lang)) {
-            $conditions['lang'] = $lang;
+            $conditions['Sentence.lang'] = $lang;
         }
 
         $this->paginate = array(

--- a/app/controllers/components/common_sentence.php
+++ b/app/controllers/components/common_sentence.php
@@ -98,35 +98,4 @@ class CommonSentenceComponent extends Object
         return $isSaved;
     }
 
-    public function getAllNeededForSentences($sentenceIds, $lang = null)
-    {
-        $allSentences = array();
-
-        $Sentence = ClassRegistry::init('Sentence');
-        foreach ($sentenceIds as $i=>$sentenceId) {
-
-            $sentence = $Sentence->getSentenceWithId($sentenceId);
-
-
-            $alltranslations = $Sentence->getTranslationsOf(
-                $sentenceId,
-                $lang
-            );
-            $translations = $alltranslations['Translation'];
-            $indirectTranslations = $alltranslations['IndirectTranslation'];
-
-            $allSentences[$i] = array (
-                "Sentence" => $sentence['Sentence'],
-                "Transcription" => $sentence['Transcription'],
-                "User" => $sentence['User'],
-                "Translations" => $translations,
-                "IndirectTranslations" => $indirectTranslations
-            );
-        }
-        return $allSentences;
-    }
-
-
-
-
 }

--- a/app/controllers/contributions_controller.php
+++ b/app/controllers/contributions_controller.php
@@ -87,7 +87,6 @@ class ContributionsController extends AppController
                 'conditions' => $conditions,
                 'limit' => 200,
                 'order' => 'id DESC',
-                'contain' => array()
             )
         );
         $contributions = $this->paginate();
@@ -200,7 +199,6 @@ class ContributionsController extends AppController
                 ),
                 'limit' => 200,
                 'order' => 'id DESC',
-                'contain' => array()
             )
         );
         $contributions = $this->paginate();

--- a/app/controllers/links_controller.php
+++ b/app/controllers/links_controller.php
@@ -42,13 +42,10 @@ class LinksController extends AppController
     {
         $this->loadModel('Sentence');
         $langFilter = isset($this->params['form']['langFilter']) ? $this->params['form']['langFilter'] : 'und';
-        $alltranslations = $this->Sentence->getTranslationsOf($sentenceId, $langFilter);
-        $translations = $alltranslations['Translation'];
-        $indirectTranslations = $alltranslations['IndirectTranslation'];
+        $translations = $this->Sentence->getTranslationsOf($sentenceId, $langFilter);
 
         $this->set('sentenceId', $sentenceId);
         $this->set('translations', $translations);
-        $this->set('indirectTranslations', $indirectTranslations);
         $this->set('message', $message);
         $this->set('langFilter', $langFilter);
         $this->render('/sentences/translations_group');

--- a/app/controllers/pages_controller.php
+++ b/app/controllers/pages_controller.php
@@ -188,13 +188,8 @@ class PagesController extends AppController
         $lang = $this->Session->read('random_lang_selected');
         $randomId = $this->Sentence->getRandomId($lang);
         $randomSentence = $this->Sentence->getSentenceWithId($randomId);
-        $alltranslations = $this->Sentence->getTranslationsOf($randomId);
-        $translations = $alltranslations['Translation'];
-        $indirectTranslations = $alltranslations['IndirectTranslation'];
 
         $this->set('random', $randomSentence);
-        $this->set('translations', $translations);
-        $this->set('indirectTranslations', $indirectTranslations);
 
         if (isset($randomSentence['Sentence']['script'])) {
             $this->set('sentenceScript', $randomSentence['Sentence']['script']);

--- a/app/controllers/s_controller.php
+++ b/app/controllers/s_controller.php
@@ -86,15 +86,7 @@ class SController extends AppController
                 return;
             }
 
-
             $this->set('sentence', $sentence);
-
-            // we get translations and split them
-            $alltranslations = $this->Sentence->getTranslationsOf($id);
-            $translations = $alltranslations['Translation'];
-
-            $this->set('translations', $translations);
-
 
         } else {
 

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -928,7 +928,9 @@ class SentencesController extends AppController
         $translationLang = null,
         &$real_total = 0
     ) {
-        if ($translationLang != "und") {
+        if ($translationLang == "none") {
+            unset($pagination[$model]['contain']['Translation']);
+        } elseif ($translationLang != "und") {
             $this->Sentence->linkTranslationModel(array(
                 'Translation.lang' => $translationLang
             ));

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -262,7 +262,6 @@ class SentencesController extends AppController
             return;
         }
 
-        $this->Sentence->recursive = -1;
         $sentence = $this->Sentence->findById($id);
         if (!$sentence) {
             $this->redirect(array('controller' => 'pages', 'action' => 'home'));
@@ -381,7 +380,6 @@ class SentencesController extends AppController
             $realSentenceId = Sanitize::paranoid($hack_array[1]);
             $sentenceLang = Sanitize::paranoid($hack_array[0]);
 
-            $this->Sentence->recursive = -1;
             $sentence = $this->Sentence->findById($realSentenceId);
             if (!$sentence || !CurrentUser::canEditSentenceOfUserId($sentence['Sentence']['user_id'])) {
                 $this->redirect(array('controller' => 'pages', 'action' => 'home'));

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -685,7 +685,6 @@ class SentencesController extends AppController
             $tagsArray = array_map('trim', $tagsArray);
             $result = $this->Tag->find('all', array(
                 'conditions' => array('name' => $tagsArray),
-                'contain' => array(),
                 'fields' => array('id', 'name')
             ));
             $tagsById = Set::combine($result, '{n}.Tag.id', '{n}.Tag.name');

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -201,15 +201,8 @@ class SentencesController extends AppController
 
             $this->set('sentence', $sentence);
 
-            // we get translations and split them
-            $alltranslations = $this->Sentence->getTranslationsOf($id);
-            $translations = $alltranslations['Translation'];
-            $indirectTranslations = $alltranslations['IndirectTranslation'];
-
             $this->set('tagsArray', $tagsArray);
             $this->set('listsArray', $listsArray);
-            $this->set('translations', $translations);
-            $this->set('indirectTranslations', $indirectTranslations);
 
         } else {
             // ----- if we want a random sentence in a specific language -----
@@ -968,15 +961,10 @@ class SentencesController extends AppController
 
         $randomId = $this->Sentence->getRandomId($lang);
         $randomSentence = $this->Sentence->getSentenceWithId($randomId);
-        $alltranslations = $this->Sentence->getTranslationsOf($randomId);
-        $translations = $alltranslations['Translation'];
-        $indirectTranslations = $alltranslations['IndirectTranslation'];
 
         $this->Session->write('random_lang_selected', $lang);
 
         $this->set('random', $randomSentence);
-        $this->set('translations', $translations);
-        $this->set('indirectTranslations', $indirectTranslations);
     }
 
     /**

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -928,6 +928,11 @@ class SentencesController extends AppController
         $translationLang = null,
         &$real_total = 0
     ) {
+        if ($translationLang != "und") {
+            $this->Sentence->linkTranslationModel(array(
+                'Translation.lang' => $translationLang
+            ));
+        }
 
         $this->paginate = $pagination;
         $results = $this->paginate($model);
@@ -936,10 +941,6 @@ class SentencesController extends AppController
         }
         if (isset($results[0]['Sentence']['_total_found'])) {
             $real_total = $results[0]['Sentence']['_total_found'];
-        }
-
-        if ($translationLang == "und") {
-            $translationLang = null ;
         }
 
         return $results;

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -780,10 +780,8 @@ class SentencesController extends AppController
             $model = 'Sentence';
             $pagination = array(
                 'Sentence' => array(
-                    'fields' => array(
-                        'id',
-                    ),
-                    'contain' => array(),
+                    'fields' => $this->Sentence->fields(),
+                    'contain' => $this->Sentence->contain(),
                     'limit' => CurrentUser::getSetting('sentences_per_page'),
                     'sphinx' => $sphinx,
                     'search' => $query
@@ -856,13 +854,11 @@ class SentencesController extends AppController
 
         $pagination = array(
             'Sentence' => array(
-                'fields' => array(
-                    'id',
-                ),
+                'fields' => $this->Sentence->fields(),
+                'contain' => $this->Sentence->contain(),
                 'conditions' => array(
-                    'lang' => $lang,
+                    'Sentence.lang' => $lang,
                 ),
-                'contain' => array(),
                 'limit' => CurrentUser::getSetting('sentences_per_page'),
                 'order' => "Sentence.id desc"
             )
@@ -881,16 +877,14 @@ class SentencesController extends AppController
             $model = 'SentenceNotTranslatedInto';
             $pagination = array(
                 'SentenceNotTranslatedInto' => array(
-                    'fields' => array(
-                        'id',
-                    ),
+                    'fields' => $this->Sentence->fields(),
                     'conditions' => array(
                         'source' => $lang,
                         'translatedInto' => $translationLang,
                         'notTranslatedInto' => $notTranslatedInto,
                         'audioOnly' => $audioOnly,
                     ),
-                    'contain' => array(),
+                    'contain' => $this->Sentence->contain(),
                     'order' => 'Sentence.id DESC',
                     'limit' => 10,
                 )
@@ -962,11 +956,8 @@ class SentencesController extends AppController
             $translationLang = null ;
         }
 
-        $allSentences = $this->CommonSentence->getAllNeededForSentences(
-            $sentenceIds,
-            $translationLang
-        );
-        return $allSentences;
+        $this->Sentence->addTranslationsToSentences($results, $translationLang);
+        return $results;
     }
     /**
      * Show random sentence.

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -891,6 +891,7 @@ class SentencesController extends AppController
                         'audioOnly' => $audioOnly,
                     ),
                     'contain' => array(),
+                    'order' => 'Sentence.id DESC',
                     'limit' => 10,
                 )
             );

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -945,18 +945,10 @@ class SentencesController extends AppController
             $real_total = $results[0]['Sentence']['_total_found'];
         }
 
-        $sentenceIds = array();
-
-        foreach ($results as $i=>$sentence) {
-            $sentenceIds[$i] = $sentence['Sentence']['id'];
-        }
-
-
         if ($translationLang == "und") {
             $translationLang = null ;
         }
 
-        $this->Sentence->addTranslationsToSentences($results, $translationLang);
         return $results;
     }
     /**
@@ -1027,7 +1019,6 @@ class SentencesController extends AppController
             'number' => $number,
             'contain' => $this->Sentence->contain(),
         ));
-        $this->Sentence->addTranslationsToSentences($allSentences);
 
         $this->set("allSentences", $allSentences);
         $this->set('lastNumberChosen', $number);

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -1020,14 +1020,14 @@ class SentencesController extends AppController
             $number = 5 ;
         }
 
-        // for far better perfomance we must do it in one request, but hmmm no time
-        // for that and as said above that's a work around
-
-        $randomIds = $this->Sentence->getSeveralRandomIds($lang, $number);
-
         $this->Session->write('random_lang_selected', $lang);
 
-        $allSentences = $this->CommonSentence->getAllNeededForSentences($randomIds);
+        $allSentences = $this->Sentence->find('random', array(
+            'lang' => $lang,
+            'number' => $number,
+            'contain' => $this->Sentence->contain(),
+        ));
+        $this->Sentence->addTranslationsToSentences($allSentences);
 
         $this->set("allSentences", $allSentences);
         $this->set('lastNumberChosen', $number);

--- a/app/controllers/sentences_lists_controller.php
+++ b/app/controllers/sentences_lists_controller.php
@@ -187,18 +187,11 @@ class SentencesListsController extends AppController
             $id, CurrentUser::getSetting('sentences_per_page')
         );
         $sentencesInList = $this->paginate('SentencesSentencesLists');
-
-        $sentenceIds = array();
-        foreach ($sentencesInList as $sentence) {
-            $sentenceIds[] = $sentence['SentencesSentencesLists']['sentence_id'];
-        }
-        $sentencesInList = $this->CommonSentence->getAllNeededForSentences(
-            $sentenceIds, $translationsLang
-        );
+        $this->SentencesSentencesLists->Sentence
+             ->addTranslationsToSentences($sentencesInList, $translationsLang);
 
         $thisListCount = $this->params['paging']['SentencesSentencesLists']['count'];
         $downloadability_info = $this->_get_downloadability_info($thisListCount);
-
 
         $this->set('translationsLang', $translationsLang);
         $this->set('list', $list);

--- a/app/controllers/sentences_lists_controller.php
+++ b/app/controllers/sentences_lists_controller.php
@@ -187,8 +187,6 @@ class SentencesListsController extends AppController
             $id, CurrentUser::getSetting('sentences_per_page')
         );
         $sentencesInList = $this->paginate('SentencesSentencesLists');
-        $this->SentencesSentencesLists->Sentence
-             ->addTranslationsToSentences($sentencesInList, $translationsLang);
 
         $thisListCount = $this->params['paging']['SentencesSentencesLists']['count'];
         $downloadability_info = $this->_get_downloadability_info($thisListCount);

--- a/app/controllers/sinograms_controller.php
+++ b/app/controllers/sinograms_controller.php
@@ -184,10 +184,6 @@ class SinogramsController extends AppController
                     $sentenceWhichUseThisSinogram, $this->Auth->user('id')
                 );
 
-            $alltranslations = $this->Sentence->getTranslationsOf($sentenceId);
-            $translations = $alltranslations['Translation'];
-            $indirectTranslations = $alltranslations['IndirectTranslation'];
-
             $this->set('specialOptions', $specialOptions);
             $this->set("sentenceFound", true);
         } else {
@@ -197,8 +193,7 @@ class SinogramsController extends AppController
         $this->set("sentence", $sentenceWhichUseThisSinogram['Sentence']);
         $this->set("transcrs", $sentenceWhichUseThisSinogram['Transcription']);
         $this->set("sentenceOwner", $sentenceWhichUseThisSinogram['User']);
-        $this->set('indirectTranslations', $indirectTranslations);
-        $this->set('translations', $translations);
+        $this->set('translations', $sentenceWhichUseThisSinogram['Translation']);
 
     }
 

--- a/app/controllers/tags_controller.php
+++ b/app/controllers/tags_controller.php
@@ -272,7 +272,6 @@ class TagsController extends AppController
             );
 
             $sentences = $this->paginate('TagsSentences');
-            $this->Tag->Sentence->addTranslationsToSentences($sentences);
 
             $taggerIds = array();
             foreach ($sentences as $sentence) {

--- a/app/controllers/tags_controller.php
+++ b/app/controllers/tags_controller.php
@@ -271,21 +271,16 @@ class TagsController extends AppController
                 $lang
             );
 
-            $sentencesIdsTaggerIds = $this->paginate('TagsSentences');
+            $sentences = $this->paginate('TagsSentences');
+            $this->Tag->Sentence->addTranslationsToSentences($sentences);
 
             $taggerIds = array();
-            $sentenceIds = array();
-
-            foreach ($sentencesIdsTaggerIds as $sentenceIdTaggerId) {
-                $taggerIds[] = $sentenceIdTaggerId['TagsSentences']['user_id'];
-                $sentenceIds[] = $sentenceIdTaggerId['TagsSentences']['sentence_id'];
+            foreach ($sentences as $sentence) {
+                $taggerIds[] = $sentence['TagsSentences']['user_id'];
             }
-            $allSentences = $this->CommonSentence->getAllNeededForSentences(
-                $sentenceIds
-            );
 
             $this->set('langFilter', $lang);
-            $this->set('allSentences', $allSentences);
+            $this->set('allSentences', $sentences);
             $this->set('tagName', $tagName);
             $this->set('taggerIds', $taggerIds);
         } else {

--- a/app/controllers/tags_controller.php
+++ b/app/controllers/tags_controller.php
@@ -173,7 +173,6 @@ class TagsController extends AppController
         $this->paginate = array(
             'limit' => 50,
             'fields' => array('name', 'id', 'nbrOfSentences'),
-            'contain' => array(),
             'order' => 'nbrOfSentences DESC'
         );
         if (!empty($filter)) {

--- a/app/controllers/users_controller.php
+++ b/app/controllers/users_controller.php
@@ -542,7 +542,6 @@ class UsersController extends AppController
             'limit' => 20,
             'order' => 'group_id',
             'fields' => array('username', 'since', 'image', 'group_id'),
-            'contain' => array()
         );
 
         $users = $this->paginate(array('User.group_id < 5'));

--- a/app/models/behaviors/sphinx.php
+++ b/app/models/behaviors/sphinx.php
@@ -58,7 +58,6 @@ class SphinxBehavior extends ModelBehavior
 
         if ($model->findQueryType == 'count')
         {
-            $model->recursive = -1;
             $query['limit'] = 1;
             $query['page'] = 1;
         }

--- a/app/models/behaviors/transcriptable.php
+++ b/app/models/behaviors/transcriptable.php
@@ -72,7 +72,6 @@ class TranscriptableBehavior extends ModelBehavior
                     'conditions' => array(
                         $model->alias . '.' . $model->primaryKey => $model->id
                     ),
-                    'contain' => array(),
                 ));
                 $this->createTranscriptions($model, $sentence);
             }

--- a/app/models/contribution.php
+++ b/app/models/contribution.php
@@ -41,8 +41,6 @@ class Contribution extends AppModel
     );
     public $belongsTo = array('Sentence', 'User');
 
-    public $recursive = -1;
-
     /**
      * Get number of contributions made by a given user
      *
@@ -55,7 +53,6 @@ class Contribution extends AppModel
         return $this->find(
             'count',
             array(
-                'contain' => array(),
                 'conditions' => array(
                     'Contribution.user_id' => $userId
                 )
@@ -177,7 +174,6 @@ class Contribution extends AppModel
                     'Contribution.translation_id' => null,
                     'Contribution.action' => 'insert'
                 ),
-                'contain' => array()
             )
         );
     }

--- a/app/models/favorite.php
+++ b/app/models/favorite.php
@@ -39,7 +39,6 @@ class Favorite extends AppModel
 {
     public $name = 'Favorite';
     public $useTable = 'favorites_users';
-    public $recursive = -1;
 
     public $actsAs = array(
         'Containable'

--- a/app/models/link.php
+++ b/app/models/link.php
@@ -42,8 +42,6 @@ class Link extends AppModel
         'Sentence'
     );
 
-    public $recursive = -1;
-
     public function beforeSave() {
         if (   isset($this->data[$this->alias]['sentence_id'])
             && isset($this->data[$this->alias]['translation_id'])) {

--- a/app/models/private_message.php
+++ b/app/models/private_message.php
@@ -124,7 +124,6 @@ class PrivateMessage extends AppModel
                     'PrivateMessage.folder' => 'Inbox',
                     'PrivateMessage.isnonread' => 1
                 ),
-                "contain" => array()
             )
         );
     }

--- a/app/models/recordings.php
+++ b/app/models/recordings.php
@@ -19,8 +19,6 @@
 
 class Recordings extends AppModel
 {
-    public $recursive = -1;
-
     public $useTable = false;
 
     public $belongsTo = array(

--- a/app/models/recordings.php
+++ b/app/models/recordings.php
@@ -52,7 +52,6 @@ class Recordings extends AppModel
         $sentences = $this->Sentence->find('all', array(
             'conditions' => array('Sentence.id' => $allSentenceIds),
             'fields' => array('id', 'lang', 'hasaudio'),
-            'recursive' => -1
         ));
         $sentences = Set::combine($sentences, '{n}.Sentence.id', '{n}.Sentence');
 

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -72,6 +72,10 @@ class Sentence extends AppModel
         ),
         'SentenceAnnotation',
         'Transcription',
+        'Translation' => array(
+            'className' => 'Translation',
+            'foreignKey' => 'sentence_id',
+        ),
     );
 
     public $hasOne = 'ReindexFlag';
@@ -114,13 +118,18 @@ class Sentence extends AppModel
     public function __construct($id = false, $table = null, $ds = null)
     {
         parent::__construct($id, $table, $ds);
+
         if (!Configure::read('AutoTranscriptions.enabled')) {
             $this->Behaviors->disable('Transcriptable');
         }
         if (Configure::read('Search.enabled')) {
             $this->Behaviors->attach('Sphinx');
         }
+
         $this->_findMethods['random'] = true;
+
+        $this->hasMany['Translation']['finderQuery']
+            = $this->Translation->hasManyTranslationsLikeSqlQuery();
     }
 
     private function clean($text)
@@ -623,7 +632,7 @@ class Sentence extends AppModel
             $languages = CurrentUser::getLanguages();
         }
 
-        return $this->Translation->find($id, $languages);
+        return $this->Translation->getTranslationsOf($id, $languages);
     }
 
 

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -551,8 +551,6 @@ class Sentence extends AppModel
      */
     public function getSentenceWithId($id)
     {
-        $contain = $this->contain();
-        $fields = $this->fields();
         $result = $this->find(
             'first',
             array(

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -120,6 +120,7 @@ class Sentence extends AppModel
         if (Configure::read('Search.enabled')) {
             $this->Behaviors->attach('Sphinx');
         }
+        $this->_findMethods['random'] = true;
     }
 
     private function clean($text)
@@ -341,6 +342,22 @@ class Sentence extends AppModel
         );
 
         return $results[0]['Sentence']['id'];
+    }
+
+    /**
+     * Custom ->find('random', ...) function.
+     */
+    public function _findRandom($state, $query, $results = array())
+    {
+        if ($state == 'before') {
+            $ids = $this->getSeveralRandomIds($query['lang'], $query['number']);
+            $query['conditions'][$this->alias.'.'.$this->primaryKey] = $ids;
+            unset($query['lang']);
+            unset($query['number']);
+            return $query;
+        } else {
+            return $results;
+        }
     }
 
     /**

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -63,7 +63,6 @@ class Sentence extends AppModel
     );
 
     public $hasMany = array(
-        'Link',
         'Contribution',
         'SentenceComment',
         'Favorites_users' => array (
@@ -93,8 +92,8 @@ class Sentence extends AppModel
     );
 
     public $hasAndBelongsToMany = array(
-        'Translation' => array(
-            'className' => 'Translation',
+        'Link' => array(
+            'className' => 'Link',
             'joinTable' => 'sentences_translations',
             'foreignKey' => 'translation_id',
             'associationForeignKey' => 'sentence_id'
@@ -262,7 +261,7 @@ class Sentence extends AppModel
             'first',
             array(
                 'conditions' => array('Sentence.id' => $this->id),
-                'contain' => array ('Translation', 'User')
+                'contain' => array('Link', 'User')
             )
         );
 
@@ -298,7 +297,7 @@ class Sentence extends AppModel
 
         // --- Logs for links ---
         $action = 'delete';
-        foreach ($this->data['Translation'] as $translation) {
+        foreach ($this->data['Link'] as $translation) {
             $this->Contribution->saveLinkContribution(
                 $sentenceId, $translation['id'], $action
             );

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -466,6 +466,7 @@ class Sentence extends AppModel
     public function fields()
     {
         return array(
+            'id',
             'text',
             'lang',
             'user_id',

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -504,8 +504,7 @@ class Sentence extends AppModel
     /**
      * Returns the appropriate value for the 'contain' parameter
      * of a typical ->find('all', ...). It makes it return everything
-     * we need to display typical sentence groups (except translations,
-     * that require calling ->addTranslationsToSentences() afterwards).
+     * we need to display typical sentence groups.
      */
     public function contain()
     {
@@ -522,6 +521,11 @@ class Sentence extends AppModel
             'Transcription'   => array(
                 'User' => array('fields' => array('username')),
             ),
+            'Translation' => array(
+                'Transcription' => array(
+                    'User' => array('fields' => array('username')),
+                ),
+            ),
         );
     }
 
@@ -534,24 +538,6 @@ class Sentence extends AppModel
         $params = $this->contain();
         $params['fields'] = $this->fields();
         return $params;
-    }
-
-    /**
-     * Add a 'Translation' and 'IndirectTranslation' keys to each 'Sentence'
-     * of $resultSet. Use this to get indirect and direct translations added
-     * to the result of a ->find() to the Sentence model.
-     */
-    public function addTranslationsToSentences(&$resultSet, $lang = null)
-    {
-        foreach ($resultSet as &$result) {
-            $alltranslations = $this->getTranslationsOf(
-                $result['Sentence']['id'],
-                $lang
-            );
-            foreach ($alltranslations as $type => $translations) {
-                $result['Sentence'][$type] = $translations;
-            }
-        }
     }
 
     /**

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -47,6 +47,7 @@ class Sentence extends AppModel
 
     public $name = 'Sentence';
     public $actsAs = array('Containable', 'Transcriptable');
+    public $recursive = -1;
 
     const MIN_CORRECTNESS = -1;
     const MAX_CORRECTNESS = 0;
@@ -244,7 +245,6 @@ class Sentence extends AppModel
         $sentences = $this->find('all', array(
             'conditions' => array('id' => $ids),
             'fields' => array('id as sentence_id', 'lang'),
-            'recursive' => -1,
         ));
         foreach ($sentences as &$rec) {
             unset($rec['Sentence']['script']); // TODO get this removed
@@ -480,7 +480,6 @@ class Sentence extends AppModel
             array(
                 'fields' => array('id'),
                 'sphinx' => $sphinx,
-                'contain' => array(),
                 'search' => '',
                 'limit' => 100,
             )
@@ -595,7 +594,6 @@ class Sentence extends AppModel
                 'conditions' => array(
                     'Sentence.user_id' => $userId
                 ),
-                'contain' => array()
             )
         );
     }
@@ -648,7 +646,6 @@ class Sentence extends AppModel
             array(
                 'fields' => array("id"),
                 'conditions' => $conditions,
-                'contain'=> array()
             )
         );
 
@@ -912,7 +909,6 @@ class Sentence extends AppModel
     {
         $sentence = $this->find('first', array(
             'conditions' => array('id' => $sentenceId),
-            'recursive' => -1,
             'fields' => array('lang', 'user_id'),
         ));
         if (!$sentence) {
@@ -962,14 +958,7 @@ class Sentence extends AppModel
      */
     public function getTotalNumberOfSentences()
     {
-        $numSentences = $this->find(
-            'count',
-            array(
-                'contain' => array()
-            )
-        );
-
-        return $numSentences;
+        return $this->find('count');
     }
 
 
@@ -1012,7 +1001,6 @@ class Sentence extends AppModel
             array(
                 'fields' => array('text'),
                 'conditions' => array('id' => $sentenceId),
-                'contain' => array()
             )
         );
 
@@ -1033,7 +1021,6 @@ class Sentence extends AppModel
             array(
                 'fields' => array('lang'),
                 'conditions' => array('id' => $sentenceId),
-                'contain' => array()
             )
         );
         
@@ -1060,7 +1047,6 @@ class Sentence extends AppModel
         $result = $this->find('all', array(
             'fields' => array('lang', 'id'),
             'conditions' => array('Sentence.id' => $sentencesIds),
-            'recursive' => -1
         ));
         return Set::combine($result, '{n}.Sentence.id', '{n}.Sentence.lang');
     }

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -127,8 +127,13 @@ class Sentence extends AppModel
 
         $this->_findMethods['random'] = true;
 
+        $this->linkTranslationModel();
+    }
+
+    public function linkTranslationModel($conditions = array())
+    {
         $this->hasMany['Translation']['finderQuery']
-            = $this->Translation->hasManyTranslationsLikeSqlQuery();
+            = $this->Translation->hasManyTranslationsLikeSqlQuery($conditions);
     }
 
     private function clean($text)

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -44,10 +44,8 @@ App::import('Vendor', 'LanguagesLib');
 
 class Sentence extends AppModel
 {
-
     public $name = 'Sentence';
     public $actsAs = array('Containable', 'Transcriptable');
-    public $recursive = -1;
 
     const MIN_CORRECTNESS = -1;
     const MAX_CORRECTNESS = 0;

--- a/app/models/sentence_comment.php
+++ b/app/models/sentence_comment.php
@@ -52,7 +52,6 @@ class SentenceComment extends AppModel
             'count',
             array(
                 'conditions' => array( 'SentenceComment.user_id' => $userId),
-                'contain' => array()
              )
         );
 
@@ -191,7 +190,6 @@ class SentenceComment extends AppModel
             array(
                 'fields' => array('SentenceComment.user_id'),
                 'conditions' => array('SentenceComment.id' => $commentId),
-                'contain' => array()
             )
         );
 

--- a/app/models/sentence_not_translated_into.php
+++ b/app/models/sentence_not_translated_into.php
@@ -26,6 +26,8 @@
  * @link     http://tatoeba.org
  */
 
+App::import('Core', 'Sanitize');
+
 /**
  * Model Class used only for pagination
  *
@@ -58,60 +60,76 @@ class SentenceNotTranslatedInto extends AppModel
         $recursive = null,
         $extra = array()
     ) {
-        $recursive = -1;
         $source = $conditions['source'] ;
         $target = $conditions['notTranslatedInto'] ;
         $audioOnly = $conditions['audioOnly'];
 
-        $source = Sanitize::paranoid($source);
-        $target = Sanitize::paranoid($target);
-        $audioOnly = Sanitize::paranoid($audioOnly);
-
-        if ($page < 1) {
-         $page = 1;
-        }
-
-        $limitHigh = $limit * $page;
-        $limitLow = $limitHigh - $limit;
-
-        // to add to the sql conditions, if we want only sentences with audio
-        $filterAudio = '';
-        if ($audioOnly == true) {
-            $filterAudio = "AND Sentence.hasaudio != 'no' ";
-        }
+        $dbo = $this->getDataSource();
 
         if ($target == 'und') {
             // we want only untranslated sentences
-            $sql
-                = "
-            SELECT distinct Sentence.id FROM sentences as Sentence
-            WHERE Sentence.lang = '$source' $filterAudio
-              AND Sentence.id NOT IN
-              (
-                SELECT s.id FROM sentences s
-                  JOIN sentences_translations st ON ( s.id = st.sentence_id )
-                WHERE s.lang = '$source'
-              )
-            ORDER BY Sentence.id DESC
-            LIMIT $limitLow,$limit;
-            ";
+            $subQuery = $dbo->buildStatement(
+                array(
+                    'fields' => array('Sentence.id'),
+                    'table' => 'sentences',
+                    'alias' => 'Sentence',
+                    'limit' => null,
+                    'joins' => array(array(
+                        'table' => 'sentences_translations',
+                        'alias' => 'Link',
+                        'conditions' => array(
+                            'Sentence.id = Link.sentence_id'
+                        ),
+                    )),
+                    'conditions' => array('Sentence.lang' => $source),
+                    'order' => null,
+                    'group' => null,
+                ),
+                $this
+            );
         } else {
-            $sql
+            $subquery
                 = "
-            SELECT distinct Sentence.id FROM sentences as Sentence
-            WHERE Sentence.lang = '$source' $filterAudio
-              AND Sentence.id NOT IN
-              (
                 SELECT sentence_id FROM sentences_translations
                 WHERE sentence_lang = '$source'
                   AND translation_lang = '$target'
-              )
-            ORDER BY Sentence.id DESC
-            LIMIT $limitLow,$limit;
             ";
+            $subQuery = $dbo->buildStatement(
+                array(
+                    'fields' => array('Link.sentence_id'),
+                    'table' => 'sentences_translations',
+                    'alias' => 'Link',
+                    'limit' => null,
+                    'conditions' => array(
+                        'Link.sentence_lang' => $source,
+                        'Link.translation_lang' => $target,
+                    ),
+                    'order' => null,
+                    'group' => null,
+                ),
+                $this
+            );
+        }
+        $notTranslatedInCondition
+            = $dbo->expression("Sentence.id NOT IN ($subQuery)");
+
+        $conditions = array(
+            'Sentence.lang' => $source,
+            $notTranslatedInCondition,
+        );
+        if ($audioOnly == true) {
+            $conditions['Sentence.hasaudio !='] = 'no';
         }
 
-        $result = $this->query($sql);
+        $result = ClassRegistry::init('Sentence')->find('all', array(
+            'fields' => $fields,
+            'conditions' => $conditions,
+            'order' => $order,
+            'limit' => $limit,
+            'page' => $page,
+            'contain' => array(),
+        ));
+
         return $result;
     }
 

--- a/app/models/sentence_not_translated_into.php
+++ b/app/models/sentence_not_translated_into.php
@@ -121,14 +121,9 @@ class SentenceNotTranslatedInto extends AppModel
             $conditions['Sentence.hasaudio !='] = 'no';
         }
 
-        $result = ClassRegistry::init('Sentence')->find('all', array(
-            'fields' => $fields,
-            'conditions' => $conditions,
-            'order' => $order,
-            'limit' => $limit,
-            'page' => $page,
-            'contain' => array(),
-        ));
+        $Sentence = ClassRegistry::init('Sentence');
+        $options = compact('fields', 'conditions', 'order', 'limit', 'page');
+        $result = $Sentence->find('all', array_merge($options, $extra));
 
         return $result;
     }

--- a/app/models/sentence_not_translated_into.php
+++ b/app/models/sentence_not_translated_into.php
@@ -47,7 +47,8 @@ class SentenceNotTranslatedInto extends AppModel
 
 
     /**
-     * Overriding the paginate function in order to use a "raw" SQL request
+     * Overriding the paginate function in order to speed up
+     * things using custom queries.
      *
      * @return array
      */
@@ -88,12 +89,6 @@ class SentenceNotTranslatedInto extends AppModel
                 $this
             );
         } else {
-            $subquery
-                = "
-                SELECT sentence_id FROM sentences_translations
-                WHERE sentence_lang = '$source'
-                  AND translation_lang = '$target'
-            ";
             $subQuery = $dbo->buildStatement(
                 array(
                     'fields' => array('Link.sentence_id'),

--- a/app/models/sentences_list.php
+++ b/app/models/sentences_list.php
@@ -37,7 +37,6 @@
 class SentencesList extends AppModel
 {
     public $actsAs = array('Containable');
-    public $recursive = -1;
     public $belongsTo = array('User');
     public $hasMany = array('SentencesSentencesLists');
     public $hasAndBelongsToMany = array('Sentence');

--- a/app/models/sentences_sentences_lists.php
+++ b/app/models/sentences_sentences_lists.php
@@ -40,7 +40,6 @@ class SentencesSentencesLists extends AppModel
     public $name = 'SentencesSentencesLists';
     public $useTable = 'sentences_sentences_lists';
     public $actsAs = array('Containable');
-    public $recursive = -1;
 
     public $belongsTo = array(
         'Sentence' => array('foreignKey' => 'sentence_id'),

--- a/app/models/sentences_sentences_lists.php
+++ b/app/models/sentences_sentences_lists.php
@@ -102,6 +102,8 @@ class SentencesSentencesLists extends AppModel
         return array(
             'limit' => $limit,
             'conditions' => array('sentences_list_id' => $listId),
+            'contain' => array('Sentence' => $this->Sentence->paginateContain()),
+            'fields' => array('created', 'sentence_id'),
             'order' => 'created DESC'
         );
     }

--- a/app/models/tag.php
+++ b/app/models/tag.php
@@ -216,7 +216,6 @@ class Tag extends AppModel
             'first',
             array(
                 'conditions' => array('Tag.internal_name' => $tagInternalName),
-                'contain' => array(),
                 'fields' => 'id'
             )
         );
@@ -234,7 +233,6 @@ class Tag extends AppModel
             'first',
             array(
                 'conditions' => array('Tag.name'=>$tagName),
-                'contain' => array(),
                 'fields' => 'id'
             )
         );
@@ -252,7 +250,6 @@ class Tag extends AppModel
         'first',
             array(
                 'conditions' => array('Tag.id'=>$tagId),
-                'contain' => array(),
                 'fields' => 'name'
             )
         );
@@ -270,7 +267,6 @@ class Tag extends AppModel
             'first',
             array(
                 'conditions' => array('Tag.id'=>$tagId),
-                'contain' => array(),
                 'fields' => 'name'
             )
         );

--- a/app/models/tag.php
+++ b/app/models/tag.php
@@ -180,29 +180,15 @@ class Tag extends AppModel
     public function paramsForPaginate($tagId, $limit, $lang = null)
     {
         $conditions = array('Tag.id' => $tagId);
-        $contain =  array(
+        $contain = array(
             'Tag' => array(
-                'fields' => array()
-            )
+                'fields' => array('id'),
+            ),
+            'Sentence' => $this->Sentence->paginateContain(),
         );
 
         if (!empty($lang) && $lang != 'und') {
-             $conditions = array(
-                "AND" => array(
-                    'Tag.id' => $tagId,
-                    'Sentence.lang' => $lang
-                )
-            );
-
-            $contain =  array(
-                'Tag' => array(
-                    'fields' => array()
-                ),
-                'Sentence' => array(
-                    'fields' => array()
-                ),
-            );
-
+            $conditions['Sentence.lang'] = $lang;
         }
         $params = array(
             'TagsSentences' => array(

--- a/app/models/tags_sentences.php
+++ b/app/models/tags_sentences.php
@@ -176,8 +176,8 @@ class TagsSentences extends AppModel
                 'fields' => 'tag_id',
                 'conditions' => array(
                     "tag_id" => $tagId,
-                    "sentence_id" => $sentenceId),
-                'contain' => array()
+                    "sentence_id" => $sentenceId
+                ),
             )
         );
 
@@ -191,7 +191,6 @@ class TagsSentences extends AppModel
         $records = $this->find('all', array(
             'conditions' => array('sentence_id' => $sentenceId),
             'fields' => 'tag_id',
-            'recursive' => -1,
         ));
         $tagsId = Set::classicExtract($records, '{n}.TagsSentences.tag_id');
         $values = array($sentenceId => array($tagsId));

--- a/app/models/transcription.php
+++ b/app/models/transcription.php
@@ -88,7 +88,6 @@ class Transcription extends AppModel
     );
 
     public $actsAs = array('Containable');
-    public $recursive = -1;
 
     public $validate = array(
         'sentence_id' => array(

--- a/app/models/transcription.php
+++ b/app/models/transcription.php
@@ -236,7 +236,6 @@ class Transcription extends AppModel
             return false;
         $parentSentence = $this->Sentence->find('first', array(
             'conditions' => array('Sentence.id' => $parentSentenceId),
-            'contain' => array(),
         ));
         if (!$parentSentence)
             return false;

--- a/app/models/translation.php
+++ b/app/models/translation.php
@@ -86,14 +86,14 @@ class Translation extends AppModel
 
     /**
      * Build the array parameter for find() that allows fast retrieval
-     * of direct and indirect translations of sentence $id.
+     * of direct and indirect translations of sentences of id $ids.
      *
-     * @param int  $id Sentence id the query will fetch translations of.
+     * @param array or int $ids Sentence(s) id the query will fetch translations of.
      * @param bool $escapeId Escape $id while building SQL internally.
      *
      * @return array find()-compatible options
      */
-    public function fetchTranslationsQuery($id, $escapeId = true)
+    public function fetchTranslationsQuery($ids, $escapeId = true)
     {
         /**
          * This query is constructed with a subquery, which finds the
@@ -124,9 +124,9 @@ class Translation extends AppModel
          */
         $dbo = $this->getDataSource();
         if ($escapeId) {
-            $conditions = array('Link.sentence_id' => $id);
+            $conditions = array('Link.sentence_id' => $ids);
         } else {
-            $conditions = array("Link.sentence_id = $id");
+            $conditions = array("Link.sentence_id = $ids");
         }
         $subQuery = $dbo->buildStatement(
             array(
@@ -153,7 +153,7 @@ class Translation extends AppModel
                 )),
                 'conditions' => $conditions,
                 'order' => null,
-                'group' => 'translation_id',
+                'group' => array('sentence_id', 'translation_id'),
             ),
             $this
         );
@@ -197,16 +197,16 @@ class Translation extends AppModel
     }
 
     /**
-     * Get translations of a given sentence and translations of translations.
+     * Get translations of one or more given sentences and translations of translations.
      *
-     * @param int   $id    Id of the sentence we want translations of.
+     * @param int   $ids   Ids of the sentences we want translations of.
      * @param array $langs To filter translations only in some languages.
      *
      * @return array Array of translations (direct and indirect).
      */
-    public function getTranslationsOf($id, $langs)
+    public function getTranslationsOf($ids, $langs)
     {
-        $query = $this->fetchTranslationsQuery($id);
+        $query = $this->fetchTranslationsQuery($ids);
         if ($langs) {
             $query['conditions']['Translation.lang'] = $langs;
         }

--- a/app/models/translation.php
+++ b/app/models/translation.php
@@ -56,7 +56,7 @@ class Translation extends AppModel
     public function hasManyTranslationsLikeSqlQuery()
     {
         $dbo = $this->getDataSource();
-        $query = $this->fetchTranslationsQuery('{$__cakeID__$}');
+        $query = $this->fetchTranslationsQuery('({$__cakeID__$})', false);
         $query = array_merge(
             array(
                 'table' => $dbo->fullTableName($this),
@@ -89,10 +89,11 @@ class Translation extends AppModel
      * of direct and indirect translations of sentence $id.
      *
      * @param int  $id Sentence id the query will fetch translations of.
+     * @param bool $escapeId Escape $id while building SQL internally.
      *
      * @return array find()-compatible options
      */
-    public function fetchTranslationsQuery($id)
+    public function fetchTranslationsQuery($id, $escapeId = true)
     {
         /**
          * This query is constructed with a subquery, which finds the
@@ -122,6 +123,11 @@ class Translation extends AppModel
          *   ORDER BY Translation.lang;
          */
         $dbo = $this->getDataSource();
+        if ($escapeId) {
+            $conditions = array('Link.sentence_id' => $id);
+        } else {
+            $conditions = array("Link.sentence_id = $id");
+        }
         $subQuery = $dbo->buildStatement(
             array(
                 'fields' => array(
@@ -145,7 +151,7 @@ class Translation extends AppModel
                         'Link.translation_id = IndirectLink.sentence_id'
                     ),
                 )),
-                'conditions' => array('Link.sentence_id' => $id),
+                'conditions' => $conditions,
                 'order' => null,
                 'group' => 'translation_id',
             ),

--- a/app/models/translation.php
+++ b/app/models/translation.php
@@ -181,6 +181,21 @@ class Translation extends AppModel
         );
     }
 
+    public function afterFind($results, $primary = false) {
+        if ($primary) {
+            // Direct Translation::find() call case, as
+            // opposed to find('contain' => array('Translation')).
+            // Let's fix getTranslationsOf()'s return value.
+            foreach ($results as $i => $result) {
+                foreach ($results[$i]['AllTranslations'] as $k => $v) {
+                    $results[$i]['Translation'][$k] = $v;
+                }
+                unset($results[$i]['AllTranslations']);
+            }
+        }
+        return $results;
+    }
+
     /**
      * Get translations of a given sentence and translations of translations.
      *
@@ -200,23 +215,7 @@ class Translation extends AppModel
                 'User' => array('fields' => 'username')
             )
         );
-        $translations = parent::find('all', $query);
-
-        $orderedTranslations = array(
-            'Translation' => array(),
-            'IndirectTranslation' => array()
-        );
-        $map = array(
-            '0' => 'Translation',
-            '1' => 'IndirectTranslation',
-        );
-        foreach ($translations as $record) {
-            $distance = $record['AllTranslations']['type'];
-            unset($record['AllTranslations']);
-            $orderedTranslations[ $map[$distance] ][] = $record;
-        };
-
-        return $orderedTranslations;
+        return $this->find('all', $query);
     }
 }
 ?>

--- a/app/models/translation.php
+++ b/app/models/translation.php
@@ -39,6 +39,7 @@ class Translation extends AppModel
     public $actsAs = array('Containable', 'Transcriptable');
     public $useTable = 'sentences';
     public $hasMany = array('Transcription');
+    public $recursive = -1;
 
     public function __construct($id = false, $table = null, $ds = null)
     {

--- a/app/models/translation.php
+++ b/app/models/translation.php
@@ -39,7 +39,6 @@ class Translation extends AppModel
     public $actsAs = array('Containable', 'Transcriptable');
     public $useTable = 'sentences';
     public $hasMany = array('Transcription');
-    public $recursive = -1;
 
     public function __construct($id = false, $table = null, $ds = null)
     {

--- a/app/models/translation.php
+++ b/app/models/translation.php
@@ -53,7 +53,7 @@ class Translation extends AppModel
      * fast. It returns results that mimics a regular hasMany relationship,
      * so that it interfaces well with CakePHP's Containable behavior.
      */
-    public function hasManyTranslationsLikeSqlQuery()
+    public function hasManyTranslationsLikeSqlQuery($conditions = array())
     {
         $dbo = $this->getDataSource();
         $query = $this->fetchTranslationsQuery('({$__cakeID__$})', false);
@@ -61,7 +61,7 @@ class Translation extends AppModel
             array(
                 'table' => $dbo->fullTableName($this),
                 'alias' => $this->alias,
-                'conditions' => array(),
+                'conditions' => $conditions,
                 'group' => null,
                 'order' => null,
                 'limit' => null,

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -53,8 +53,6 @@ class User extends AppModel
         'Containable'
     );
 
-    public $recursive = -1;
-
     // contributor vs. advanced contributor vs. corpus maintainer vs. admin
     const LOWEST_TRUST_GROUP_ID = 4;
 

--- a/app/models/users_languages.php
+++ b/app/models/users_languages.php
@@ -43,7 +43,6 @@ class UsersLanguages extends AppModel
         'User' => array('foreignKey' => 'of_user_id'),
         'Language' => array('foreignKey' => 'language_code')
     );
-    public $recursive = -1;
 
 
     public function beforeSave()

--- a/app/models/users_sentences.php
+++ b/app/models/users_sentences.php
@@ -39,7 +39,6 @@ class UsersSentences extends AppModel
     public $name = 'UsersSentences';
     public $useTable = "users_sentences";
     public $actsAs = array('Containable');
-    public $recursive = -1;
     public $belongsTo = array(
         'Sentence',
         'User' => array('foreignKey' => 'user_id')

--- a/app/models/wall.php
+++ b/app/models/wall.php
@@ -249,7 +249,6 @@ class Wall extends AppModel
             array(
                 'fields' => array('owner'),
                 'conditions' => array('id' => $messageId),
-                'contain' => array()
             )
         );
 
@@ -282,7 +281,6 @@ class Wall extends AppModel
                     'lft <=' => $replyLft,
                     'rght >=' => $replyRght
                 ),
-                'contain' => array()
             )
         );
 
@@ -349,7 +347,6 @@ class Wall extends AppModel
             array(
                 'fields' => array('lft', 'rght'),
                 'conditions' => array('id' => $messageId),
-                'contain' => array()
             )
         );
 
@@ -372,7 +369,6 @@ class Wall extends AppModel
                 'conditions' => array(
                     'id' => $messageId,
                 ),
-                'contain' => array()
             )
         );
         return $replyLftRght['Wall']['lft'] != ($replyLftRght['Wall']['rght'] - 1);
@@ -404,7 +400,6 @@ class Wall extends AppModel
                     'lft <=' => $replyLft,
                     'rght >=' => $replyRght
                 ),
-                'contain' => array()
             )
         );
 

--- a/app/tests/cases/models/sentence_not_translated_into.test.php
+++ b/app/tests/cases/models/sentence_not_translated_into.test.php
@@ -1,0 +1,102 @@
+<?php
+/* SentenceNotTranslatedInto Test cases generated on: 2016-02-08 17:31:23 : 1454952683*/
+App::import('Model', 'SentenceNotTranslatedInto');
+
+class SentenceNotTranslatedIntoTestCase extends CakeTestCase {
+    var $fixtures = array(
+        'app.contribution',
+        'app.group',
+        'app.favorites_user',
+        'app.sentence',
+        'app.sentence_annotation',
+        'app.sentence_comment',
+        'app.sentence_not_translated_into',
+        'app.sentences_list',
+        'app.sentences_sentences_list',
+        'app.language',
+        'app.link',
+        'app.reindex_flag',
+        'app.tag',
+        'app.tags_sentence',
+        'app.transcription',
+        'app.user',
+        'app.wall',
+        'app.wall_thread',
+    );
+
+    public function startTest() {
+        $this->SNTI =& ClassRegistry::init('SentenceNotTranslatedInto');
+        $this->Sentence =& ClassRegistry::init('Sentence');
+    }
+
+    public function endTest() {
+        unset($this->SNTI);
+        ClassRegistry::flush();
+    }
+
+    public function testPaginateAllSentences_LonelyAndWithTranslation() {
+        $expectedIds = array(7, 1);
+        $returnedIds = $this->_runPaginate('eng', 'none', false);
+        $this->assertEqual($expectedIds, $returnedIds);
+    }
+
+    public function testPaginateAllSentences_LonelyAndWithTranslation_Paginate() {
+        $expectedIds = array(7);
+        $returnedIds = $this->_runPaginate('eng', 'none', false, 1, 1);
+        $this->assertEqual($expectedIds, $returnedIds);
+
+        $expectedIds = array(1);
+        $returnedIds = $this->_runPaginate('eng', 'none', false, 2, 1);
+        $this->assertEqual($expectedIds, $returnedIds);
+    }
+
+    public function testPaginateAllSentences_LonelyAndWithTranslation_WithAudio() {
+        $this->Sentence->save(array('id' => 1, 'hasaudio' => 'from_users'));
+        $expectedIds = array(1);
+        $returnedIds = $this->_runPaginate('eng', 'none', true);
+        $this->assertEqual($expectedIds, $returnedIds);
+    }
+
+    public function testPaginateAllSentences_Lonely() {
+        $expectedIds = array(12, 8);
+        $returnedIds = $this->_runPaginate('fra', 'und', false);
+        $this->assertEqual($expectedIds, $returnedIds);
+    }
+
+    public function testPaginateAllSentences_Lonely_WithAudio() {
+        $this->Sentence->save(array('id' => 8, 'hasaudio' => 'from_users'));
+        $expectedIds = array(8);
+        $returnedIds = $this->_runPaginate('fra', 'und', true);
+        $this->assertEqual($expectedIds, $returnedIds);
+    }
+
+    public function testPaginateAllSentencesWithoutTranslation() {
+        $expectedIds = array(7);
+        $returnedIds = $this->_runPaginate('eng', 'und', false);
+        $this->assertEqual($expectedIds, $returnedIds);
+    }
+
+    public function testPaginateAllSentencesWithoutTranslation_WithAudio() {
+        $expectedIds = array();
+        $returnedIds = $this->_runPaginate('eng', 'und', true);
+        $this->assertEqual($expectedIds, $returnedIds);
+    }
+
+    public function _runPaginate($lang, $notTranslatedInto, $audioOnly, $page = 1, $limit = 10) {
+        $results = $this->SNTI->paginate(
+            array( /* conditions */
+                'source' => $lang,
+                'notTranslatedInto' => $notTranslatedInto,
+                'audioOnly' => $audioOnly,
+            ),
+            array('id'), /* fields */
+            'Sentence.id DESC', /* order */
+            $limit,      /* limit */
+            $page,       /* page */
+            1,           /* recursive */
+            array()      /* extra parameters to find() */
+        );
+        $ids = Set::extract($results, '{n}.Sentence.id');
+        return $ids;
+    }
+}

--- a/app/tests/cases/models/translation.test.php
+++ b/app/tests/cases/models/translation.test.php
@@ -80,37 +80,63 @@ class TranslationTestCase extends CakeTestCase {
         $this->assertEqual($expected, $result);
     }
 
-    function _assertFind($sentenceId, $langs, $expectedTranslationIds, $expectedIndirectTranslationIds) {
-        $result = $this->Translation->getTranslationsOf($sentenceId, $langs);
-        $returned = array(0 => array(), 1 => array());
+    function _assertFind($sentenceIdsAndTheirExpectedTranslationIds, $langs) {
+        $sentenceIds = array_keys($sentenceIdsAndTheirExpectedTranslationIds);
+        $result = $this->Translation->getTranslationsOf($sentenceIds, $langs);
+        $returned = array_fill_keys(
+            $sentenceIds,
+            array(0 => array(), 1 => array())
+        );
         foreach ($result as $rec) {
             $rec = $rec['Translation'];
-            $returned[$rec['type']][] = $rec['id'];
+            $sentenceId = $rec['sentence_id'];
+            $returned[$sentenceId][$rec['type']][] = $rec['id'];
         }
-        $expected = array(
-            $expectedTranslationIds,
-            $expectedIndirectTranslationIds,
-        );
-        $this->assertEqual($expected, $returned);
+        $this->assertEqual($sentenceIdsAndTheirExpectedTranslationIds, $returned);
     }
 
     function testFindCheckIds() {
-        $this->_assertFind(1, array(), array(2, 4, 3), array(5, 6));
+        $checkIf[1] = array(
+            0 => array(2, 4, 3), 1 => array(5, 6)
+        );
+        $this->_assertFind($checkIf, array());
+    }
+
+    function testFindCheckSeveralIds() {
+        $checkIf[1] = array(
+            array(2, 4, 3), array(5, 6)
+        );
+        $checkIf[2] = array(
+            array(5, 1, 4), array(6, 3)
+        );
+        $this->_assertFind($checkIf, array());
     }
 
     function testFindWithFilteredDirectTranslation() {
-        $this->_assertFind(1, array('cmn'), array(2), array());
+        $checkIf[1] = array(
+            array(2), array()
+        );
+        $this->_assertFind($checkIf, array('cmn'));
     }
 
     function testFindWithFilteredIndirectTranslation() {
-        $this->_assertFind(1, array('jpn'), array(), array(6));
+        $checkIf[1] = array(
+            array(), array(6)
+        );
+        $this->_assertFind($checkIf, array('jpn'));
     }
 
     function testFindWithFilteredMultipleLang() {
-        $this->_assertFind(1, array('spa', 'deu'), array(3), array(5));
+        $checkIf[1] = array(
+            array(3), array(5)
+        );
+        $this->_assertFind($checkIf, array('spa', 'deu'));
     }
 
     function testFindWithoutTranslation() {
-        $this->_assertFind(7, array(), array(), array());
+        $checkIf[7] = array(
+            array(), array()
+        );
+        $this->_assertFind($checkIf, array());
     }
 }

--- a/app/tests/cases/models/translation.test.php
+++ b/app/tests/cases/models/translation.test.php
@@ -35,7 +35,7 @@ class TranslationTestCase extends CakeTestCase {
         $this->Translation->unbindModel(
             array('hasMany' => array('Transcription'))
         );
-        $result = $this->Translation->find(5, array());
+        $result = $this->Translation->getTranslationsOf(5, array());
         $expected = array(
             'Translation' => array(
                 array(
@@ -79,7 +79,7 @@ class TranslationTestCase extends CakeTestCase {
     }
 
     function _assertFind($sentenceId, $langs, $expectedTranslationIds, $expectedIndirectTranslationIds) {
-        $result = $this->Translation->find($sentenceId, $langs);
+        $result = $this->Translation->getTranslationsOf($sentenceId, $langs);
         $result = Set::classicExtract($result, '{}.{n}.Translation.id');
         $expected = array(
             'Translation' => $expectedTranslationIds,

--- a/app/tests/cases/models/translation.test.php
+++ b/app/tests/cases/models/translation.test.php
@@ -37,7 +37,6 @@ class TranslationTestCase extends CakeTestCase {
         );
         $result = $this->Translation->getTranslationsOf(5, array());
         $expected = array(
-            'Translation' => array(
                 array(
                     'Translation' => array(
                         'id' => "2",
@@ -47,10 +46,10 @@ class TranslationTestCase extends CakeTestCase {
                         'hasaudio' => "no",
                         'correctness' => "0",
                         'script' => 'Hans',
+                        'type' => '0',
+                        'sentence_id' => '5',
                     ),
                 ),
-            ),
-            'IndirectTranslation' => array(
                 array(
                     'Translation' => array(
                         'id' => "1",
@@ -60,6 +59,8 @@ class TranslationTestCase extends CakeTestCase {
                         'hasaudio' => "no",
                         'correctness' => "0",
                         'script' => null,
+                        'type' => '1',
+                        'sentence_id' => '5',
                     ),
                 ),
                 array(
@@ -71,21 +72,26 @@ class TranslationTestCase extends CakeTestCase {
                         'hasaudio' => "no",
                         'correctness' => "0",
                         'script' => null,
+                        'type' => '1',
+                        'sentence_id' => '5',
                     ),
                 ),
-            ),
         );
         $this->assertEqual($expected, $result);
     }
 
     function _assertFind($sentenceId, $langs, $expectedTranslationIds, $expectedIndirectTranslationIds) {
         $result = $this->Translation->getTranslationsOf($sentenceId, $langs);
-        $result = Set::classicExtract($result, '{}.{n}.Translation.id');
+        $returned = array(0 => array(), 1 => array());
+        foreach ($result as $rec) {
+            $rec = $rec['Translation'];
+            $returned[$rec['type']][] = $rec['id'];
+        }
         $expected = array(
-            'Translation' => $expectedTranslationIds,
-            'IndirectTranslation' => $expectedIndirectTranslationIds,
+            $expectedTranslationIds,
+            $expectedIndirectTranslationIds,
         );
-        $this->assertEqual($expected, $result);
+        $this->assertEqual($expected, $returned);
     }
 
     function testFindCheckIds() {

--- a/app/views/activities/translate_sentences_of.ctp
+++ b/app/views/activities/translate_sentences_of.ctp
@@ -70,9 +70,8 @@ $this->set('title_for_layout', $pages->formatTitle($title));
             $sentences->displaySentencesGroup(
                 $sentence['Sentence'],
                 $sentence['Transcription'],
-                $sentence['Sentence']['Translation'],
-                $sentence['User'],
-                $sentence['Sentence']['IndirectTranslation']
+                $sentence['Translation'],
+                $sentence['User']
             );
         }
         

--- a/app/views/activities/translate_sentences_of.ctp
+++ b/app/views/activities/translate_sentences_of.ctp
@@ -68,11 +68,11 @@ $this->set('title_for_layout', $pages->formatTitle($title));
         
         foreach ($results as $sentence) {
             $sentences->displaySentencesGroup(
-                $sentence['Sentence'], 
+                $sentence['Sentence'],
                 $sentence['Transcription'],
-                $sentence['Translations'], 
+                $sentence['Sentence']['Translation'],
                 $sentence['User'],
-                $sentence['IndirectTranslations']
+                $sentence['Sentence']['IndirectTranslation']
             );
         }
         

--- a/app/views/helpers/lists.php
+++ b/app/views/helpers/lists.php
@@ -369,7 +369,7 @@ class ListsHelper extends AppHelper
         $sentence,
         $canCurrentUserEdit = false
     ) {
-        $sentenceId = $sentence['Sentence']['id'];
+        $sentenceId = $sentence['id'];
         if (empty($sentenceId)) {
             // In case the sentence has been deleted, we don't want to display
             // it in the list.
@@ -390,11 +390,11 @@ class ListsHelper extends AppHelper
             // Sentences group
             $withAudio = true;
             $this->Sentences->displaySentencesGroup(
-                $sentence['Sentence'],
+                $sentence,
                 $sentence['Transcription'],
-                $sentence['Translations'],
+                $sentence['Translation'],
                 $sentence['User'],
-                $sentence['IndirectTranslations'],
+                $sentence['IndirectTranslation'],
                 array('withAudio' => false)
             );
             ?>

--- a/app/views/helpers/lists.php
+++ b/app/views/helpers/lists.php
@@ -394,7 +394,6 @@ class ListsHelper extends AppHelper
                 $sentence['Transcription'],
                 $sentence['Translation'],
                 $sentence['User'],
-                $sentence['IndirectTranslation'],
                 array('withAudio' => false)
             );
             ?>

--- a/app/views/helpers/tags.php
+++ b/app/views/helpers/tags.php
@@ -217,9 +217,8 @@ class TagsHelper extends AppHelper
      * @param array $sentence             Sentence data.
      * @param array $transcriptions       Sentence transcriptions.
      * @param array $sentenceOwner        Array with Sentence owner info.
-     * @param array $translations         Array with translations of this sentence.
-     * @param array $indirectTranslations Array with Ind. translations of this
-     *                                    sentence.
+     * @param array $translations         Array with translations of this sentence
+     *                                    (direct and indirect).
      * @param bool  $canCurrentUserRemove 'true' if user can remove tag from this
      *                                    sentence..
      * @param int   $tagId                Id of the tag.
@@ -231,7 +230,6 @@ class TagsHelper extends AppHelper
         $transcriptions,
         $sentenceOwner,
         $translations = array(),
-        $indirectTranslations = array(),
         $canCurrentUserRemove = false,
         $tagId = null
     ) {
@@ -255,7 +253,6 @@ class TagsHelper extends AppHelper
                 $transcriptions,
                 $translations,
                 $sentenceOwner,
-                $indirectTranslations,
                 array('withAudio' => true)
             );
             ?>

--- a/app/views/pages/index.ctp
+++ b/app/views/pages/index.ctp
@@ -76,14 +76,14 @@ if (!$isLogged) {
         <?php
         $sentence = $random['Sentence'];
         $transcrs = $random['Transcription'];
+        $translations = $random['Translation'];
         $sentenceOwner = $random['User'];
 
         $sentences->displaySentencesGroup(
             $sentence, 
             $transcrs,
             $translations, 
-            $sentenceOwner,
-            $indirectTranslations
+            $sentenceOwner
         );
         ?>
         </div>

--- a/app/views/s/s.ctp
+++ b/app/views/s/s.ctp
@@ -35,7 +35,7 @@ if (isset($sentence)) {
     // display sentence and translations
     $sentences->displaySGroup(
         $sentence['Sentence'],
-        $translations
+        $sentence['Translation']
     );
     
     ?>

--- a/app/views/sentences/random.ctp
+++ b/app/views/sentences/random.ctp
@@ -31,12 +31,12 @@ $sentences->javascriptForAJAXSentencesGroup();
 $sentence = $random['Sentence'];
 $transcription = $random['Transcription'];
 $sentenceOwner = $random['User'];
+$translations = $random['Translation'];
 
 $sentences->displaySentencesGroup(
     $sentence, 
     $transcription,
     $translations, 
-    $sentenceOwner,
-    $indirectTranslations
+    $sentenceOwner
 );
 ?>

--- a/app/views/sentences/search.ctp
+++ b/app/views/sentences/search.ctp
@@ -111,9 +111,8 @@ if ($search_disabled) {
         $sentences->displaySentencesGroup(
             $sentence['Sentence'],
             $sentence['Transcription'],
-            $sentence['Sentence']['Translation'],
+            $sentence['Translation'],
             $sentence['User'],
-            $sentence['Sentence']['IndirectTranslation'],
             array('langFilter' => $to)
         );
     }

--- a/app/views/sentences/search.ctp
+++ b/app/views/sentences/search.ctp
@@ -111,9 +111,9 @@ if ($search_disabled) {
         $sentences->displaySentencesGroup(
             $sentence['Sentence'],
             $sentence['Transcription'],
-            $sentence['Translations'],
+            $sentence['Sentence']['Translation'],
             $sentence['User'],
-            $sentence['IndirectTranslations'],
+            $sentence['Sentence']['IndirectTranslation'],
             array('langFilter' => $to)
         );
     }

--- a/app/views/sentences/several_random_sentences.ctp
+++ b/app/views/sentences/several_random_sentences.ctp
@@ -99,9 +99,8 @@ $this->set('title_for_layout', $pages->formatTitle(__('Random sentences', true))
             $sentences->displaySentencesGroup(
                 $sentence['Sentence'],
                 $sentence['Transcription'],
-                $sentence['Sentence']['Translation'],
-                $sentence['User'],
-                $sentence['Sentence']['IndirectTranslation']
+                $sentence['Translation'],
+                $sentence['User']
             );
         }
         ?>

--- a/app/views/sentences/several_random_sentences.ctp
+++ b/app/views/sentences/several_random_sentences.ctp
@@ -99,9 +99,9 @@ $this->set('title_for_layout', $pages->formatTitle(__('Random sentences', true))
             $sentences->displaySentencesGroup(
                 $sentence['Sentence'],
                 $sentence['Transcription'],
-                $sentence['Translations'],
+                $sentence['Sentence']['Translation'],
                 $sentence['User'],
-                $sentence['IndirectTranslations']
+                $sentence['Sentence']['IndirectTranslation']
             );
         }
         ?>

--- a/app/views/sentences/show.ctp
+++ b/app/views/sentences/show.ctp
@@ -165,9 +165,8 @@ $navigation->displaySentenceNavigation(
             $sentences->displaySentencesGroup(
                 $sentence['Sentence'],
                 $sentence['Transcription'],
-                $translations,
-                $sentence['User'],
-                $indirectTranslations
+                $sentence['Translation'],
+                $sentence['User']
             );
             
         } else {

--- a/app/views/sentences/show_all_in.ctp
+++ b/app/views/sentences/show_all_in.ctp
@@ -68,12 +68,15 @@ $this->set('title_for_layout', $pages->formatTitle($title));
             $filterAudioOnly,
         );
         $pagination->display($paginationUrl);
-        
+
         foreach ($results as $sentence) {
+            $translations = isset($sentence['Translation']) ?
+                            $sentence['Translation'] :
+                            array();
             $sentences->displaySentencesGroup(
                 $sentence['Sentence'], 
                 $sentence['Transcription'],
-                $sentence['Translation'],
+                $translations,
                 $sentence['User'],
                 array('langFilter' => $translationLang)
             );

--- a/app/views/sentences/show_all_in.ctp
+++ b/app/views/sentences/show_all_in.ctp
@@ -73,9 +73,8 @@ $this->set('title_for_layout', $pages->formatTitle($title));
             $sentences->displaySentencesGroup(
                 $sentence['Sentence'], 
                 $sentence['Transcription'],
-                $sentence['Sentence']['Translation'],
+                $sentence['Translation'],
                 $sentence['User'],
-                $sentence['Sentence']['IndirectTranslation'],
                 array('langFilter' => $translationLang)
             );
         }

--- a/app/views/sentences/show_all_in.ctp
+++ b/app/views/sentences/show_all_in.ctp
@@ -73,9 +73,9 @@ $this->set('title_for_layout', $pages->formatTitle($title));
             $sentences->displaySentencesGroup(
                 $sentence['Sentence'], 
                 $sentence['Transcription'],
-                $sentence['Translations'], 
+                $sentence['Sentence']['Translation'],
                 $sentence['User'],
-                $sentence['IndirectTranslations'],
+                $sentence['Sentence']['IndirectTranslation'],
                 array('langFilter' => $translationLang)
             );
         }

--- a/app/views/sentences/translations_group.ctp
+++ b/app/views/sentences/translations_group.ctp
@@ -28,7 +28,6 @@ if (!$saved) {
 $sentences->displayTranslations(
     $sentenceId,
     $translations,
-    $indirectTranslations,
     true,
     $langFilter
 );

--- a/app/views/sentences_lists/show.ctp
+++ b/app/views/sentences_lists/show.ctp
@@ -147,7 +147,7 @@ $this->set('title_for_layout', $pages->formatTitle($listName));
          data-list-id="<?php echo $listId; ?>">
     <?php
     foreach ($sentencesInList as $sentence) {
-        $lists->displaySentence($sentence, $canRemoveSentence);
+        $lists->displaySentence($sentence['Sentence'], $canRemoveSentence);
     }
     ?>
     </div>

--- a/app/views/sinograms/load_example_sentence.ctp
+++ b/app/views/sinograms/load_example_sentence.ctp
@@ -52,8 +52,7 @@ if ($sentenceFound == false) {
             $sentence,
             $transcrs,
             $translations,
-            $sentenceOwner,
-            $indirectTranslations
+            $sentenceOwner
         );
         ?>
     </div>

--- a/app/views/tags/show_sentences_with_tag.ctp
+++ b/app/views/tags/show_sentences_with_tag.ctp
@@ -67,7 +67,6 @@ if ($tagExists) {
                         $sentence['Transcription'],
                         $sentence['User'],
                         $sentence['Translation'],
-                        $sentence['IndirectTranslation'],
                         $canUserRemove,
                         $tagId
                     );

--- a/app/views/tags/show_sentences_with_tag.ctp
+++ b/app/views/tags/show_sentences_with_tag.ctp
@@ -61,12 +61,13 @@ if ($tagExists) {
                     $canUserRemove = CurrentUser::canRemoveTagFromSentence(
                         $taggerIds[$i]
                     );
+                    $sentence = $sentence['Sentence'];
                     $tags->displaySentence(
-                        $sentence['Sentence'],
+                        $sentence,
                         $sentence['Transcription'],
                         $sentence['User'],
-                        $sentence['Translations'],
-                        $sentence['IndirectTranslations'],
+                        $sentence['Translation'],
+                        $sentence['IndirectTranslation'],
                         $canUserRemove,
                         $tagId
                     );

--- a/app/webroot/css/sentences/search.css
+++ b/app/webroot/css/sentences/search.css
@@ -24,6 +24,10 @@
     margin: 40px 0;
 }
 
+.match {
+    background-color: #FFFF90;
+}
+
 /*
  * Search warning
  */


### PR DESCRIPTION
This PR adds keyword highlighting to search results, along with some refactoring.

The previous way of displaying a list of sentences and their translations was:
```php
// from a controller
$ids = $this->Sentence->getSomeSentenceIds($someConditions);
$results = $this->CommonSentence->getAllNeededForSentences($ids);
```
This resulted into `1 + number_of_sentences * 6` SQL requests: one to get the ids, and 6 to get sentence, favorites, users, lists, transcriptions and transcriptions authors data for each sentence. And it wasn’t very CakePHPish.

This PR makes it this way:
```php
// from a controller
$results = $this->Sentence->find('all', array(
    'conditions' => $someConditions,
    'contain' => array('Translation', 'User', 'SentencesList', ...)
));
```

Which results into 1 + 6 SQL requests, regardless of the number of sentences. CakePHP runs one request on each table and joins everything. In other words, the Translation model can now be added to the `contain` array just like other models.

Direct and indirect translations are no more returned separated into `Translations` and `IndirectTranslations` subarrays. Instead, all the translations are returned grouped, and each translation have an additional `type` field (0 or 1) that says whether it’s direct or indirect. Separating direct and indirect translations is done at the very end, in the view.

Filtering the returned translations by language isn’t very straightforward, but… It works that way:
```php
$this->Sentence->linkTranslationModel(array(
    'Translation.lang' => $lang
));
$results = $this->Sentence->find('all', ...);
```
You need to change the conditions under which the Translation model links with the Sentence one beforehand. This is because linking is performed with a precomputed SQL query that is used as-is by `find()`.

I also converted some of the raw SQL queries of `sentence_not_translated_into.php` to proper `find()` calls in the process.

Other than that, I replaced all the `contain => array()` or `'recursive' => -1` parameters of `find()` calls by a single `public $recursive = -1;` in `app_model.php`. This way, `find()` just returns no attached model unless explicitly specified in the `contain` parameter.

Everything seems to be working fine, but since this PR messes a lot with the core code, please test it thoroughly.