### PR TITLE
Unclear "Click to edit" message when user tries to delete all sentence content

### DIFF
--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -1265,6 +1265,11 @@
     color: #fff;
 }
 
+.editableSentence button[disabled]{
+    background-color: #ccc;
+    border-color: #aaa;
+}
+
 .editableSentence textarea{
     margin: 0;
     padding: 0;

--- a/app/webroot/js/sentences.edit_in_place.js
+++ b/app/webroot/js/sentences.edit_in_place.js
@@ -28,6 +28,13 @@ $(document).ready(function() {
         div.editable(rootUrl + '/sentences/edit_sentence', {
             type      : 'textarea',
             submit    : div.attr('data-submit'),
+            onsubmit  : function () {
+                if($(this).find('textarea').val().trim().length == 0){
+                    return false;
+                } else {
+                    return true;   
+                }
+            },
             cancel    : div.attr('data-cancel'),
             event     : 'edit_sentence',
             data : function(value, settings) {
@@ -53,9 +60,23 @@ $(document).ready(function() {
             cssclass  : 'editInPlaceForm',
             onblur    : 'ignore'
         }).bind('edit_sentence', function(e) {
+            $(this).find('textarea').keyup(function(event) {
+                var submitBtn = $(this).parent().find('button[type=submit]');
+                if($(this).val().trim().length == 0) {
+                    submitBtn.prop('disabled', true);
+                    submitBtn.css("background-color","gray");
+                }
+                else {
+                    submitBtn.prop('disabled', false);
+                    submitBtn.css("background-color","");
+                }
+                
+            }); 
             $(this).find('textarea').keydown(function(event) {
-                if (event.which == 13)
-                    $(this).closest('form').submit();
+                if (event.which == 13){
+                    event.preventDefault();
+                    $(this).closest('form').submit();   
+                }
             });
         });
     });

--- a/app/webroot/js/sentences.edit_in_place.js
+++ b/app/webroot/js/sentences.edit_in_place.js
@@ -34,7 +34,7 @@ $(document).ready(function() {
                 } else {
                     return true;   
                 }
-            },
+            }, 
             cancel    : div.attr('data-cancel'),
             event     : 'edit_sentence',
             data : function(value, settings) {
@@ -64,11 +64,9 @@ $(document).ready(function() {
                 var submitBtn = $(this).parent().find('button[type=submit]');
                 if($(this).val().trim().length == 0) {
                     submitBtn.prop('disabled', true);
-                    submitBtn.css("background-color","gray");
                 }
                 else {
                     submitBtn.prop('disabled', false);
-                    submitBtn.css("background-color","");
                 }
                 
             }); 


### PR DESCRIPTION
This pull request addresses issue #307.

I still am not sure entirely of the spacing format, so I am sure it is incorrect at the moment. Would be happy to fix it if I know what to fix!