### PR TITLE
@username can produce multiple notification emails

### DIFF
--- a/app/controllers/components/mailer.php
+++ b/app/controllers/components/mailer.php
@@ -95,7 +95,8 @@ class MailerComponent extends Object
             . '#comments';
         $recipientIsOwner = ($recipient == $sentenceOwner);
         $commentText = $comment['text'];
-
+        $sentenceText = $comment['sentence_text'];
+        
         $this->Email->to = $recipient;
         $this->Email->subject = $subject;
         $this->Email->template = 'comment_on_sentence';
@@ -104,7 +105,8 @@ class MailerComponent extends Object
         $this->set('linkToSentence', $linkToSentence);
         $this->set('commentText', $commentText);
         $this->set('recipientIsOwner', $recipientIsOwner);
-
+        $this->set('sentenceText', $sentenceText);
+        
         $this->_send();
     }
 

--- a/app/controllers/sentence_comments_controller.php
+++ b/app/controllers/sentence_comments_controller.php
@@ -216,6 +216,13 @@ class SentenceCommentsController extends AppController
                 $participants[] = $sentenceOwner;
             }
 
+            $commentId = $this->SentenceComment->id;
+            $mentionEmails = $this->_getMentionEmails($comment, $commentId);
+            foreach($mentionEmails as $email) {
+                $participants[] = $email;
+            }
+            $participants = array_unique($participants);
+            
             // send message to the other participants of the thread
             foreach ($participants as $participant) {
                 if ($participant != $userEmail) {
@@ -227,9 +234,7 @@ class SentenceCommentsController extends AppController
                 }
             }
 
-            $commentId = $this->SentenceComment->id;
-            $this->_sendMentionsNotifications($comment, $commentId);
-
+            
             $this->flash(
                 __('Your comment has been saved.', true),
                 '/sentence_comments/show/'
@@ -258,6 +263,29 @@ class SentenceCommentsController extends AppController
             }
         }
     }
+    
+    private function _getMentionEmails($comment, $commentId)
+    {
+        preg_match_all(
+            "/@[a-zA-Z0-9_]+/",
+            $comment['text'],
+            $usernames
+        );
+        $emails = array();
+        foreach ($usernames[0] as $string) {
+            $username = substr($string, 1);
+            $user = $this->User->findByUsername($username);
+            $sendNotif = !empty($user) && $username != CurrentUser::get('username')
+                && $user['User']['send_notifications'] == 1;
+            if ($sendNotif) {
+                $emails[] = $user['User']['email'];
+                //$this->Mailer->sendMentionNotification($email, $comment, $commentId);
+            }
+        }
+        
+        return $emails;
+    }
+
 
     /**
      * Edit comment

--- a/app/controllers/sentence_comments_controller.php
+++ b/app/controllers/sentence_comments_controller.php
@@ -279,7 +279,6 @@ class SentenceCommentsController extends AppController
                 && $user['User']['send_notifications'] == 1;
             if ($sendNotif) {
                 $emails[] = $user['User']['email'];
-                //$this->Mailer->sendMentionNotification($email, $comment, $commentId);
             }
         }
         

--- a/app/controllers/sentence_comments_controller.php
+++ b/app/controllers/sentence_comments_controller.php
@@ -259,7 +259,6 @@ class SentenceCommentsController extends AppController
                 && $user['User']['send_notifications'] == 1;
             if ($sendNotif) {
                 $emails[] = $user['User']['email'];
-                //$this->Mailer->sendMentionNotification($email, $comment, $commentId);
             }
         }
         

--- a/app/controllers/sentence_comments_controller.php
+++ b/app/controllers/sentence_comments_controller.php
@@ -217,7 +217,7 @@ class SentenceCommentsController extends AppController
             }
 
             $commentId = $this->SentenceComment->id;
-            $mentionEmails = $this->_getMentionEmails($comment, $commentId);
+            $mentionEmails = $this->_getMentionedEmails($comment, $commentId);
             foreach($mentionEmails as $email) {
                 $participants[] = $email;
             }
@@ -244,27 +244,7 @@ class SentenceCommentsController extends AppController
     }
 
 
-    private function _sendMentionsNotifications($comment, $commentId)
-    {
-        preg_match_all(
-            "/@[a-zA-Z0-9_]+/",
-            $comment['text'],
-            $usernames
-        );
-
-        foreach ($usernames[0] as $string) {
-            $username = substr($string, 1);
-            $user = $this->User->findByUsername($username);
-            $sendNotif = !empty($user) && $username != CurrentUser::get('username')
-                && $user['User']['send_notifications'] == 1;
-            if ($sendNotif) {
-                $email = $user['User']['email'];
-                $this->Mailer->sendMentionNotification($email, $comment, $commentId);
-            }
-        }
-    }
-    
-    private function _getMentionEmails($comment, $commentId)
+    private function _getMentionedEmails($comment, $commentId)
     {
         preg_match_all(
             "/@[a-zA-Z0-9_]+/",
@@ -279,6 +259,7 @@ class SentenceCommentsController extends AppController
                 && $user['User']['send_notifications'] == 1;
             if ($sendNotif) {
                 $emails[] = $user['User']['email'];
+                //$this->Mailer->sendMentionNotification($email, $comment, $commentId);
             }
         }
         

--- a/app/views/elements/email/html/comment_on_sentence.ctp
+++ b/app/views/elements/email/html/comment_on_sentence.ctp
@@ -1,16 +1,12 @@
 <?php
 $author = "<strong>$author</strong>";
-if ($recipientIsOwner) {
-    echo $html->tag('p', sprintf(
-        '%s has posted a comment on one of your sentences.',
-        $author
-    ));
-} else {
-    echo $html->tag('p', sprintf(
-        '%s has posted a comment on a sentence where you also posted a comment.',
-        $author
-    ));
-}
+
+echo $html->tag('p', sprintf(
+    "%s has posted a comment on sentence '%s'.",
+    $author,
+    $sentenceText
+));
+
 
 echo $html->div(null, $messages->formatedContent($commentText),
     array(


### PR DESCRIPTION
This pull request addresses issue #932.

It seems like this is probably some code we can get rid of (i.e. views/elements/email/html/user_mentioned_in_comment.ctp I think can be removed completely), but I wasn't sure if this was a different issue or if we want to try and eliminate any unneeded code now.