### PR TITLE
Got rid of unnecessary regexp substitutions during match highlighting

### DIFF
--- a/app/views/helpers/sentences.php
+++ b/app/views/helpers/sentences.php
@@ -660,13 +660,12 @@ class SentencesHelper extends AppHelper
         foreach ($excerpts as $excerpt) {
             $excerpt = h($excerpt);
             $from = str_replace($markers, '', $excerpt);
-            $from = '/'.preg_quote($from, '/').'/';
             $to = str_replace(
                 $markers,
                 array('<span class="match">', '</span>'),
                 $excerpt
             );
-            $text = preg_replace($from, $to, $text);
+            $text = str_replace($from, $to, $text);
         }
         return $text;
     }


### PR DESCRIPTION
This PR addresses issue #1119.
As I expected from the first glance at disappearing "$10", this issue was related to some unnecessary interpretation of "$10" as a variable. It appeared to be that this interpreter was `preg_replace`. Although the search string itself was quoted to be replacement safe, the source string itself was subject to magic that's why some other unexpected substitutions are possible. Since in his case straightforward string-to-string replacement is intended, usage of `preg_quote` is not only an overkill but also incorrect.
Quote from [str_replace manual page](http://php.net/manual/en/function.str-replace.php):

> If you don't need fancy replacing rules (like regular expressions), you should always use this function instead of preg_replace().