### PR TITLE
Ara rename

### DIFF
--- a/app/vendors/languages_lib.php
+++ b/app/vendors/languages_lib.php
@@ -50,7 +50,7 @@ class LanguagesLib
             'abk' => 'ab', // Abkhaz
             'afr' => 'af', // Afrikaans
             'amh' => 'am', // Amharic
-            'ara' => 'ar', // Arabic
+            'arb' => 'ar', // Arabic
             'arg' => 'an', // Aragonese
             'asm' => 'as', // Assamese
             'aym' => 'ay', // Aymara
@@ -232,7 +232,7 @@ class LanguagesLib
         if (!$languages || $currentLang != $lastLang) {
             $lastLang = $currentLang;
             $languages = array(
-                'ara' => __d('languages', 'Arabic', true),
+                'arb' => __d('languages', 'Arabic', true),
                 'eng' => __d('languages', 'English', true),
                 'jpn' => __d('languages', 'Japanese', true),
                 'fra' => __d('languages', 'French', true),
@@ -520,7 +520,7 @@ class LanguagesLib
                 'mww' => __d('languages', 'Hmong Daw (White)',true),
                 'bcl' => __d('languages', 'Bikol (Central)',true),
                 'nau' => __d('languages', 'Nauruan',true),
-                
+
             );
         }
         return $languages;
@@ -566,7 +566,7 @@ class LanguagesLib
         $direction = "ltr";
 
         $rightToLeftLangs = array(
-            "ara",
+            "arb",
             "heb",
             "arz",
             "uig",
@@ -580,7 +580,7 @@ class LanguagesLib
             "oar",
             "ary",
             "aii",
-            
+
         );
 
         if (in_array($lang, $rightToLeftLangs)) {

--- a/app/vendors/languages_lib.php
+++ b/app/vendors/languages_lib.php
@@ -232,7 +232,7 @@ class LanguagesLib
         if (!$languages || $currentLang != $lastLang) {
             $lastLang = $currentLang;
             $languages = array(
-                'arb' => __d('languages', 'Arabic', true),
+                'arb' => __d('languages', 'Arabic (Modern Standard)', true),
                 'eng' => __d('languages', 'English', true),
                 'jpn' => __d('languages', 'Japanese', true),
                 'fra' => __d('languages', 'French', true),
@@ -264,7 +264,7 @@ class LanguagesLib
                 'lat' => __d('languages', 'Latin', true),
                 // TODO to change when shanghainese will not be the only wu dialect
                 'wuu' => __d('languages', 'Shanghainese', true),
-                'arz' => __d('languages', 'Egyptian Arabic', true),
+                'arz' => __d('languages', 'Arabic Dialect (Egyptian)', true),
                 'bel' => __d('languages', 'Belarusian', true),
                 'hun' => __d('languages', 'Hungarian', true),
                 'isl' => __d('languages', 'Icelandic', true),
@@ -287,7 +287,7 @@ class LanguagesLib
                 'slk' => __d('languages', 'Slovak', true),
                 'dan' => __d('languages', 'Danish', true),
                 'hye' => __d('languages', 'Armenian', true),
-                'acm' => __d('languages', 'Iraqi Arabic', true),
+                'acm' => __d('languages', 'Arabic Dialect (Iraqi)', true),
                 'san' => __d('languages', 'Sanskrit', true),
                 'urd' => __d('languages', 'Urdu', true),
                 'hin' => __d('languages', 'Hindi', true),
@@ -361,7 +361,7 @@ class LanguagesLib
                 'lao' => __d('languages', 'Lao',true),
                 'bod' => __d('languages', 'Tibetan',true),
                 'hil' => __d('languages', 'Hiligaynon',true),
-                'arq' => __d('languages', 'Algerian Arabic',true),
+                'arq' => __d('languages', 'Arabic Dialect (Algerian)',true),
                 'pcd' => __d('languages', 'Picard',true),
                 'grc' => __d('languages', 'Ancient Greek',true),
                 'amh' => __d('languages', 'Amharic',true),
@@ -488,7 +488,7 @@ class LanguagesLib
                 'fuv' => __d('languages', 'Nigerian Fulfulde',true),
                 'hoc' => __d('languages', 'Ho',true),
                 'sun' => __d('languages', 'Sundanese',true),
-                'apc' => __d('languages', 'North Levantine Arabic',true),
+                'apc' => __d('languages', 'Arabic Dialect (North Levantine)',true),
                 'tyv' => __d('languages', 'Tuvinian',true),
                 'krc' => __d('languages', 'Karachay-Balkar',true),
                 'pap' => __d('languages', 'Papiamento',true),
@@ -496,7 +496,7 @@ class LanguagesLib
                 'ori' => __d('languages', 'Odia (Oriya)',true),
                 'iba' => __d('languages', 'Iban',true),
                 'oar' => __d('languages', 'Old Aramaic',true),
-                'ary' => __d('languages', 'Moroccan Arabic',true),
+                'ary' => __d('languages', 'Arabic Dialect (Moroccan)',true),
                 'cyo' => __d('languages', 'Cuyonon',true),
                 'ibo' => __d('languages', 'Igbo',true),
                 'csb' => __d('languages', 'Kashubian',true),

--- a/docs/database/updates/2016-04-13.sql
+++ b/docs/database/updates/2016-04-13.sql
@@ -1,0 +1,39 @@
+UPDATE sentences
+SET lang = 'arb'
+WHERE lang = 'ara';
+
+UPDATE languages
+SET code = 'arb'
+WHERE code = 'ara';
+
+UPDATE contributions
+SET sentence_lang = 'arb'
+WHERE sentence_lang = 'ara';
+
+UPDATE contributions
+SET translation_lang = 'arb'
+WHERE translation_lang = 'ara';
+
+UPDATE last_contributions
+SET sentence_lang = 'arb'
+WHERE sentence_lang = 'ara';
+
+UPDATE last_contributions
+SET translation_lang = 'arb'
+WHERE translation_lang = 'ara';
+
+UPDATE sentences_translations
+SET sentence_lang = 'arb'
+WHERE sentence_lang = 'ara';
+
+UPDATE sentences_translations
+SET translation_lang = 'arb'
+WHERE translation_lang = 'ara';
+
+UPDATE users_languages
+SET language_code = 'arb'
+WHERE language_code = 'ara';
+
+UPDATE contributions_stats
+SET lang = 'arb'
+WHERE lang = 'ara';


### PR DESCRIPTION
While I'm still disillusioned by the discussion on #1084 which amounts to a projection of a disgraceful and malicious victimhood mentality on none other than a technical issue tracker, I think something can be done to more explicitly indicate that Tatoeba isn't in the business of making political decisions.

This pull request has a few sql update statements to relabel ara and relabels arabic corpora with the pattern Arabic Dialect (...). Please check if I missed a table that should be updated and if active contributors on these corpora object to this change. Also I'm not sure what the impact on urls is gonna be from these changes for seo purposes.

@trang I think you should reconsider the current wave of migration of nontechnical discussions to github instead of confining them to the wall.