### PR TITLE
Misalignment of "Help", "Advanced Search" with "From" and "To"

### DIFF
--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -406,6 +406,7 @@ rt {
 .search-bar-extra {
     text-align: right;
     padding-right: 2px;
+    padding-bottom: 2px;
 }
 .search-bar-extra a {
     color: #FFFFFF;


### PR DESCRIPTION
This pull request addresses issue #1072

Just added padding at the bottom.  I wasn't assigned but it was a quick enough fix.