### PR TITLE
Made human friendly error message on invalid sphinx queries and made $ searchable.

### DIFF
--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -522,6 +522,19 @@ class SentencesController extends AppController
         }
     }
 
+    private function _find_sphinx_markers($query)
+    {
+        // TODO take into account escaped sequences
+        $sphinx_markers = array('"', '/', '$', '^', '-', '|', '!');
+        $result = array();
+        foreach ($sphinx_markers as $marker) {
+            if (strpos($query, $marker) !== false) {
+                $result[] = $marker;
+            }
+        }
+        return $result;
+    }
+
     /**
      * Search sentences.
      *
@@ -774,6 +787,10 @@ class SentencesController extends AppController
             $sphinx['filter'][] = array('has_audio', $audio);
         }
 
+        $sphinx_markers = $this->_find_sphinx_markers($query);
+        if (!empty($sphinx_markers)) {
+            $this->set(compact('sphinx_markers'));
+        }
         $search_disabled = !Configure::read('Search.enabled');
         if (!$search_disabled) {
             $model = 'Sentence';

--- a/app/models/behaviors/sphinx.php
+++ b/app/models/behaviors/sphinx.php
@@ -54,28 +54,23 @@ class SphinxBehavior extends ModelBehavior
      */
     function beforeFind(&$model, $query)
     {
-        if (empty($query['sphinx']))
+        if (empty($query['sphinx'])) {
             return true;
+        }
 
-        if ($model->findQueryType == 'count')
-        {
+        if ($model->findQueryType == 'count') {
             $query['limit'] = 1;
             $query['page'] = 1;
-        }
-        else if (empty($query['limit']))
-        {
+        } else if (empty($query['limit'])) {
             $query['limit'] = 9999999;
             $query['page'] = 1;
         }
 
         $sphinx = $this->runtime[$model->alias]['sphinx'];
-        foreach ($query['sphinx'] as $key => $setting)
-        {
-            switch ($key)
-            {
+        foreach ($query['sphinx'] as $key => $setting) {
+            switch ($key) {
                 case 'filter':
-                    foreach ($setting as $arg)
-                    {
+                    foreach ($setting as $arg) {
                         $arg[2] = empty($arg[2]) ? false : $arg[2];
                         $sphinx->SetFilter($arg[0], (array)$arg[1], $arg[2]);
                     }
@@ -83,8 +78,7 @@ class SphinxBehavior extends ModelBehavior
                 case 'filterRange':
                 case 'filterFloatRange':
                     $method = 'Set' . $key;
-                    foreach ($setting as $arg)
-                    {
+                    foreach ($setting as $arg) {
                         $arg[3] = empty($arg[3]) ? false : $arg[3];
                         $sphinx->{$method}($arg[0], (array)$arg[1], $arg[2], $arg[3]);
                     }
@@ -99,12 +93,9 @@ class SphinxBehavior extends ModelBehavior
                     $sphinx->SetFieldWeights($setting);
                     break;
                 case 'rankingMode': 
-                    if (is_array($setting))
-                    {
+                    if (is_array($setting)) {
                         $sphinx->SetRankingMode(key($setting), reset($setting));
-                    }
-                    else
-                    {
+                    } else {
                         $sphinx->SetRankingMode($setting);
                     }
                     break;
@@ -121,15 +112,11 @@ class SphinxBehavior extends ModelBehavior
 
         $result = $sphinx->Query($this->escapeQuery($query['search']), $indexes);
 
-        if ($result === false)
-        {
+        if ($result === false) {
             trigger_error("Search query failed: " . $sphinx->GetLastError());
             return false;
-        }
-        else if(isset($result['matches']))
-        {
-            if ($sphinx->GetLastWarning())
-            {
+        } else if(isset($result['matches'])) {
+            if ($sphinx->GetLastWarning()) {
                 trigger_error("Search query warning: " . $sphinx->GetLastWarning());
             }
         }
@@ -138,21 +125,19 @@ class SphinxBehavior extends ModelBehavior
         unset($query['order']);
         unset($query['offset']);
         $query['page'] = 1;
-        if ($model->findQueryType == 'count')
-        {
+        if ($model->findQueryType == 'count') {
             $result['total'] = !empty($result['total']) ? $result['total'] : 0;
             $query['fields'] = 'ABS(' . $result['total'] . ') AS count';
 
-        }
-        else
-        {
+        } else {
             $this->_cached_result = $result;
             $this->_cached_query = $query['search'];
     
-            if (isset($result['matches']))
+            if (isset($result['matches'])) {
                 $ids = array_keys($result['matches']);
-            else
+            } else {
                 $ids = array(0);
+            }
             $query['conditions'] = array($model->alias . '.'.$model->primaryKey => $ids);
             $query['order'] = 'FIND_IN_SET('.$model->alias.'.'.$model->primaryKey.', \'' . implode(',', $ids) . '\')';
 

--- a/app/models/behaviors/sphinx.php
+++ b/app/models/behaviors/sphinx.php
@@ -110,7 +110,7 @@ class SphinxBehavior extends ModelBehavior
 
         $indexes = !empty($query['sphinx']['index']) ? implode(',' , $query['sphinx']['index']) : '*';
 
-        $result = $sphinx->Query($this->escapeQuery($query['search']), $indexes);
+        $result = $sphinx->Query($query['search'], $indexes);
 
         if ($result === false) {
             trigger_error("Search query failed: " . $sphinx->GetLastError());
@@ -144,11 +144,6 @@ class SphinxBehavior extends ModelBehavior
         }
 
         return $query;
-    }
-
-    private function escapeQuery($search)
-    {
-      return str_replace('/', '\\/', $search);
     }
 
     private function addHighlightMarkers($model, &$results, $search) {
@@ -198,10 +193,10 @@ class SphinxBehavior extends ModelBehavior
     }
 
     public function afterFind(&$model, $results, $primary) {
-        if(!is_null($this->_cached_query)) {
+        if (!is_null($this->_cached_query)) {
             $search = $this->_cached_query;
             if ($search) {
-                $this->addHighlightMarkers($model, $results, $this->escapeQuery($search));
+                $this->addHighlightMarkers($model, $results, $search);
             }
             $this->_cached_query = null;
         }

--- a/app/vendors/shells/sphinx_conf.php
+++ b/app/vendors/shells/sphinx_conf.php
@@ -200,6 +200,11 @@ class SphinxConfShell extends Shell {
         'tha' => array('U+0E01..U+0E2E', 'U+0E30..U+0E3A', 'U+0E40..U+0E4E', 'U+0E50..U+0E59'),
     );
 
+    public $regexpFilter = array(
+      '\$(\w+) => $ \1', 
+      '(\w+)\$ => \1 $' 
+    );
+
     public $indexExtraOptions = array();
 
     private $configs;
@@ -254,6 +259,11 @@ class SphinxConfShell extends Shell {
     // languages should be safe.
     private function conf_beginning() {
         $charset_table_opt = implode(", ", $this->charsetTable);
+        $regexp_filter = "";
+        foreach ($this->regexpFilter as $regex) {
+            $regexp_filter .= "    regexp_filter           = $regex\n";
+        }
+
         return <<<EOT
 source default
 {
@@ -273,6 +283,7 @@ index common_index
 {
     index_field_lengths     = 1
     ignore_chars            = U+AD, U+5B0..U+5C5, U+5C7
+$regexp_filter
     charset_table           = $charset_table_opt
     min_infix_len           = 3
     docinfo                 = extern

--- a/app/vendors/shells/sphinx_conf.php
+++ b/app/vendors/shells/sphinx_conf.php
@@ -52,6 +52,8 @@ class SphinxConfShell extends Shell {
     public $charsetTable = array(
         # Ascii
         '0..9', 'a..z', '_', 'A..Z->a..z',
+        # Searchable symbols
+        '$',
         # Latin-1 Supplement, with case folding (0080-00FF)
         'U+C0..U+D6->U+E0..U+F6', 'U+D8..U+DE->U+F8..U+FE', 'U+E0..U+F6', 'U+F8..U+FF',
         # Latin extended-A, with case folding (0100-017F)

--- a/app/views/sentences/search.ctp
+++ b/app/views/sentences/search.ctp
@@ -90,6 +90,7 @@ if ($search_disabled) {
                      'inconvenience. Please try again later.'); ?></p>
 <?
 } else if (!is_array($results)) {
+  if (!isset($sphinx_markers)) {
 ?>
     <h2><?php echo __('Search error'); ?></h2>
     <p><?php
@@ -102,6 +103,20 @@ if ($search_disabled) {
         );
     ?></p>
 <?
+  } else {
+?>
+    <h2><?php echo __('Search error'); ?></h2>
+    <p><?php
+        echo format(
+            __(
+                'Invalid query. '.
+                'Please refer to '.
+                '<a href="{}">text search wiki</a> for more details.', true),
+            'http://en.wiki.tatoeba.org/articles/show/text-search'
+        );
+    ?></p>
+<?
+  }
 } elseif (!empty($results)) {
 
     if (!$is_advanced_search && !empty($query)) {

--- a/app/views/sentences/search.ctp
+++ b/app/views/sentences/search.ctp
@@ -110,8 +110,8 @@ if ($search_disabled) {
         echo format(
             __(
                 'Invalid query. '.
-                'Please refer to '.
-                '<a href="{}">text search wiki</a> for more details.', true),
+                'Please refer to the '.
+                '<a href="{}">search documentation</a> for more details.', true),
             'http://en.wiki.tatoeba.org/articles/show/text-search'
         );
     ?></p>


### PR DESCRIPTION
This PR addresses the issue #1126.
Note that this fix does not return $100 for the query "\$" since $ sign is considered as part of word and one has to search it as a beginning of word to be found. On the other hand, since we have a limitation that the search string used in wildcard searches should be at least 3 characters long, "\$\*" doesn't return anything either. On the other hand "\$10\*" will return $100000 and anything else.
Standalone $ signs such as that in the sentence "In English the shorthand for buck or dollar is "$"." are found by my fix.