### PR TITLE
New homepage, layout, menu and footer

### DIFF
--- a/app/controllers/pages_controller.php
+++ b/app/controllers/pages_controller.php
@@ -91,6 +91,13 @@ class PagesController extends AppController
         // Random sentence part
         $this->_random_sentence();
 
+        // Stats
+        $stats = ClassRegistry::init('Language')->getSentencesStatistics(5);
+        $numSentences = ClassRegistry::init('Sentence')->getTotalNumberOfSentences();
+
+        $this->set('stats', $stats);
+        $this->set('numSentences', $numSentences);
+
         if ($isLogged) {
             $this->_homepageForMembers();
         } else {
@@ -100,6 +107,9 @@ class PagesController extends AppController
 
 
     private function _homepageForGuests() {
+        $contribToday = ClassRegistry::init('Contribution')->getTodayContributions();
+
+        $this->set('contribToday', $contribToday);
         $this->render('index_for_guests');
     }
 

--- a/app/controllers/pages_controller.php
+++ b/app/controllers/pages_controller.php
@@ -83,12 +83,29 @@ class PagesController extends AppController
      */
     public function index()
     {
-        $this->helpers[] = 'Wall';
         $this->helpers[] = 'Sentences';
-        $this->helpers[] = 'Messages';
 
         $userId = $this->Auth->user('id');
         $isLogged = !empty($userId);
+
+        // Random sentence part
+        $this->_random_sentence();
+
+        if ($isLogged) {
+            $this->_homepageForMembers();
+        } else {
+            $this->_homepageForGuests();
+        }
+    }
+
+
+    private function _homepageForGuests() {
+        $this->render('index_for_guests');
+    }
+
+    private function _homepageForMembers() {
+        $this->helpers[] = 'Wall';
+        $this->helpers[] = 'Messages';
 
         /*latest comments part */
         $this->loadModel('SentenceComment');
@@ -105,11 +122,7 @@ class PagesController extends AppController
         $this->loadModel('Wall');
         $latestMessages = $this->Wall->getLastMessages(5);
 
-        $this->set('isLogged', $isLogged);
         $this->set('latestMessages', $latestMessages);
-
-        // Random sentence part
-        $this->_random_sentence();
     }
 
     /**

--- a/app/locale/default.pot
+++ b/app/locale/default.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-07 21:29+0000\n"
+"POT-Creation-Date: 2016-03-09 15:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1126,7 +1126,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/sentences_statistics.ctp#L58
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L99
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L113
 msgid "show all languages"
 msgstr ""
 
@@ -1542,31 +1542,31 @@ msgstr ""
 msgid "Add a language"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L492
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L494
 msgid "Unspecified"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L493
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L495
 msgid "0: Almost no knowledge"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L494
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L496
 msgid "1: Beginner"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L495
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L497
 msgid "2: Intermediate"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L496
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L498
 msgid "3: Advanced"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L497
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L499
 msgid "4: Fluent"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L498
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L500
 msgid "5: Native level"
 msgstr ""
 
@@ -2606,6 +2606,7 @@ msgid "However it is also possible to let any member in Tatoeba add and remove s
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index.ctp#L28
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L30
 msgid "Tatoeba: Collection of sentences and translations"
 msgstr ""
 
@@ -2619,38 +2620,46 @@ msgstr ""
 msgid "Latest comments"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L34
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L36
 msgid "Want to help?"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L36
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L38
 msgid "We are collecting sentences and their translations. You can help us by translating or adding new sentences."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L40
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L42
 msgid "Join the community"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L54
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L56
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/user/profile.ctp#L72
 msgid "Stats"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L59
-msgid "{number} contributions today"
-msgstr ""
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L61
+msgid "{number} contribution today"
+msgid_plural "{number} contributions today"
+msgstr[0] ""
+msgstr[1] ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L63
-msgid "{number} supported languages"
-msgstr ""
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L68
+msgid "{number} supported language"
+msgid_plural "{number} supported languages"
+msgstr[0] ""
+msgstr[1] ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L67
-msgid "{number} sentences"
-msgstr ""
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L75
+msgid "{number} sentence"
+msgid_plural "{number} sentences"
+msgstr[0] ""
+msgstr[1] ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L86
-msgid "{number} sentences in {lang}"
-msgstr ""
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L97
+msgid "{number} sentence in {lang}"
+msgid_plural "{number} sentences in {lang}"
+msgstr[0] ""
+msgstr[1] ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/terms_of_use.ctp#L32
 msgid "Table of contents"

--- a/app/locale/default.pot
+++ b/app/locale/default.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-09 15:19+0000\n"
+"POT-Creation-Date: 2016-03-09 15:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1158,8 +1158,10 @@ msgstr ""
 msgid "Tip: <em>=word</em> will search for an exact match on <em>word</em>"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L151
-msgid "More"
+#. @translators: links to a page with tips to perform
+#. searches, like search operators
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L153
+msgid "More tips"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/space.ctp#L43

--- a/app/locale/default.pot
+++ b/app/locale/default.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-27 20:23+0000\n"
+"POT-Creation-Date: 2016-03-07 20:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -132,61 +132,61 @@ msgstr ""
 msgid "We could not save your changes."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L273
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L282
 msgid "You cannot delete this sentence."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L286
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L295
 msgid "The sentence #{id} has been deleted."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L294
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L303
 msgid "Error: the sentence #{id} could not be deleted."
 msgstr ""
 
 #. @translators: This string will be preceded by “Warning: the
 #. following criteria have been ignored:”
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L544
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L553
 msgid "“owned by a self-identified native”, because “sentence language” is set to “any”"
 msgstr ""
 
 #. @translators: This string will be preceded by
 #. “Warning: the following criteria have been
 #. ignored:”
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L615
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L624
 msgid "“translation is orphan”, because “translation owner” is set to a username"
 msgstr ""
 
 #. @translators: This string will be preceded by
 #. “Warning: the following criteria have been ignored:”
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L624
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L633
 msgid "“translation owner”, because “{username}” is not a valid username"
 msgstr ""
 
 #. @translators: This string will be preceded by
 #. “Warning: the following criteria have been
 #. ignored:”
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L665
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L674
 msgid "“sentence is orphan”, because “sentence owner” is set to a username"
 msgstr ""
 
 #. @translators: This string will be preceded by “Warning:
 #. the following criteria have been ignored:”
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L674
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L683
 msgid "“sentence owner”, because “{username}” is not a valid username"
 msgstr ""
 
 #. @translators: This string will be preceded by
 #. “Warning: the following criteria have been
 #. ignored:”
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L710
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L719
 msgid "“tagged as {tagName}”, because it's an invalid tag name"
 msgstr ""
 
 #. @translators: This string will be preceded by
 #. “Warning: the following criteria have been
 #. ignored:”
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L748
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/controllers/sentences_controller.php#L757
 msgid "“owned by a self-identified native”, because the criterion “owned by: {username}” is set whereas he or she is not a self-identified native in the language you're searching into"
 msgstr ""
 
@@ -438,7 +438,7 @@ msgid "If you see another username appear after adopting a sentence, it means th
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/activities/improve_sentences.ctp#L28
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L105
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L99
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contribute.ctp#L92
 msgid "Improve sentences"
 msgstr ""
@@ -505,7 +505,7 @@ msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/activities/translate_sentences.ctp#L27
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/activities/translate_sentences.ctp#L79
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L96
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L90
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contribute.ctp#L83
 msgid "Translate sentences"
 msgstr ""
@@ -561,12 +561,12 @@ msgid "Display random sentences"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/activities/translate_sentences.ctp#L147
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L59
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L58
 msgid "Quantity"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/activities/translate_sentences.ctp#L161
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L72
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L71
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/stats/native_speakers.ctp#L65
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/stats/sentences_by_language.ctp#L56
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/stats/users_languages.ctp#L36
@@ -574,7 +574,7 @@ msgid "Language"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/activities/translate_sentences.ctp#L177
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L86
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L85
 msgid "show random sentences"
 msgstr ""
 
@@ -642,7 +642,7 @@ msgstr ""
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/contributions/index.ctp#L38
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/contributions/latest.ctp#L38
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/contributions/latest.ctp#L73
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index.ctp#L95
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index.ctp#L89
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/users/show.ctp#L41
 msgid "Latest contributions"
 msgstr ""
@@ -887,45 +887,86 @@ msgid "Your new password: "
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L36
-msgid "One visitor online"
-msgid_plural "{n}&nbsp;visitors online"
-msgstr[0] ""
-msgstr[1] ""
-
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L42
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/terms_of_use.ctp#L28
-msgid "Terms of use"
+msgid "Need some help?"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L53
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L41
+msgid "Quick Start Guide"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L49
+msgid "Tatoeba Wiki"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L57
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contact.ctp#L42
+msgid "FAQ"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L65
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L37
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/help.ctp#L28
+msgid "Help"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L77
+msgid "Developers"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L82
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/downloads.ctp#L84
+msgid "Downloads"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L93
+msgid "GitHub"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L102
+msgid "Google group"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L111
+msgid "About"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L116
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/about.ctp#L31
+msgid "What is Tatoeba?"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L127
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contact.ctp#L38
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contact.ctp#L68
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/help.ctp#L52
 msgid "Contact us"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L64
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L172
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/donate.ctp#L28
-msgid "Donate"
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L138
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/terms_of_use.ctp#L28
+msgid "Terms of use"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L75
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L149
 msgid "Blog"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L84
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L158
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contact.ctp#L59
 msgid "Twitter"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L93
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L167
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contact.ctp#L61
 msgid "Facebook"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L102
-msgid "GitHub"
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L185
+msgid "Our sentences and translations can be used under the Creative Commons Attribution 2.0 license (CC-BY 2.0)."
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L193
+msgid "If you love this content, please consider a <a href={}>donation</a>."
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/header.ctp#L30
@@ -942,7 +983,6 @@ msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/join_us.ctp#L41
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/login.ctp#L44
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L68
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contribute.ctp#L37
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contribute.ctp#L41
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/users/login.ctp#L98
@@ -953,7 +993,6 @@ msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/login.ctp#L59
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/login.ctp#L109
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L82
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/users/login.ctp#L38
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/users/login.ctp#L77
 msgid "Log in"
@@ -1028,7 +1067,7 @@ msgid "Folders"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/random_sentence_header.ctp#L39
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L61
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L55
 msgid "Random sentence"
 msgstr ""
 
@@ -1037,18 +1076,13 @@ msgid "show another "
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/random_sentence_header.ctp#L70
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index.ctp#L98
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index.ctp#L117
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index.ctp#L92
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index.ctp#L111
 msgid "show more..."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L37
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L156
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/help.ctp#L28
-msgid "Help"
-msgstr ""
-
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L44
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L134
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/advanced_search.ctp#L20
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/search.ctp#L31
 msgctxt "title"
@@ -1056,14 +1090,15 @@ msgid "Advanced search"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L70
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L546
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L564
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L549
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L567
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sinograms/index.ctp#L181
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/tags/view_all.ctp#L43
 msgid "Search"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L76
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L103
 msgid "Clear search"
 msgstr ""
 
@@ -1083,14 +1118,15 @@ msgstr ""
 msgid "No results found for: {search}"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/sentences_statistics.ctp#L34
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/sentences_statistics.ctp#L32
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/stats/sentences_by_language.ctp#L46
 msgid "One sentence"
 msgid_plural "{n}&nbsp;sentences"
 msgstr[0] ""
 msgstr[1] ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/sentences_statistics.ctp#L60
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/sentences_statistics.ctp#L58
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L99
 msgid "show all languages"
 msgstr ""
 
@@ -1102,20 +1138,28 @@ msgstr ""
 msgid "Please <a href=\"{}\">click here</a> to log in again."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L32
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L34
 msgid "Tatoeba is a collection of sentences and translations."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L35
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L39
 msgid "It's collaborative, open, free and even addictive."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L43
-msgid "How it works"
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L91
+msgid "Search sentences in {langFrom} translated into {langTo} containing:"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L54
-msgid "About us"
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L114
+msgid "Enter a word or a phrase"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L146
+msgid "Tip: <em>=word</em> will search for an exact match on <em>word</em>"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L151
+msgid "More"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/space.ctp#L43
@@ -1137,7 +1181,7 @@ msgid "My collection"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/space.ctp#L104
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L603
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L606
 msgid "My lists"
 msgstr ""
 
@@ -1173,104 +1217,72 @@ msgid "Log out"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L49
-msgid "Home"
-msgstr ""
-
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L55
 msgid "Browse"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L66
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L60
 msgid "Browse by language"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L72
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L66
 msgid "Browse by list"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L76
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L70
 msgid "Browse by tag"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L80
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L74
 msgid "Browse audio"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L86
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L80
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contribute.ctp#L71
 msgid "Contribute"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L92
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L86
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contribute.ctp#L79
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/add.ctp#L28
 msgid "Add sentences"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L100
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L94
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contribute.ctp#L87
 msgid "Adopt sentences"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L109
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L103
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contribute.ctp#L96
 msgid "Discuss sentences"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L115
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/users/all.ctp#L38
-msgid "Members"
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L107
+msgid "Show activity timeline"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L121
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L113
+msgid "Community"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L119
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/wall/index.ctp#L38
+msgid "Wall"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L123
 msgid "List of all members"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L125
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L127
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/stats/users_languages.ctp#L27
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/stats/users_languages.ctp#L32
 msgid "Languages of members"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L129
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L131
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/stats/native_speakers.ctp#L28
 msgid "Native speakers"
-msgstr ""
-
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L135
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/wall/index.ctp#L38
-msgid "Wall"
-msgstr ""
-
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L141
-msgid "More"
-msgstr ""
-
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L147
-msgid "Quick Start Guide"
-msgstr ""
-
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L150
-msgid "Tatoeba Wiki"
-msgstr ""
-
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L153
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contact.ctp#L42
-msgid "FAQ"
-msgstr ""
-
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L160
-msgid "Show activity timeline"
-msgstr ""
-
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L164
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/downloads.ctp#L84
-msgid "Downloads"
-msgstr ""
-
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/top_menu.ctp#L168
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/tools/index.ctp#L32
-msgid "Tools"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/users_menu.ctp#L62
@@ -1282,8 +1294,8 @@ msgid "Transcriptions"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/users_menu.ctp#L88
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L489
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L577
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L492
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L580
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/downloads.ctp#L251
 msgid "Lists"
 msgstr ""
@@ -1293,7 +1305,7 @@ msgid "Favorites"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/users_menu.ctp#L114
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L196
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L197
 msgid "Comments"
 msgstr ""
 
@@ -1307,7 +1319,7 @@ msgid "Wall messages"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/users_menu.ctp#L153
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L132
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L133
 msgid "Logs"
 msgstr ""
 
@@ -1617,19 +1629,19 @@ msgstr ""
 msgid "Delete this list"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L413
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L416
 msgid "Remove sentence {number} from list"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L422
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L425
 msgid "Remove from list"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L448
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L451
 msgid "Add a sentence to this list : "
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L453
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L456
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/menu.php#L372
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/navigation.php#L89
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/sentences.php#L717
@@ -1639,36 +1651,36 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L466
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L469
 msgid "NOTE : You can also add existing sentences with this icon {addToListButton} (while <a href=\"{url}\">browsing</a> for instance)."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L518
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L521
 msgid "Create a new list"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L531
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L534
 msgctxt "list"
 msgid "Name"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L534
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L537
 msgid "create"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L582
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L585
 msgid "All lists"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L592
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L595
 msgid "Collaborative lists"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/logs.php#L384
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/s/s.ctp#L50
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentence_annotations/show.ctp#L40
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L159
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L175
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L160
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L176
 msgid "Sentence #{number}"
 msgstr ""
 
@@ -2050,44 +2062,44 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L183
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L185
 msgid "Show alternative script"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L185
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L187
 msgid "Show transcription"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L227
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L229
 msgid "Edit alternative script"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L229
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L231
 msgid "Edit transcription"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L235
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L237
 msgid "You cannot edit this script."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L237
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L239
 msgid "You cannot edit this transcription."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L258
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L260
 msgid "This alternative script may contain errors because it has been generated by a piece of software that is not perfect."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L265
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L267
 msgid "This transcription may contain errors because it has been generated by a piece of software that is not perfect."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L279
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L281
 msgctxt "alternative script"
 msgid "Click to mark it as reviewed."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L285
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/transcriptions.php#L287
 msgctxt "transcription"
 msgid "Click to mark it as reviewed."
 msgstr ""
@@ -2124,12 +2136,8 @@ msgstr ""
 msgid "Warning: this website is for testing purposes. Everything you submit will be definitely lost."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/layouts/default.ctp#L104
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/layouts/default.ctp#L102
 msgid "No language matches"
-msgstr ""
-
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/about.ctp#L31
-msgid "What is Tatoeba?"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contact.ctp#L48
@@ -2206,6 +2214,10 @@ msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/contribute.ctp#L158
 msgid "And finally, you can <strong>join the team</strong>. You can help us code new features, improve usability, debug, optimize, keep the site secure, and more."
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/donate.ctp#L28
+msgid "Donate"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/donate.ctp#L33
@@ -2597,14 +2609,47 @@ msgstr ""
 msgid "Tatoeba: Collection of sentences and translations"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index.ctp#L52
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index.ctp#L45
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/wall/index.ctp#L72
 msgid "Latest messages"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index.ctp#L114
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index.ctp#L108
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/users/show.ctp#L95
 msgid "Latest comments"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L34
+msgid "Want to help?"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L36
+msgid "We are collecting sentences and their translations. You can help us by translating or adding new sentences."
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L40
+msgid "Join the community"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L54
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/user/profile.ctp#L72
+msgid "Stats"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L59
+msgid "{number} contributions today"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L63
+msgid "{number} supported languages"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L67
+msgid "{number} sentences"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/index_for_guests.ctp#L86
+msgid "{number} sentences in {lang}"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/terms_of_use.ctp#L32
@@ -2725,7 +2770,7 @@ msgid "Click the top sentence to go to tatoeba.org to translate it or leave a co
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/s/s.ctp#L53
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L182
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L183
 msgid "There is no sentence with id {number}"
 msgstr ""
 
@@ -2813,6 +2858,10 @@ msgstr ""
 msgid "{user} does not have any sentence"
 msgstr ""
 
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/random.ctp#L31
+msgid "An error occurred while fetching the random sentence. If this persists, please <a href=\"{}\">let us know</a>."
+msgstr ""
+
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/search.ctp#L29
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/search.ctp#L87
 msgid "Search disabled"
@@ -2869,48 +2918,61 @@ msgid "Search: {keywords}"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L28
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L96
 msgid "Random sentences"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L33
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L32
 msgid "For serial translators"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L37
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L36
 msgid "Translating sentences one by one is too slow for you? You want to increase your rank in Tatoeba, or the rank of your language, at the speed of light? So this is for you!"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L44
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L43
 msgid "Just keep in mind that our server is not as fast as you ;-)"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L39
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L106
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L245
+msgid "The random sentence feature is currently disabled, please try again later."
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/several_random_sentences.ctp#L108
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L247
+msgid "An error occurred while fetching random sentences. If this persists, please <a href=\"{}\">let us know</a>."
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L40
 msgid "{language} example sentence: {sentence}"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L47
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L48
 msgid "Browse translated example sentences. This page shows translations and information about the sentence: {sentenceText}"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L58
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L59
 msgid "Sentence does not exist: "
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L76
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L77
 msgid "Reviewed by"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L146
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L147
 msgid "There is no log for this sentence"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L220
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L221
 msgid "There are no comments for now."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L225
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L226
 msgid "Sentence deleted"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show.ctp#L243
+msgid "Random Sentence"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/show_all_in.ctp#L30
@@ -2925,7 +2987,7 @@ msgstr ""
 msgid "Sentences in {language} with audio"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences_lists/add_new_sentence_to_list.ctp#L46
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences_lists/add_new_sentence_to_list.ctp#L45
 msgid "Problem while saving"
 msgstr ""
 
@@ -3278,6 +3340,10 @@ msgstr ""
 msgid "Useful tools"
 msgstr ""
 
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/tools/index.ctp#L32
+msgid "Tools"
+msgstr ""
+
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/tools/index.ctp#L38
 msgid "Furigana autogeneration"
 msgstr ""
@@ -3442,10 +3508,6 @@ msgstr ""
 msgid "Details (optional). For instance, which dialect or from which country."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/user/profile.ctp#L72
-msgid "Stats"
-msgstr ""
-
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/user/profile.ctp#L74
 msgid "Comments posted"
 msgstr ""
@@ -3583,6 +3645,10 @@ msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/user/settings.ctp#L220
 msgid "New password again"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/users/all.ctp#L38
+msgid "Members"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/users/all.ctp#L43

--- a/app/locale/default.pot
+++ b/app/locale/default.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-07 20:22+0000\n"
+"POT-Creation-Date: 2016-03-07 21:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -904,7 +904,7 @@ msgid "FAQ"
 msgstr ""
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/foot.ctp#L65
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L37
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L57
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/pages/help.ctp#L28
 msgid "Help"
 msgstr ""
@@ -1081,15 +1081,7 @@ msgstr ""
 msgid "show more..."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L44
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L134
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/advanced_search.ctp#L20
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/search.ctp#L31
-msgctxt "title"
-msgid "Advanced search"
-msgstr ""
-
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L70
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L52
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L549
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/lists.php#L567
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sinograms/index.ctp#L181
@@ -1097,16 +1089,24 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L76
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L64
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L134
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/advanced_search.ctp#L20
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/sentences/search.ctp#L31
+msgctxt "title"
+msgid "Advanced search"
+msgstr ""
+
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L74
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/short_description.ctp#L103
 msgid "Clear search"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L100
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L98
 msgid "From"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L117
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/elements/search_bar.ctp#L115
 msgid "To"
 msgstr ""
 
@@ -1519,54 +1519,54 @@ msgstr ""
 msgid "Any language"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L326
-msgctxt "language"
-msgid "Any"
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L327
+msgctxt "searchbar"
+msgid "Any language"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L359
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L361
 msgid "unknown"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L459
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L461
 msgid "You cannot add sentences because you did not add any language in your profile."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L464
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L466
 msgid "You cannot translate sentences because you did not add any language in your profile."
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L472
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L474
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/user/language.ctp#L29
 #: github.com/Tatoeba/tatoeba2/tree/dev/app/views/user/profile.ctp#L294
 msgid "Add a language"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L490
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L492
 msgid "Unspecified"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L491
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L493
 msgid "0: Almost no knowledge"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L492
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L494
 msgid "1: Beginner"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L493
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L495
 msgid "2: Intermediate"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L494
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L496
 msgid "3: Advanced"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L495
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L497
 msgid "4: Fluent"
 msgstr ""
 
-#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L496
+#: github.com/Tatoeba/tatoeba2/tree/dev/app/views/helpers/languages.php#L498
 msgid "5: Native level"
 msgstr ""
 

--- a/app/views/elements/currently_active_members.ctp
+++ b/app/views/elements/currently_active_members.ctp
@@ -45,27 +45,6 @@ foreach($currentContributors as $i=>$currentContributor){
     $percentage = ($numberOfContributions/$total)*100;
     ?>
     <div class="currentContributor">
-        <div class="activityBar">
-        <?php
-        $maxActivity = 5;
-        $relativeScore = $numberOfContributions/$highestNumberOfContributions;
-        $activity = ceil($relativeScore*$maxActivity);
-        for ($j = $activity; $j < $maxActivity; $j++) {
-            echo '<div class="level0 box"></div>';
-        }
-        for ($k = $activity; $k > 0; $k--) {
-            echo '<div class="level'.$k.' box"></div>';
-        }
-        // The contributor who has contributed the most in the last contributions
-        // will have a level 5 activity. The activity of all other people will be
-        // relative to that number one contributor.
-        // For instance if the top contributor for the last contributions has made
-        // 100 contributions, and I have made 31 contributions, my activity would
-        // be 2 (0.31*5 = 1.55).
-        ?>
-        </div>
-    
-    
         <div class="image">
             <?php
             echo $members->image(
@@ -74,34 +53,55 @@ foreach($currentContributors as $i=>$currentContributor){
             );
             ?>
         </div>
-        
-        
-        <div class="username">
-            <?php
-            echo $html->link($currentContributor['userName'],
-                array(
-                    "controller" => "contributions",
-                    "action" => "of_user",
-                    $currentContributor['userName']
-                )
-            );
-        ?>
+
+        <div class="info">
+            <div class="username">
+                <?php
+                echo $html->link($currentContributor['userName'],
+                    array(
+                        "controller" => "contributions",
+                        "action" => "of_user",
+                        $currentContributor['userName']
+                    )
+                );
+                ?>
+            </div>
+
+
+            <div class="score">
+                <?php
+                echo format(
+                    __n(
+                        '#{rank} - {n}&nbsp;sentence - {percentage}%',
+                        '#{rank} - {n}&nbsp;sentences - {percentage}%',
+                        $numberOfContributions, true),
+                    array(
+                        'rank' => $i + 1,
+                        'n' => $numberOfContributions,
+                        'percentage' => $percentage
+                    )
+                );
+                ?>
+            </div>
         </div>
-        
-        
-        <div class="score">
+
+        <div class="activityBar">
             <?php
-            echo format(
-                __n(
-                    '#{rank} - {n}&nbsp;sentence - {percentage}%',
-                    '#{rank} - {n}&nbsp;sentences - {percentage}%',
-                    $numberOfContributions, true),
-                array(
-                    'rank' => $i + 1,
-                    'n' => $numberOfContributions,
-                    'percentage' => $percentage
-                )
-            );
+            $maxActivity = 5;
+            $relativeScore = $numberOfContributions/$highestNumberOfContributions;
+            $activity = ceil($relativeScore*$maxActivity);
+            for ($j = $activity; $j < $maxActivity; $j++) {
+                echo '<div class="level0 box"></div>';
+            }
+            for ($k = $activity; $k > 0; $k--) {
+                echo '<div class="level'.$k.' box"></div>';
+            }
+            // The contributor who has contributed the most in the last contributions
+            // will have a level 5 activity. The activity of all other people will be
+            // relative to that number one contributor.
+            // For instance if the top contributor for the last contributions has made
+            // 100 contributions, and I have made 31 contributions, my activity would
+            // be 2 (0.31*5 = 1.55).
             ?>
         </div>
     </div>

--- a/app/views/elements/foot.ctp
+++ b/app/views/elements/foot.ctp
@@ -25,85 +25,182 @@
  * @link     http://tatoeba.org
  */
 
-$onlineVisitors = ClassRegistry::init('Visitor')->numberOfOnlineVisitors();
 if (isset($this->params['lang'])) {
     Configure::write('Config.language', $this->params['lang']);
 }
 ?>
 <div id="footer">
-<ul>
-    <li>
-        <?php echo format(__n('One visitor online', '{n}&nbsp;visitors online', $onlineVisitors, true),
-                          array('n' => $onlineVisitors)); ?>
-    </li>
-    <li>
-        <?php
-        echo $html->link(
-            __('Terms of use', true),
-            array(
-                "controller" => 'pages',
-                "action" => 'terms_of_use'
-            )
-        );
-        ?>
-    </li>
-    <li>
-        <?php
-        echo $html->link(
-            __('Contact us', true),
-            array(
-                "controller" => 'pages',
-                "action" => 'contact'
-            )
-        );
-        ?>
-    </li>
-    <li>
-        <?php
-        echo $html->link(
-            __('Donate', true),
-            array(
-                "controller" => 'pages',
-                "action" => 'donate'
-            )
-        );
-        ?>
-    </li>
-    <li>
-        <?php
-        echo $html->link(
-            __('Blog', true),
-            'http://blog.tatoeba.org/',
-            array('target' => '_blank')
-        );
-        ?>
-    </li>
-    <li>
-        <?php
-        echo $html->link(
-            __('Twitter', true),
-            'http://twitter.com/tatoeba_org',
-            array('target' => '_blank')
-        );
-        ?>
-    </li>
-    <li>
-        <?php
-        echo $html->link(
-            __('Facebook', true),
-            'https://www.facebook.com/groups/129340017083187/',
-            array('target' => '_blank')
-        );
-        ?>
-    </li>
-    <li>
-        <?php
-        echo $html->link(
-            __('GitHub', true),
-            'https://github.com/Tatoeba/tatoeba2',
-            array('target' => '_blank')
-        );
-        ?>
-    </li>
-</ul>
+
+    <div class="category">
+        <h3><?php __('Need some help?'); ?></h3>
+        <ul>
+            <li>
+                <?php
+                echo $html->link(
+                    __('Quick Start Guide', true),
+                    'http://en.wiki.tatoeba.org/articles/show/quick-start'
+                );
+                ?>
+            </li>
+            <li>
+                <?php
+                echo $html->link(
+                    __('Tatoeba Wiki', true),
+                    'http://en.wiki.tatoeba.org/articles/show/main'
+                );
+                ?>
+            </li>
+            <li>
+                <?php
+                echo $html->link(
+                    __('FAQ', true),
+                    'http://en.wiki.tatoeba.org/articles/show/faq'
+                );
+                ?>
+            </li>
+            <li>
+                <?php
+                echo $html->link(
+                    __('Help', true),
+                    array(
+                        "controller" => "pages",
+                        "action" => "help"
+                    )
+                );
+                ?>
+            </li>
+        </ul>
+    </div>
+
+    <div class="category">
+        <h3><?php __('Developers'); ?></h3>
+        <ul>
+            <li>
+                <?php
+                echo $html->link(
+                    __('Downloads', true),
+                    array(
+                        "controller" => "pages",
+                        "action" => "downloads"
+                    )
+                );
+                ?>
+            </li>
+            <li>
+                <?php
+                echo $html->link(
+                    __('GitHub', true),
+                    'https://github.com/Tatoeba/tatoeba2',
+                    array('target' => '_blank')
+                );
+                ?>
+            </li>
+            <li>
+                <?php
+                echo $html->link(
+                    __('Google group', true),
+                    'https://groups.google.com/forum/#!forum/tatoebaproject'
+                );
+                ?>
+            </li>
+        </ul>
+    </div>
+
+    <div class="category">
+        <h3><?php __('About'); ?></h3>
+        <ul>
+            <li>
+                <?php
+                echo $html->link(
+                    __('What is Tatoeba?', true),
+                    array(
+                        "controller" => "pages",
+                        "action" => "about"
+                    )
+                );
+                ?>
+            </li>
+            <li>
+                <?php
+                echo $html->link(
+                    __('Contact us', true),
+                    array(
+                        "controller" => 'pages',
+                        "action" => 'contact'
+                    )
+                );
+                ?>
+            </li>
+            <li>
+                <?php
+                echo $html->link(
+                    __('Terms of use', true),
+                    array(
+                        "controller" => 'pages',
+                        "action" => 'terms_of_use'
+                    )
+                );
+                ?>
+            </li>
+            <li>
+                <?php
+                echo $html->link(
+                    __('Blog', true),
+                    'http://blog.tatoeba.org/',
+                    array('target' => '_blank')
+                );
+                ?>
+            </li>
+            <li>
+                <?php
+                echo $html->link(
+                    __('Twitter', true),
+                    'http://twitter.com/tatoeba_org',
+                    array('target' => '_blank')
+                );
+                ?>
+            </li>
+            <li>
+                <?php
+                echo $html->link(
+                    __('Facebook', true),
+                    'https://www.facebook.com/groups/129340017083187/',
+                    array('target' => '_blank')
+                );
+                ?>
+            </li>
+        </ul>
+    </div>
+
+
+
+    <div class="license">
+        <a class="cc-by-icon" rel="license"
+           href="http://creativecommons.org/licenses/by/2.0/fr/">
+            <img alt="Creative Commons License" style="border-width:0"
+                 src="http://i.creativecommons.org/l/by/2.0/fr/88x31.png" />
+        </a>
+        <div class="text">
+            <?php
+            __(
+                'Our sentences and translations can be used under the '.
+                'Creative Commons Attribution 2.0 license (CC-BY 2.0).'
+            );
+            ?>
+            <br/>
+            <?php
+            echo format(
+                __(
+                    'If you love this content, please consider a '.
+                    '<a href={}>donation</a>.', true
+                ),
+                $html->url(
+                    array('controller' => 'pages', 'action' => 'donate')
+                )
+            );
+            ?>
+        </div>
+
+    </div>
+
 </div>

--- a/app/views/elements/foot.ctp
+++ b/app/views/elements/foot.ctp
@@ -175,7 +175,7 @@ if (isset($this->params['lang'])) {
 
     <div class="license">
         <a class="cc-by-icon" rel="license"
-           href="http://creativecommons.org/licenses/by/2.0/fr/">
+           href="http://creativecommons.org/licenses/by/2.0/">
             <img alt="Creative Commons License" style="border-width:0"
                  src="http://i.creativecommons.org/l/by/2.0/fr/88x31.png" />
         </a>

--- a/app/views/elements/foot.ctp
+++ b/app/views/elements/foot.ctp
@@ -31,6 +31,7 @@ if (isset($this->params['lang'])) {
 ?>
 <div id="footer">
 
+    <div class="container">
     <div class="category">
         <h3><?php __('Need some help?'); ?></h3>
         <ul>
@@ -172,8 +173,6 @@ if (isset($this->params['lang'])) {
         </ul>
     </div>
 
-
-
     <div class="license">
         <a class="cc-by-icon" rel="license"
            href="http://creativecommons.org/licenses/by/2.0/fr/">
@@ -202,5 +201,5 @@ if (isset($this->params['lang'])) {
         </div>
 
     </div>
-
+    </div>
 </div>

--- a/app/views/elements/header.ctp
+++ b/app/views/elements/header.ctp
@@ -25,7 +25,7 @@
  * @link     http://tatoeba.org
  */
 ?>
-<div id="logo">
+<li id="logo">
     <?php
     $name = __('Tatoeba', true);
     $path = array(
@@ -35,13 +35,16 @@
     $logo = $html->image(
         IMG_PATH . 'tatoeba.svg',
         array(
-            'width' => 64,
-            'height' => 64,
+            'width' => 48,
+            'height' => 48,
             'title' => $name
 
         )
     );
-    echo $html->link($logo, $path, array('escape' => false));
-    echo $html->div('tatoeba-name', $name);
+    echo $html->link(
+        $logo . $html->div('tatoeba-name', $name),
+        $path,
+        array('escape' => false)
+    );
     ?>
-</div>
+</li>

--- a/app/views/elements/search_bar.ctp
+++ b/app/views/elements/search_bar.ctp
@@ -32,24 +32,6 @@ if (isset($this->params['lang'])) {
 
 <div class="search_bar">
 <?php
-echo $html->div('search-bar-extra');
-echo $html->link(
-    __('Help', true),
-    'http://en.wiki.tatoeba.org/articles/show/text-search',
-    array(
-        'target' => '_blank'
-    )
-);
-echo $html->link(
-    __p('title', 'Advanced search', true),
-    array(
-        'controller' => 'sentences',
-        'action' => 'advanced_search'
-    )
-);
-echo '</div>';
-
-
 if ($selectedLanguageFrom == null) {
     $selectedLanguageFrom = 'und';
 }
@@ -70,6 +52,22 @@ echo $form->create(
         <?php __('Search'); ?>
     </label>
     <?php
+    echo $html->div('search-bar-extra');
+    echo $html->link(
+        __('Help', true),
+        'http://en.wiki.tatoeba.org/articles/show/text-search',
+        array(
+            'target' => '_blank'
+        )
+    );
+    echo $html->link(
+        __p('title', 'Advanced search', true),
+        array(
+            'controller' => 'sentences',
+            'action' => 'advanced_search'
+        )
+    );
+    echo '</div>';
     $clearButton = $this->Html->tag('button', '✖', array(
         'id' => 'clearSearch',
         'type' => 'button',

--- a/app/views/elements/search_bar.ctp
+++ b/app/views/elements/search_bar.ctp
@@ -122,7 +122,10 @@ echo $form->create(
 
 <fieldset class="submit">
     <?php
-    echo $form->button(null, array('class' => 'search-submit-button'));
+    echo $form->button(
+        $images->svgIcon('search'),
+        array('class' => 'search-submit-button')
+    );
     ?>
 </fieldset>
 

--- a/app/views/elements/search_bar.ctp
+++ b/app/views/elements/search_bar.ctp
@@ -102,7 +102,7 @@ echo $form->create(
 </fieldset>
 
 <fieldset class="into">
-    <span id="into"><a id="arrow" style="color:white;">&raquo;</a></span>
+    <span id="arrow">&raquo;</span>
 </fieldset>
     
 <fieldset class="select to">

--- a/app/views/elements/sentences_statistics.ctp
+++ b/app/views/elements/sentences_statistics.ctp
@@ -24,8 +24,6 @@
  * @license  Affero General Public License
  * @link     http://tatoeba.org
  */
-$stats = ClassRegistry::init('Language')->getSentencesStatistics(5);
-$numSentences = ClassRegistry::init('Sentence')->getTotalNumberOfSentences();
 ?>
 
 <div class="module">

--- a/app/views/elements/short_description.ctp
+++ b/app/views/elements/short_description.ctp
@@ -59,11 +59,11 @@
                 )
             );
 
-            if ($selectedLanguageFrom == null) {
+            if (!isset($selectedLanguageFrom)) {
                 $selectedLanguageFrom = 'und';
             }
 
-            if ($selectedLanguageTo == null) {
+            if (!isset($selectedLanguageTo)) {
                 $selectedLanguageTo = 'und';
             }
 

--- a/app/views/elements/short_description.ctp
+++ b/app/views/elements/short_description.ctp
@@ -27,20 +27,24 @@
 ?>
 
 <div class="topContent">
-    <div class="container">
-        <div class="description">
-            <strong>
-                <?php
-                __("Tatoeba is a collection of sentences and translations.");
-                ?>
-            </strong>
-            <div>
-                <?php
-                __("It's collaborative, open, free and even addictive.");
-                ?>
+    <div class="descriptionBar">
+        <div class="container">
+            <div class="description">
+                <strong>
+                    <?php
+                    __("Tatoeba is a collection of sentences and translations.");
+                    ?>
+                </strong>
+                <div>
+                    <?php
+                    __("It's collaborative, open, free and even addictive.");
+                    ?>
+                </div>
             </div>
         </div>
+    </div>
 
+    <div class="container">
         <!-- Search -->
         <?php
         if (isset($this->params['lang'])) {

--- a/app/views/elements/short_description.ctp
+++ b/app/views/elements/short_description.ctp
@@ -28,13 +28,141 @@
 
 <div class="topContent">
     <div class="container">
-    <div class="description">
-        <strong>
-            <?php __("Tatoeba is a collection of sentences and translations."); ?>
-        </strong>
-        <div>
-            <?php __("It's collaborative, open, free and even addictive."); ?>
+        <div class="description">
+            <strong>
+                <?php
+                __("Tatoeba is a collection of sentences and translations.");
+                ?>
+            </strong>
+            <div>
+                <?php
+                __("It's collaborative, open, free and even addictive.");
+                ?>
+            </div>
         </div>
-    </div>
+
+        <!-- Search -->
+        <?php
+        if (isset($this->params['lang'])) {
+            Configure::write('Config.language', $this->params['lang']);
+        }
+        ?>
+
+        <div class="search-bar">
+            <?php
+            echo $form->create(
+                'Sentence',
+                array(
+                    "action" => "search",
+                    "type" => "get",
+                    "id" => "new-search-bar"
+                )
+            );
+
+            if ($selectedLanguageFrom == null) {
+                $selectedLanguageFrom = 'und';
+            }
+
+            if ($selectedLanguageTo == null) {
+                $selectedLanguageTo = 'und';
+            }
+
+            ?>
+            <fieldset class="input text languages">
+                <?php
+                $langFrom = $this->Search->selectLang(
+                    'from',
+                    $selectedLanguageFrom,
+                    array(
+                        'div' => false,
+                        'label' => '',
+                    )
+                );
+
+                $langTo = $this->Search->selectLang(
+                    'to',
+                    $selectedLanguageTo,
+                    array(
+                        'div' => false,
+                        'label' => '',
+                    )
+                );
+                echo format(
+                    __('Search sentences in {langFrom} '.
+                        'translated into {langTo} containing:', true),
+                    array('langFrom' => $langFrom, 'langTo' => $langTo)
+                );
+                ?>
+            </fieldset>
+
+            <fieldset class="input text search-input">
+                <?php
+                $clearButton = $this->Html->tag('button', '✖', array(
+                    'id' => 'clearSearch',
+                    'type' => 'button',
+                    'title' => __('Clear search', true),
+                ));
+                echo $form->input(
+                    'query',
+                    array(
+                        'id' => 'SentenceQuery',
+                        'label' => '',
+                        'accesskey' => 4,
+                        'lang' => '',
+                        'dir' => 'auto',
+                        'after' => $clearButton,
+                        'placeholder' => __('Enter a word or a phrase', true)
+                    )
+                );
+                ?>
+            </fieldset>
+
+            <fieldset class="submit">
+                <?php
+                echo $form->button(
+                    $images->svgIcon('search'),
+                    array('class' => 'search-submit-button')
+                );
+                ?>
+            </fieldset>
+
+
+            <div class="extra-links">
+                <div class="advanced-search">
+                    <?php
+                    echo $html->link(
+                        __p('title', 'Advanced search', true),
+                        array(
+                            'controller' => 'sentences',
+                            'action' => 'advanced_search'
+                        )
+                    );
+                    ?>
+                </div>
+
+                <div class="tip">
+                    <?php
+                    __(
+                        "Tip: <em>=word</em> will search for ".
+                        "an exact match on <em>word</em>"
+                    );
+                    echo "<br/>";
+                    echo $html->link(
+                        __('More', true),
+                        'http://en.wiki.tatoeba.org/articles/show/text-search',
+                        array(
+                            'target' => '_blank'
+                        )
+                    );
+                    ?>
+                </div>
+            </div>
+
+            <?php
+            echo $form->end();
+            ?>
+        </div>
+
+
     </div>
 </div>

--- a/app/views/elements/short_description.ctp
+++ b/app/views/elements/short_description.ctp
@@ -28,67 +28,11 @@
 
 <div class="topContent">
     <div class="description">
-        <p>
+        <strong>
             <?php __("Tatoeba is a collection of sentences and translations."); ?>
-        </p>
-        <p>
+        </strong>
+        <div>
             <?php __("It's collaborative, open, free and even addictive."); ?>
-        </p>
-    </div><!--
-
-    --><ul class="links">
-        <?php
-        echo '<li>';
-        echo $html->link(
-            __("How it works", true),
-            'http://en.wiki.tatoeba.org/articles/show/quick-start',
-            array(
-                "class" => "learnMore"
-            )
-        );
-        echo '</li>';
-
-
-        echo '<li>';
-        echo $html->link(
-            __("About us", true),
-            array(
-                "controller" => "pages",
-                "action" => "about"
-            ),
-            array(
-                "class" => "learnMore"
-            )
-        );
-        echo '</li>';
-
-
-        echo '<li>';
-        echo $html->link(
-            __("Register", true),
-            array(
-                "controller" => "users",
-                "action" => "register"
-            ),
-            array(
-                "class" => "registerButton"
-            )
-        );
-        echo '</li>';
-
-
-        echo '<li>';
-        echo $html->link(
-            __("Log in", true),
-            array(
-                "controller" => "users",
-                "action" => "login"
-            ),
-            array(
-                "class" => "loginButton"
-            )
-        );
-        echo '</li>';
-        ?>
-    </ul>
+        </div>
+    </div>
 </div>

--- a/app/views/elements/short_description.ctp
+++ b/app/views/elements/short_description.ctp
@@ -148,7 +148,9 @@
                     );
                     echo "<br/>";
                     echo $html->link(
-                        __('More', true),
+                        /* @translators: links to a page with tips to perform
+                           searches, like search operators */
+                        __('More tips', true),
                         'http://en.wiki.tatoeba.org/articles/show/text-search',
                         array(
                             'target' => '_blank'

--- a/app/views/elements/short_description.ctp
+++ b/app/views/elements/short_description.ctp
@@ -27,6 +27,7 @@
 ?>
 
 <div class="topContent">
+    <div class="container">
     <div class="description">
         <strong>
             <?php __("Tatoeba is a collection of sentences and translations."); ?>
@@ -34,5 +35,6 @@
         <div>
             <?php __("It's collaborative, open, free and even addictive."); ?>
         </div>
+    </div>
     </div>
 </div>

--- a/app/views/elements/top_menu.ctp
+++ b/app/views/elements/top_menu.ctp
@@ -103,6 +103,10 @@ $menuElements = array(
             __('Discuss sentences', true) => array(
                 "controller" => "sentence_comments",
                 "action" => "index"
+            ),
+            __('Show activity timeline', true) => array(
+                "controller" => "contributions",
+                "action" => "activity_timeline"
             )
         )
     ),

--- a/app/views/elements/top_menu.ctp
+++ b/app/views/elements/top_menu.ctp
@@ -46,12 +46,6 @@ if (empty($notTranslatedInto)) {
 
 // array containing the elements of the menu : $title => $route
 $menuElements = array(
-    __('Home', true) => array(
-        "route" => array(
-            "controller" => "pages",
-            "action" => "index"
-        )
-    ),
     __('Browse', true) => array(
         "route" => array(
             "controller" => null,
@@ -112,12 +106,16 @@ $menuElements = array(
             )
         )
     ),
-    __('Members', true) => array(
+    __('Community', true) => array(
         "route" => array(
             "controller" => null,
             "action" => null
         ),
         "sub-menu" => array(
+            __('Wall', true) => array(
+                "controller" => "wall",
+                "action" => "index"
+            ),
             __('List of all members', true) => array(
                 "controller" => "users",
                 "action" => "all"
@@ -131,49 +129,6 @@ $menuElements = array(
                 "action" => "native_speakers"
             )
         )
-    ),
-    __('Wall', true) => array(
-        "route" => array(
-            "controller" => "wall",
-            "action" => "index"
-        )
-    ),
-    __('More', true) => array(
-        "route" => array(
-            "controller" => null,
-            "action" => null,
-        ),
-        "sub-menu" => array(
-            __('Quick Start Guide', true) =>
-                'http://en.wiki.tatoeba.org/articles/show/quick-start'
-            ,
-            __('Tatoeba Wiki', true) =>
-                'http://en.wiki.tatoeba.org/articles/show/main'
-            ,
-            __('FAQ', true) =>
-                'http://en.wiki.tatoeba.org/articles/show/faq'
-            ,
-            __('Help', true) => array(
-                "controller" => "pages",
-                "action" => "help"
-            ),
-            __('Show activity timeline', true) => array(
-                "controller" => "contributions",
-                "action" => "activity_timeline"
-            ),
-            __('Downloads', true) => array(
-                "controller" => "pages",
-                "action" => "downloads"
-            ),
-            __('Tools', true) => array(
-                "controller" => "tools",
-                "action" => "index"
-            ),
-            __('Donate', true) => array(
-                "controller" => "pages",
-                "action" => "donate"
-            )
-        )
     )
 );
 
@@ -181,29 +136,10 @@ $menuElements = array(
 
 <div id="top_menu_container">
     <div id="top_menu">
-        <div id="languageSelectionContainer">
-        <?php echo $this->element('interface_language'); ?>
-        </div>
-        
-        <div id="user_menu">
-        <?php
-        // User menu    
-        if (!$session->read('Auth.User.id')) {
-            $isOnLoginPage = ($this->params['controller'] == 'users')
-            && ($this->params['action'] == 'login');
-            
-            if (!$isOnLoginPage) {
-                echo $this->element('login');
-            }
-        } else {
-            echo $this->element('space');
-        }
-        ?>
-        </div>
-        
-        
         <ul id="navigation_menu">
         <?php
+        echo $this->element('header');
+
         // current path param
         $param = '';
         if (isset($this->params['pass'][0])) {
@@ -282,6 +218,26 @@ $menuElements = array(
         }
         ?>
         </ul>
-        
+
+        <div id="languageSelectionContainer">
+            <?php echo $this->element('interface_language'); ?>
+        </div>
+
+        <div id="user_menu">
+            <?php
+            // User menu
+            if (!$session->read('Auth.User.id')) {
+                $isOnLoginPage = ($this->params['controller'] == 'users')
+                    && ($this->params['action'] == 'login');
+
+                if (!$isOnLoginPage) {
+                    echo $this->element('login');
+                }
+            } else {
+                echo $this->element('space');
+            }
+            ?>
+        </div>
+
     </div>
 </div>

--- a/app/views/helpers/languages.php
+++ b/app/views/helpers/languages.php
@@ -323,7 +323,9 @@ class LanguagesHelper extends AppHelper
     public function getSearchableLanguagesArray()
     {
         $languages = $this->onlyLanguagesArray();
-        array_unshift($languages, array('und' => __p('language', 'Any', true)));
+        array_unshift(
+            $languages, array('und' => __('Any language', true))
+        );
 
         return $languages;
     }

--- a/app/views/helpers/languages.php
+++ b/app/views/helpers/languages.php
@@ -324,7 +324,7 @@ class LanguagesHelper extends AppHelper
     {
         $languages = $this->onlyLanguagesArray();
         array_unshift(
-            $languages, array('und' => __('Any language', true))
+            $languages, array('und' => __p('searchbar', 'Any language', true))
         );
 
         return $languages;

--- a/app/views/layouts/default.ctp
+++ b/app/views/layouts/default.ctp
@@ -125,20 +125,24 @@
     <div id="container">
         <!--  SEARCH BAR  -->
         <?php
-        echo $this->element('search_bar', array(
-            'selectedLanguageFrom' => $session->read('search_from'),
-            'selectedLanguageTo' => $session->read('search_to'),
-            'searchQuery' => $session->read('search_query'),
-            'cache' => array(
-                // Only use cache when search fields are not prefilled
-                'time' => is_null($session->read('search_from'))
-                          && is_null($session->read('search_to'))
-                          && is_null($session->read('search_query'))
-                          && !$languages->preferredLanguageFilter()
-                          ? '+1 day' : false,
-                'key' => Configure::read('Config.language')
-            )
-        )); ?>
+        $isHomepage = $controller == 'pages' && $action == 'index';
+        if (CurrentUser::isMember() || !$isHomepage) {
+            echo $this->element('search_bar', array(
+                'selectedLanguageFrom' => $session->read('search_from'),
+                'selectedLanguageTo' => $session->read('search_to'),
+                'searchQuery' => $session->read('search_query'),
+                'cache' => array(
+                    // Only use cache when search fields are not prefilled
+                    'time' => is_null($session->read('search_from'))
+                    && is_null($session->read('search_to'))
+                    && is_null($session->read('search_query'))
+                    && !$languages->preferredLanguageFilter()
+                        ? '+1 day' : false,
+                    'key' => Configure::read('Config.language')
+                )
+            ));
+        }
+        ?>
             
         <!--  CONTENT -->
         <div id="content">

--- a/app/views/layouts/default.ctp
+++ b/app/views/layouts/default.ctp
@@ -123,9 +123,6 @@
 
 
     <div id="container">
-        <!--  Logo  -->
-        <?php echo $this->element('header'); ?>
-        
         <!--  SEARCH BAR  -->
         <?php
         echo $this->element('search_bar', array(

--- a/app/views/layouts/default.ctp
+++ b/app/views/layouts/default.ctp
@@ -121,53 +121,51 @@
     <!--  TOP  -->
     <?php echo $this->element('top_menu'); ?>
 
-
-    <div id="container">
-        <!--  SEARCH BAR  -->
+    <!--  SEARCH BAR  -->
+    <?php
+    $isHomepage = $controller == 'pages' && $action == 'index';
+    if (CurrentUser::isMember() || !$isHomepage) {
+        echo $this->element('search_bar', array(
+            'selectedLanguageFrom' => $session->read('search_from'),
+            'selectedLanguageTo' => $session->read('search_to'),
+            'searchQuery' => $session->read('search_query'),
+            'cache' => array(
+                // Only use cache when search fields are not prefilled
+                'time' => is_null($session->read('search_from'))
+                && is_null($session->read('search_to'))
+                && is_null($session->read('search_query'))
+                && !$languages->preferredLanguageFilter()
+                    ? '+1 day' : false,
+                'key' => Configure::read('Config.language')
+            )
+        ));
+    }
+    ?>
+            
+    <!--  CONTENT -->
+    <div id="content">
+        <div class="container">
         <?php
-        $isHomepage = $controller == 'pages' && $action == 'index';
-        if (CurrentUser::isMember() || !$isHomepage) {
-            echo $this->element('search_bar', array(
-                'selectedLanguageFrom' => $session->read('search_from'),
-                'selectedLanguageTo' => $session->read('search_to'),
-                'searchQuery' => $session->read('search_query'),
-                'cache' => array(
-                    // Only use cache when search fields are not prefilled
-                    'time' => is_null($session->read('search_from'))
-                    && is_null($session->read('search_to'))
-                    && is_null($session->read('search_query'))
-                    && !$languages->preferredLanguageFilter()
-                        ? '+1 day' : false,
-                    'key' => Configure::read('Config.language')
-                )
-            ));
+        echo $this->element('announcement');
+        if($session->check('Message.flash')){
+            echo $session->flash();
         }
-        ?>
-            
-        <!--  CONTENT -->
-        <div id="content">
-            <?php
-            echo $this->element('announcement');
-            if($session->check('Message.flash')){
-                echo $session->flash();
-            }
 
-            echo $content_for_layout;
-            ?>
-            
-            <!-- 
-                Quick fix to readjust the size of the container when
-                the main content is smaller than the annexe content.
-            -->
-            <div style="clear:both"></div>
+        echo $content_for_layout;
+        ?>
+
+        <!--
+            Quick fix to readjust the size of the container when
+            the main content is smaller than the annexe content.
+        -->
+        <div style="clear:both"></div>
         </div>
-
-
-        <!--  FOOT -->
-        <?php
-        echo $this->element('foot');
-        ?>
     </div>
+
+    <!--  FOOT -->
+    <?php
+    echo $this->element('foot');
+    ?>
     <?php echo $this->element('sql_dump'); ?>
 
     <?php

--- a/app/views/layouts/default.ctp
+++ b/app/views/layouts/default.ctp
@@ -139,6 +139,13 @@
                 'key' => Configure::read('Config.language')
             )
         ));
+    } else {
+        echo $this->element('short_description', array(
+            'cache' => array(
+                'time' => '+1 day',
+                'key' => Configure::read('Config.language')
+            )
+        ));
     }
     ?>
             

--- a/app/views/layouts/default.ctp
+++ b/app/views/layouts/default.ctp
@@ -68,11 +68,9 @@
                     background-image:url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSczMDAnIGhlaWdodD0nMzAwJyB2aWV3Qm94PScwIDAgMzAwIDMwMCc+Cgk8ZGVmcz4KCQk8cGF0dGVybiBpZD0nYmx1ZXN0cmlwZScgcGF0dGVyblVuaXRzPSd1c2VyU3BhY2VPblVzZScgeD0nMCcgeT0nMCcgd2lkdGg9JzIwJyBoZWlnaHQ9JzIwJyB2aWV3Qm94PScwIDAgNDAgNDAnID4KCQk8cmVjdCB3aWR0aD0nMTEwJScgaGVpZ2h0PScxMTAlJyBmaWxsPScjZmZmZmZmJy8+CgkJCTxwYXRoIGQ9J00xLDFoNDB2NDBoLTQwdi00MCcgZmlsbC1vcGFjaXR5PScwJyBzdHJva2Utd2lkdGg9JzEnIHN0cm9rZS1kYXNoYXJyYXk9JzAsMSwxJyBzdHJva2U9JyNjY2NjY2MnLz4KCQk8L3BhdHRlcm4+IAoJCTxmaWx0ZXIgaWQ9J2Z1enonIHg9JzAnIHk9JzAnPgoJCQk8ZmVUdXJidWxlbmNlIHR5cGU9J3R1cmJ1bGVuY2UnIHJlc3VsdD0ndCcgYmFzZUZyZXF1ZW5jeT0nLjIgLjMnIG51bU9jdGF2ZXM9JzUnIHN0aXRjaFRpbGVzPSdzdGl0Y2gnLz4KCQkJPGZlQ29sb3JNYXRyaXggdHlwZT0nc2F0dXJhdGUnIGluPSd0JyB2YWx1ZXM9JzAnLz4KCQk8L2ZpbHRlcj4KCTwvZGVmcz4KCTxyZWN0IHdpZHRoPScxMDAlJyBoZWlnaHQ9JzEwMCUnIGZpbGw9J3VybCgjYmx1ZXN0cmlwZSknLz4KPHJlY3Qgd2lkdGg9JzEwMCUnIGhlaWdodD0nMTAwJScgZmlsdGVyPSd1cmwoI2Z1enopJyBvcGFjaXR5PScwLjEnLz4KPC9zdmc+Cg==');
                 }
                 #top_menu_container { background-color: #cf0000; }
-                div.search_bar:after {
+                #content .container:before {
                     content: "<?php __("Warning: this website is for testing purposes. Everything you submit will be definitely lost.")?>";
-                    position: absolute;
                     color: #cf0000;
-                    margin-left: 92px;
                     font-size: 15px;
                 }
             </style>

--- a/app/views/pages/index.ctp
+++ b/app/views/pages/index.ctp
@@ -28,15 +28,6 @@
 $this->set('title_for_layout', __('Tatoeba: Collection of sentences and translations', true));
 
 $selectedLanguage = $session->read('random_lang_selected');
-
-if (!$isLogged) {
-    echo $this->element('short_description', array(
-        'cache' => array(
-            'time' => '+1 day',
-            'key' => Configure::read('Config.language')
-        )
-    ));
-}
 ?>
 <div id="annexe_content">
     <?php 

--- a/app/views/pages/index.ctp
+++ b/app/views/pages/index.ctp
@@ -32,6 +32,8 @@ $selectedLanguage = $session->read('random_lang_selected');
 <div id="annexe_content">
     <?php 
     echo $this->element('sentences_statistics', array(
+        'stats' => $stats,
+        'numSentences' => $numSentences,
         'cache' => array(
             'time' => '+15 minutes',
             'key' => Configure::read('Config.language')

--- a/app/views/pages/index_for_guests.ctp
+++ b/app/views/pages/index_for_guests.ctp
@@ -58,15 +58,24 @@ $this->set('title_for_layout', __('Tatoeba: Collection of sentences and translat
         $numberOfLanguages = count(LanguagesLib::languagesInTatoeba());
 
         echo $html->div('stat', format(
-            __('{number} contributions today', true),
+            __n('{number} contribution today',
+                '{number} contributions today',
+                $contribToday,
+                true),
             array('number' => $html->tag('strong', $contribToday))
         ));
         echo $html->div('stat', format(
-            __('{number} supported languages', true),
+            __n('{number} supported language',
+                '{number} supported languages',
+                $numberOfLanguages,
+                true),
             array('number' => $html->tag('strong', $numberOfLanguages))
         ));
         echo $html->div('stat', format(
-            __('{number} sentences', true),
+            __n('{number} sentence',
+                '{number} sentences',
+                $numSentences,
+                true),
             array('number' => $html->tag('strong', $numSentences))
         ));
         ?>
@@ -85,7 +94,10 @@ $this->set('title_for_layout', __('Tatoeba: Collection of sentences and translat
                     'indifferent',
                 );
                 $numberOfSentencesLabel = format(
-                    __('{number} sentences in {lang}', true),
+                    __n('{number} sentence in {lang}',
+                        '{number} sentences in {lang}',
+                        $numberOfSentences,
+                        true),
                     array(
                         'number' => $numberOfSentences,
                         'lang' => $languages->codeToNameAlone($langCode)

--- a/app/views/pages/index_for_guests.ctp
+++ b/app/views/pages/index_for_guests.ctp
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2009  HO Ngoc Phuong Trang <tranglich@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Tatoeba
+ * @author   HO Ngoc Phuong Trang <tranglich@gmail.com>
+ * @license  Affero General Public License
+ * @link     http://tatoeba.org
+ */
+
+echo $this->element('short_description', array(
+    'cache' => array(
+        'time' => '+1 day',
+        'key' => Configure::read('Config.language')
+    )
+));
+?>
+
+<div id="main_content">
+    <?php if(!isset($searchProblem)) { ?>
+    <div class="module">
+        <?php echo $this->element('random_sentence_header'); ?>
+        <div class="random_sentences_set">
+            <?php
+            $sentence = $random['Sentence'];
+            $transcrs = $random['Transcription'];
+            $translations = $random['Translation'];
+            $sentenceOwner = $random['User'];
+
+            $sentences->displaySentencesGroup(
+                $sentence,
+                $transcrs,
+                $translations,
+                $sentenceOwner
+            );
+            ?>
+        </div>
+    </div>
+    <?php } ?>
+</div>

--- a/app/views/pages/index_for_guests.ctp
+++ b/app/views/pages/index_for_guests.ctp
@@ -40,7 +40,7 @@ App::import('Vendor', 'LanguagesLib');
             __('Join the community', true),
             array(
                 'controller' => 'users',
-                'action' => 'regiser'
+                'action' => 'register'
             ),
             array(
                 'class' => 'registerLink'

--- a/app/views/pages/index_for_guests.ctp
+++ b/app/views/pages/index_for_guests.ctp
@@ -24,13 +24,6 @@
  * @license  Affero General Public License
  * @link     http://tatoeba.org
  */
-
-echo $this->element('short_description', array(
-    'cache' => array(
-        'time' => '+1 day',
-        'key' => Configure::read('Config.language')
-    )
-));
 ?>
 
 <div id="main_content">

--- a/app/views/pages/index_for_guests.ctp
+++ b/app/views/pages/index_for_guests.ctp
@@ -24,7 +24,89 @@
  * @license  Affero General Public License
  * @link     http://tatoeba.org
  */
+
+App::import('Vendor', 'LanguagesLib');
 ?>
+
+<div id="annexe_content">
+    <div class="module join-us">
+        <?php
+        echo $html->tag('h2', __('Want to help?', true));
+        echo $html->tag('p', __(
+            'We are collecting sentences and their translations. '.
+            'You can help us by translating or adding new sentences.', true
+        ));
+        echo $html->link(
+            __('Join the community', true),
+            array(
+                'controller' => 'users',
+                'action' => 'regiser'
+            ),
+            array(
+                'class' => 'registerLink'
+            )
+        )
+        ?>
+    </div>
+
+    <div class="module stats">
+        <?php
+        echo $html->tag('h2', __('Stats', true));
+
+        $numberOfLanguages = count(LanguagesLib::languagesInTatoeba());
+
+        echo $html->div('stat', format(
+            __('{number} contributions today', true),
+            array('number' => $html->tag('strong', $contribToday))
+        ));
+        echo $html->div('stat', format(
+            __('{number} supported languages', true),
+            array('number' => $html->tag('strong', $numberOfLanguages))
+        ));
+        echo $html->div('stat', format(
+            __('{number} sentences', true),
+            array('number' => $html->tag('strong', $numSentences))
+        ));
+        ?>
+
+        <ul class="guest-sentences-stats">
+            <?php
+            foreach ($stats as $stat) {
+                $langCode = $stat['Language']['code'];
+                $numberOfSentences = $stat['Language']['sentences'];
+                $link = array(
+                    "controller" => "sentences",
+                    "action" => "show_all_in",
+                    $langCode,
+                    'none',
+                    'none',
+                    'indifferent',
+                );
+                $numberOfSentencesLabel = format(
+                    __('{number} sentences in {lang}', true),
+                    array(
+                        'number' => $numberOfSentences,
+                        'lang' => $languages->codeToNameAlone($langCode)
+                    )
+                );
+                $languages->stat($langCode, $numberOfSentencesLabel, $link);
+            }
+            ?>
+
+            <li>
+                <?php
+                echo $html->link(
+                    __('show all languages', true),
+                    array(
+                        'controller' => 'stats',
+                        'action' => 'sentences_by_language'
+                    )
+                );
+                ?>
+            </li>
+        </ul>
+    </div>
+</div>
 
 <div id="main_content">
     <?php if(!isset($searchProblem)) { ?>

--- a/app/views/pages/index_for_guests.ctp
+++ b/app/views/pages/index_for_guests.ctp
@@ -26,6 +26,8 @@
  */
 
 App::import('Vendor', 'LanguagesLib');
+
+$this->set('title_for_layout', __('Tatoeba: Collection of sentences and translations', true));
 ?>
 
 <div id="annexe_content">

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -329,7 +329,8 @@ svg {
 
 #SentenceSearchForm {
     text-align: center;
-    padding: 2px 20px 10px 10px;
+    padding: 2px 10px 10px 10px;
+    margin: 0;
     position: relative;
 }
 
@@ -376,7 +377,7 @@ svg {
 
 .search-bar-extra {
     text-align: right;
-    right: 400px;
+    right: 450px;
     top: 3px;
     position: relative;
 }

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -373,6 +373,7 @@ svg {
     height: 30px;
     border: 1px solid #EEEEEE;
     border-radius: 2px;
+    padding: 2px 0 4px 0; /* Fix Chrome bogus bottom margin */
 }
 
 .search-submit-button svg {

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -234,7 +234,6 @@ svg {
 #languageSelection {
     margin-left: 10px;
     margin-top: 2px;
-    height: 24px; /* need to specify height otherwise in Firefox and Opera it's too big */
 }
 
 /* 

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -337,14 +337,22 @@ svg {
     height: 30px;
 }
 
+.search_bar .input {
+    position: relative;
+}
+
 .search_bar #clearSearch {
     background: transparent;
     border: none;
     cursor: pointer;
     color: #CCCCCC;
     position: absolute;
-    top: 5px;
-    right: 0;
+    right: 2px;
+    line-height: 28px;
+}
+
+#SentenceQuery {
+    padding-right: 30px;
 }
 
 #SentenceQuery,

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -33,11 +33,11 @@ div, p {
     word-wrap: break-word;
 }
 
-body {
+html, body {
     padding: 0;
     margin: 0;
     color: #222222;
-    background: #e5e3da;
+    background: #F5F5F5;
 }
 
 textarea {
@@ -271,13 +271,9 @@ svg {
  * Container
  */
 
-#container {
+.container {
     width: 960px;
-    margin: auto auto 100px;
-    background-color: #fff;
-    -webkit-box-shadow: 0 0 5px 5px rgba(50, 50, 50, 0.3);
-    -moz-box-shadow: 0 0 5px 5px rgba(50, 50, 50, 0.3);
-    box-shadow: 0 0 5px 5px rgba(50, 50, 50, 0.3);
+    margin: auto auto 10px;
 }
 
 
@@ -289,7 +285,6 @@ svg {
     background-color: #66AA00;
     position: relative;
     color: #FFFFFF;
-    margin-bottom: 20px;
 }
 
 .search_bar form {
@@ -376,8 +371,8 @@ svg {
 }
 
 .search-bar-extra {
-    text-align: right;
-    right: 450px;
+    text-align: center;
+    padding-right: 100px;
     top: 3px;
     position: relative;
 }
@@ -474,6 +469,7 @@ svg {
     width: 100%;
     background: #FFFFFF;
     min-height: 550px;
+    padding-top: 20px;
 }
 
 #annexe_content {
@@ -514,7 +510,7 @@ svg {
  * Footer 
  */
 #footer {
-    background: #F5F5F5;
+    padding-bottom: 10px;
 }
 
 #footer .category {

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -282,9 +282,7 @@ svg {
  */
 
 .search_bar {
-    background-color: #66AA00;
     position: relative;
-    color: #FFFFFF;
 }
 
 .search_bar form {
@@ -310,7 +308,6 @@ svg {
     font-size: 13px;
     display: block;
     margin-bottom: 2px;
-    color: #EEEEEE;
 }
 
 .search_bar label[for="SentenceQuery"] {
@@ -353,8 +350,7 @@ svg {
 }
 
 #SentenceQuery,
-.search_bar select,
-.search_bar .search-submit-button {
+.search_bar select {
     background-color: #FFFFFF;
     color: #111111;
     border: 1px solid #EEEEEE;
@@ -362,12 +358,22 @@ svg {
 }
 
 .search_bar .search-submit-button {
-    color: #aaaaaa;
-    padding: 3px 20px;
+    color: #ffffff;
     cursor: pointer;
-    background: url(/img/search.svg) center no-repeat #f1f1f1;
+    background: #66AA00;
     width: 70px;
     height: 30px;
+    border: 1px solid #66AA00;
+    border-radius: 2px;
+}
+
+.search-submit-button svg {
+    display: block;
+    margin: auto;
+    width: 20px;
+    height: 20px;
+    vertical-align: middle;
+    padding-top: 2px;
 }
 
 .search-bar-extra {
@@ -377,7 +383,6 @@ svg {
     position: relative;
 }
 .search-bar-extra a {
-    color: #FFFFFF;
     font-size: 13px;
     margin: 10px;
 }

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -359,7 +359,7 @@ svg {
 .search_bar select {
     background-color: #FFFFFF;
     color: #111111;
-    border: 1px solid #EEEEEE;
+    border: 1px solid #DDDDDD;
     border-radius: 2px;
 }
 

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -342,7 +342,7 @@ svg {
     height: 30px;
 }
 
-#clearSearch {
+.search_bar #clearSearch {
     background: transparent;
     border: none;
     cursor: pointer;

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -332,7 +332,7 @@ svg {
 }
 
 .search_bar select {
-    width: 120px;
+    width: 200px;
     font-size: 14px;
     height: 30px;
 }

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -300,8 +300,7 @@ svg {
     padding: 0;
     display: inline-block;
     text-align: left;
-    vertical-align: middle;
-    position: relative;
+    vertical-align: bottom;
 }
 
 .search_bar label {
@@ -316,7 +315,6 @@ svg {
 
 .search_bar .select {
     width: 110px;
-    margin-top: -17px;
 }
 
 #SentenceSearchForm {
@@ -377,14 +375,12 @@ svg {
 }
 
 .search-bar-extra {
-    text-align: center;
-    padding-right: 100px;
-    top: 3px;
-    position: relative;
+    text-align: right;
+    padding-right: 2px;
 }
 .search-bar-extra a {
     font-size: 13px;
-    margin: 10px;
+    margin-left: 20px;
 }
 
 .search-bar-extra a:hover {

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -127,11 +127,10 @@ svg {
 }
 
 #top_menu {
-    height: 30px;
     width: 960px;
     margin: auto;
-    font-size: 14px;
     overflow: hidden;
+    padding: 10px;
 }
 
 #top_menu .whatsNewItem {
@@ -152,13 +151,14 @@ svg {
  * Menu (Home, Browse, etc)
  */
 #top_menu ul {
+    display: inline-block;
     list-style: none;
-    margin: 0;
     padding: 0;
+    margin: 0;
 }
 
 #top_menu li {
-    float: left;
+    display: inline-block;
     padding: 0;
 }
 
@@ -198,6 +198,7 @@ svg {
     margin:0;
     padding:0;
     width:225px;
+    line-height: 24px;
 }
 
 #top_menu li:hover li a {
@@ -229,10 +230,6 @@ svg {
 /* 
  * Interface Language Selector
  */
-#languageSelectionContainer {
-    padding-top: 2px;
-    float: right;
-}
 
 #languageSelection {
     margin-left: 10px;
@@ -243,7 +240,9 @@ svg {
 /* 
  * User Menu 
  */
+#languageSelectionContainer,
 #user_menu {
+    line-height: 48px;
     float: right;
 }
 
@@ -439,22 +438,16 @@ svg {
 
 
 #logo {
-    position: absolute;
-    padding: 4px 12px;
-    z-index: 1;
-    border-top-right-radius: 40px;
-    border-bottom-right-radius: 32px;
-    background: #fff;
-    width: 64px;
-    height: 64px;
+    color: #EEEEEE;
+    font-size: 24px;
+    margin-right: 10px;
 }
 
-.tatoeba-name {
-    color: #EEEEEE;
-    position: absolute;
-    top: 2px;
-    left: 115px;
-    font-size: 18px;
+#logo .tatoeba-name,
+#logo img {
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0 5px;
 }
 
 #tatoeba {
@@ -604,7 +597,7 @@ svg {
  */
 #UserLoginForm_FromBar {
     position: absolute;
-    top: 30px;
+    top: 60px;
     z-index: 1000;
     min-width: 270px;
     padding: 5px 10px;

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -514,30 +514,46 @@ svg {
  * Footer 
  */
 #footer {
-    background: #e3e0d6;
+    background: #F5F5F5;
 }
 
-#footer a {
-    color: #3d3d3d;
-    cursor: pointer;
-    text-decoration: none;
+#footer .category {
+    width: 30%;
+    display: inline-block;
+    vertical-align: top;
+    padding: 10px;
+    font-size: 16px;
 }
+
+#footer .category h3 {
+    border-bottom: 1px solid #E2E2E2;
+    font-size: inherit;
+    font-weight: normal;
+    padding: 0 0 15px 0;
+}
+
 
 #footer ul {
-    display: block;
-    font-size: 80%;
-    text-align: right;
+    margin: 0;
+    padding: 0;
 }
-
 #footer li {
-    display: inline;
-    line-height: 30px;
-    text-align: center;
     list-style: none;
-    padding-left: 10px;
-    padding-right: 10px;
+    font-size: 15px;
+    margin: 5px 0;
 }
-
+#footer .license {
+    font-size: 15px;
+    margin-top: 20px;
+}
+#footer .license .text,
+#footer .cc-by-icon {
+    display: inline-block;
+}
+#footer .license .text {
+    max-width: 820px;
+    margin-left: 10px;
+}
 
 /*
  * HTML Elements

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -469,18 +469,16 @@ svg {
     width: 100%;
     background: #FFFFFF;
     min-height: 550px;
-    padding-top: 20px;
+    padding: 20px 0;
 }
 
 #annexe_content {
     float: right;
     width: 270px;
-    padding: 10px 20px 20px 20px;
 }
 
 #main_content {
     margin-right: 290px;
-    padding: 10px 20px 20px 20px;
 }
 
 .module {

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -289,10 +289,11 @@ svg {
     margin-left: 70px;
 }
 
-.search_bar #into {
+.search_bar #arrow {
     font-size: 1.3em;
-    margin-top: 20px;
     text-align: center;
+    cursor: pointer;
+    line-height: 30px;
 }
 
 .search_bar fieldset {

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -281,6 +281,8 @@ svg {
  */
 
 .search_bar {
+    color: #FFFFFF;
+    background-color: #66AA00;
     position: relative;
 }
 
@@ -364,12 +366,12 @@ svg {
 }
 
 .search_bar .search-submit-button {
-    color: #ffffff;
+    color: #AAAAAA;
     cursor: pointer;
-    background: #66AA00;
+    background: #F1F1F1;
     width: 70px;
     height: 30px;
-    border: 1px solid #66AA00;
+    border: 1px solid #EEEEEE;
     border-radius: 2px;
 }
 
@@ -387,6 +389,7 @@ svg {
     padding-right: 2px;
 }
 .search-bar-extra a {
+    color: #FFFFFF;
     font-size: 13px;
     margin-left: 20px;
 }

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -65,9 +65,23 @@
     padding: 5px;
 }
 
+.currentContributor .image,
+.currentContributor .info,
+.currentContributor .activityBar {
+    display: inline-block;
+    vertical-align: middle;
+}
+
 .currentContributor .image {
-    float: left;
     margin-right: 10px;
+}
+
+.currentContributor .image img {
+    display: block;
+}
+
+.currentContributor .info {
+    width: 155px;
 }
 
 .currentContributor .username {
@@ -76,13 +90,13 @@
 }
 
 .currentContributor .score {
+    display: inline-block;
     color: #777;
     font-size: 0.8em;
     line-height: 15px;
 }
 
 .activityBar {
-    float: right;
     border: 1px solid #CCC;
     width: 10px;
     margin: 2px 0;

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -1438,7 +1438,6 @@ div.hideLink {
  */
 .sentencesStats {
     margin: 5px 0;
-    padding-left: 20px;
 }
 
 .stat {

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -976,7 +976,7 @@
 }
 
 .sentence .content.column {
-    width: 500px;
+    width: 540px;
 }
 
 .sentence .audio.column {
@@ -1446,14 +1446,17 @@ div.hideLink {
     margin: 5px 0;
 }
 
+.stat .total,
+.stat .langCode {
+    display: inline-block;
+}
+
 .stat .langCode {
     display: none;
 }
 
 .stat .total {
-    line-height: 20px;
-    float: left;
-    display: block;
+    width: 200px;
     margin: 0 5px;
 }
 

--- a/app/webroot/css/pages/index.css
+++ b/app/webroot/css/pages/index.css
@@ -56,6 +56,10 @@
     padding: 50px;
 }
 
+.topContent .description {
+    padding: 0 10px;
+}
+
 .topContent strong {
     font-size: 24px;
 }

--- a/app/webroot/css/pages/index.css
+++ b/app/webroot/css/pages/index.css
@@ -51,9 +51,8 @@
  * Tatoeba short description
  */
 .topContent {
-    margin-bottom: 50px;
     background: #F5F5F5;
-    padding: 50px;
+    padding: 60px 0 50px 0;
 }
 
 .topContent .description {
@@ -62,4 +61,92 @@
 
 .topContent strong {
     font-size: 24px;
+}
+
+
+/*
+ * Search
+ */
+#new-search-bar {
+    padding: 10px;
+    margin-top: 20px;
+    color: #777;
+}
+
+#new-search-bar fieldset {
+    padding: 2px 0;
+}
+
+#new-search-bar .search-input {
+    position: relative;
+    width: 800px;
+}
+
+#new-search-bar #SentenceQuery {
+    padding: 10px;
+    width: 800px;
+    margin-left: -4px;
+}
+
+#new-search-bar #clearSearch {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: #CCCCCC;
+    position: absolute;
+    right: 5px;
+    font-size: 24px;
+    line-height: 46px;
+}
+
+#new-search-bar .search-input,
+#new-search-bar .submit {
+    display: inline-block;
+    vertical-align: middle;
+}
+
+#new-search-bar .search-submit-button {
+    color: #ffffff;
+    cursor: pointer;
+    background: #66AA00;
+    width: 70px;
+    height: 42px;
+    border: 1px solid #66AA00;
+    border-radius: 2px;
+}
+
+#new-search-bar .search-submit-button svg {
+    display: block;
+    margin: auto;
+    width: 24px;
+    height: 24px;
+    vertical-align: middle;
+    padding-top: 2px;
+}
+
+#new-search-bar .extra-links {
+    width: 820px;
+}
+
+#new-search-bar .extra-links em {
+    color: #000000;
+}
+
+#new-search-bar .advanced-search {
+    float: right;
+}
+
+::-webkit-input-placeholder { /* WebKit, Blink, Edge */
+    color: #cccccc;
+}
+:-moz-placeholder { /* Mozilla Firefox 4 to 18 */
+    color: #cccccc;
+    opacity:  1;
+}
+::-moz-placeholder { /* Mozilla Firefox 19+ */
+    color: #cccccc;
+    opacity:  1;
+}
+:-ms-input-placeholder { /* Internet Explorer 10-11 */
+    color: #cccccc;
 }

--- a/app/webroot/css/pages/index.css
+++ b/app/webroot/css/pages/index.css
@@ -21,7 +21,7 @@
  * Random sentence
  */
 #randomLangChoice {
-    width: 110px;
+    width: 200px;
 }
 
 

--- a/app/webroot/css/pages/index.css
+++ b/app/webroot/css/pages/index.css
@@ -83,7 +83,7 @@
 }
 
 #new-search-bar #SentenceQuery {
-    padding: 10px;
+    padding: 10px 40px 10px 10px;
     width: 800px;
     margin-left: -4px;
 }

--- a/app/webroot/css/pages/index.css
+++ b/app/webroot/css/pages/index.css
@@ -51,12 +51,16 @@
  * Tatoeba short description
  */
 .topContent {
-    background: #F5F5F5;
-    padding: 60px 0 50px 0;
+    padding: 0 0 50px 0;
+}
+
+.topContent .descriptionBar {
+    background: #6A0;
+    color: #FFF;
 }
 
 .topContent .description {
-    padding: 0 10px;
+    padding: 40px 0 50px 10px;
 }
 
 .topContent strong {

--- a/app/webroot/css/pages/index.css
+++ b/app/webroot/css/pages/index.css
@@ -172,7 +172,6 @@
     padding: 2px 0;
 }
 
-#annexe_content .join-us,
-#annexe_content .stats {
+#annexe_content .join-us {
     font-size: 15px;
 }

--- a/app/webroot/css/pages/index.css
+++ b/app/webroot/css/pages/index.css
@@ -51,7 +51,6 @@
  * Tatoeba short description
  */
 .topContent {
-    padding: 0 0 50px 0;
 }
 
 .topContent .descriptionBar {
@@ -60,7 +59,7 @@
 }
 
 .topContent .description {
-    padding: 40px 0 50px 10px;
+    padding: 50px 10px;
 }
 
 .topContent strong {
@@ -72,7 +71,7 @@
  * Search
  */
 #new-search-bar {
-    padding: 10px;
+    padding: 25px 10px;
     margin-top: 20px;
     color: #777;
 }
@@ -114,7 +113,7 @@
     cursor: pointer;
     background: #66AA00;
     width: 70px;
-    height: 42px;
+    height: 44px;
     border: 1px solid #66AA00;
     border-radius: 2px;
 }

--- a/app/webroot/css/pages/index.css
+++ b/app/webroot/css/pages/index.css
@@ -150,3 +150,26 @@
 :-ms-input-placeholder { /* Internet Explorer 10-11 */
     color: #cccccc;
 }
+
+
+/*
+ *
+ */
+
+.join-us .registerLink {
+    margin: 20px 0;
+    width: 180px;
+}
+
+.guest-sentences-stats {
+    padding: 10px 0;
+}
+
+.guest-sentences-stats .stat {
+    padding: 2px 0;
+}
+
+#annexe_content .join-us,
+#annexe_content .stats {
+    font-size: 15px;
+}

--- a/app/webroot/css/pages/index.css
+++ b/app/webroot/css/pages/index.css
@@ -52,53 +52,10 @@
  */
 .topContent {
     margin-bottom: 50px;
-    font-size: 40px;
+    background: #F5F5F5;
+    padding: 50px;
 }
 
-.topContent ul {
-    list-style: none;
-}
-
-.topContent .description,
-.topContent .links {
-    display: inline-block;
-    vertical-align: middle;
-    padding: 20px 40px;
-    box-sizing : border-box;
-}
-
-.topContent .description {
-    width: 65%;
-    text-align: center;
-}
-
-.topContent .links {
-    width: 35%;
-    text-align: center;
-}
-
-.topContent .links a {
-    display: inline-block;
-    padding: 15px;
-    margin: 10px 0;
-    min-width: 240px;
-    font-size: 30px;
-}
-
-.topContent .registerButton {
-    background: #6A0;
-    color: #fff;
-}
-
-.topContent .loginButton {
-    background: #06A;
-    color: #fff;
-}
-
-.topContent .links .learnMore {
-    display: inline-block;
-    border: 1px solid #6A0;
-    color: #6A0;
-    padding: 5px 15px;
+.topContent strong {
     font-size: 24px;
 }

--- a/app/webroot/css/pages/index.css
+++ b/app/webroot/css/pages/index.css
@@ -125,7 +125,7 @@
 }
 
 #new-search-bar .extra-links {
-    width: 820px;
+    width: 850px;
 }
 
 #new-search-bar .extra-links em {

--- a/app/webroot/css/sentences/advanced_search.css
+++ b/app/webroot/css/sentences/advanced_search.css
@@ -41,7 +41,7 @@ fieldset#advsearch-sort {
 }
 
 #AdvancedSearchSearchForm fieldset {
-    width: 370px;
+    width: 390px;
 }
 
 #AdvancedSearchFrom,

--- a/app/webroot/css/sentences/search.css
+++ b/app/webroot/css/sentences/search.css
@@ -44,17 +44,6 @@
 /*
  * Advanced search form
  */
-#annexe_content {
-    float: right;
-    width: auto;
-    padding: 10px 0 0;
-    margin: 0 5px;
-}
-
-#annexe_content h2 {
-    width: 280px;
-}
-
 legend {
     font-size: 15px;
 }

--- a/app/webroot/css/sentences/show.css
+++ b/app/webroot/css/sentences/show.css
@@ -25,7 +25,7 @@
 }
 
 .languageSelect select {
-    width: 120px;
+    width: 200px;
 }
 
 .smallTip {

--- a/app/webroot/img/search.svg
+++ b/app/webroot/img/search.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- http://www.flaticon.com/free-icon/musica-searcher_70376 -->
 <svg version="1.1" id="search" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-     width="20" height="20" viewBox="0 0 250.313 250.313" xml:space="preserve">
+     viewBox="0 0 250.313 250.313" xml:space="preserve">
 <g>
     <path d="M244.186,214.604l-54.379-54.378c-0.289-0.289-0.628-0.491-0.93-0.76
         c10.7-16.231,16.945-35.66,16.945-56.554C205.822,46.075,159.747,0,102.911,0S0,46.075,0,102.911

--- a/app/webroot/img/search.svg
+++ b/app/webroot/img/search.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- http://www.flaticon.com/free-icon/musica-searcher_70376 -->
 <svg version="1.1" id="search" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-     width="20" height="20" fill="#AAAAAA" viewBox="0 0 250.313 250.313" xml:space="preserve">
+     width="20" height="20" viewBox="0 0 250.313 250.313" xml:space="preserve">
 <g>
     <path d="M244.186,214.604l-54.379-54.378c-0.289-0.289-0.628-0.491-0.93-0.76
         c10.7-16.231,16.945-35.66,16.945-56.554C205.822,46.075,159.747,0,102.911,0S0,46.075,0,102.911


### PR DESCRIPTION
This pull request addresses issue #947.

The homepage has been redesigned based on [@billoliver and @kamillel's work](https://github.com/Tatoeba/tatoeba2/issues/947#issuecomment-192708682). This redesign implied changing the general layout and the organization of the menu and footer.

-----

Some comments about the implementation:

(1) I skipped certain things because of lack of time:
  * the Twitter and Facebook icons --> @kamillel said it's fine to leave them as text links.
  * the number of sentences with audio --> nobody complained so I'm not going to add this.

(2) I skipped some other things because I didn't want redesign core design elements in the scope of this issue: the design of the dropdowns, the design of the modules in the content (there's no bottom border), the fonts.
--> @kamillel agreed it's better to leave them as they are, to align with the rest of the site.

(3) The search bar on the rest of the pages has been slightly redesigned to match the new search bar on the homepage. It was just a matter of changing some colors, as [illustrated by billoliver](https://github.com/Tatoeba/tatoeba2/issues/947#issuecomment-193024810).

(4) The item "Any" in the language dropdown has been modified into "Any language" as suggested by CK.

(5) CK made various [other suggestions](https://github.com/Tatoeba/tatoeba2/issues/947#issuecomment-193021043) that I did not take into account because I didn't feel they were a problem and nobody expressed they were in favor applying of those changes.

-----

I'll bump this topic on Tatoeba's Wall one last time and if there's no complaint I'll merge this so it can go into this Saturday's update.