### PR TITLE
Corrected afb and arb to be right to left

### DIFF
--- a/app/vendors/languages_lib.php
+++ b/app/vendors/languages_lib.php
@@ -590,6 +590,8 @@ class LanguagesLib
             "oar",
             "ary",
             "aii",
+            "afb",
+            "arb"
             
         );
 


### PR DESCRIPTION
This pull request addresses issue #1106.