### PR TITLE
Fixed conversion of query parameters to controller action arguments

### DIFF
--- a/app/controllers/sentences_lists_controller.php
+++ b/app/controllers/sentences_lists_controller.php
@@ -393,14 +393,6 @@ class SentencesListsController extends AppController
      */
     public function of_user($username, $filter = null)
     {
-        $this->set('username', $username);
-        $userId = $this->User->getIdFromUsername($username);
-        if (empty($userId)) {
-            $backLink = $this->referer(array('action'=>'index'), true);
-            $this->set('backLink', $backLink);
-            $this->set("userExists", false);
-            return;
-        }
         if (isset($this->params['url']['username'])) {
             $usernameParam = $this->params['url']['username'];
         }
@@ -412,6 +404,15 @@ class SentencesListsController extends AppController
             $this->redirect(array('action' => 'of_user', $usernameParam, $searchParam));
         } else if (empty($username)) {
             $this->redirect(array('action' => 'index'));
+        }
+
+        $this->set('username', $username);
+        $userId = $this->User->getIdFromUsername($username);
+        if (empty($userId)) {
+            $backLink = $this->referer(array('action'=>'index'), true);
+            $this->set('backLink', $backLink);
+            $this->set("userExists", false);
+            return;
         }
 
         $visibility = null;

--- a/app/controllers/sentences_lists_controller.php
+++ b/app/controllers/sentences_lists_controller.php
@@ -388,7 +388,7 @@ class SentencesListsController extends AppController
     /**
      * Displays the lists of a specific user.
      *
-     * @param int    $username Username of of the user we want lists of.
+     * @param string $username Username of of the user we want lists of.
      * @param string $filter   Search query on name of list.
      */
     public function of_user($username, $filter = null)

--- a/app/controllers/sentences_lists_controller.php
+++ b/app/controllers/sentences_lists_controller.php
@@ -391,7 +391,7 @@ class SentencesListsController extends AppController
      * @param string $username Username of of the user we want lists of.
      * @param string $filter   Search query on name of list.
      */
-    public function of_user($username, $filter = null)
+    public function of_user($username=null, $filter = null)
     {
         if (isset($this->params['url']['username'])) {
             $usernameParam = $this->params['url']['username'];


### PR DESCRIPTION
This pull request addresses issue #1081

When search is initiated from search form, the following query string is requested:
/sentences_lists/of_user**?username={username}&search={list-name}**
controller fails to parse out username argument so, before it is used we have to look for it in `$this->params['url']` and redirect to proper action to form the query string
/sentences_lists/of_user**/{username}/{list-name}**

So, I just moved the code analyzing query parameters above the code playing with controller action arguments and allowed both arguments to be null (to avoid warnings).