### PR TITLE
Add ability to make lists uneditable.

### DIFF
--- a/app/controllers/sentences_lists_controller.php
+++ b/app/controllers/sentences_lists_controller.php
@@ -174,7 +174,8 @@ class SentencesListsController extends AppController
         $listId = $list['SentencesList']['id'];
         $listName = $list['SentencesList']['name'];
         $listVisibility = $list['SentencesList']['visibility'];
-        $isEditableByAnyone = $list['SentencesList']['editable_by'] == 'anyone';
+        $editableBy = $list['SentencesList']['editable_by'];
+        $isEditableByAnyone = $editableBy == 'anyone';
         $belongsToUser = CurrentUser::get('id') == $list['SentencesList']['user_id'];
 
         if ($listVisibility == 'private' && !$belongsToUser) {
@@ -200,7 +201,7 @@ class SentencesListsController extends AppController
         $this->set('listId', $listId);
         $this->set('listName', $listName);
         $this->set('listVisibility', $listVisibility);
-        $this->set('isEditableByAnyone', $isEditableByAnyone);
+        $this->set('editableBy', $editableBy);
         $this->set('belongsToUser', $belongsToUser);
         $this->set('canRemoveSentence', $belongsToUser || $isEditableByAnyone);
         $this->set('listCount', $thisListCount);

--- a/app/models/sentences_list.php
+++ b/app/models/sentences_list.php
@@ -85,10 +85,13 @@ class SentencesList extends AppModel
         $results = $this->find(
             "all",
             array(
-                "conditions" =>
-                    array("OR" => array(
+                "conditions" => array(
+                    "OR" => array(
                         "SentencesList.user_id" => $userId,
                         "SentencesList.editable_by" => 'anyone'
+                    ),
+                    "NOT" => array(
+                        "SentencesList.editable_by" => 'no_one'
                     )
                 ),
                 'fields' => array('id', 'name', 'user_id'),

--- a/app/views/helpers/lists.php
+++ b/app/views/helpers/lists.php
@@ -95,8 +95,13 @@ class ListsHelper extends AppHelper
         $visibility = 'private',
         $editableBy = 'creator'
     ) {
+        $listStatus = 'activeList';
+
+        if ($editableBy == 'no_one') {
+            $listStatus = 'inactiveList';
+        }
         ?>
-        <tr class="listSummary">
+        <tr class="listSummary <?php echo $listStatus; ?>">
 
         <td class="icon">
             <?php
@@ -305,36 +310,38 @@ class ListsHelper extends AppHelper
         <?php
     }
 
-    public function displayIsEditableByAnyOption($listId, $isChecked)
+    /**
+     * Display editable_by options for sentence lists.
+     *
+     * @param int    $listId List ID.
+     * @param string $value  Currently set option.
+     */
+    public function displayEditableByOptions($listId, $value)
     {
         $this->Javascript->link(
-            JS_PATH . 'sentences_lists.set_option.js', false
+            JS_PATH.'sentences_lists.set_option.js', false
         );
         ?>
         <dl>
             <?php
-            echo $this->Html->tag('dt', __('Permission to edit', true));
-            if ($isChecked) {
-                $checkboxValue = 'checked';
-            } else {
-                $checkboxValue = '';
-            }
+                $title = __('Who can add/remove sentences', true);
+                $loader = "<div class='is-editable loader-container'></div>";
+                echo $this->Html->tag('dt', $title.$loader);
 
-            echo "<div class='is-editable loader-container'></div>";
-
-            echo $this->Form->checkbox(
-                'isEditableByAnyone',
-                array(
-                    "id" => "editableCheckbox",
-                    "name" => "isEditableByAnyone",
-                    "checked" => $checkboxValue,
-                    "data-list-id" => $listId
-                )
-            );
-            echo $this->Html->tag('label',
-                __('Allow anyone to add and delete sentences from the list', true),
-                array('for' => 'editableCheckbox')
-            );
+                echo $this->Form->radio(
+                    'editable_by',
+                    array(
+                        'anyone' => __('Anyone', true),
+                        'creator' => __('Only me', true),
+                        'no_one' => __('No one (list inactive)', true),
+                    ),
+                    array(
+                        'name' => 'editable_by',
+                        'value' => $value,
+                        'data-list-id' => $listId,
+                        'separator' => '<br/>',
+                    )
+                );
             ?>
         </dl>
         <?php

--- a/app/views/sentences_lists/show.ctp
+++ b/app/views/sentences_lists/show.ctp
@@ -75,7 +75,7 @@ $this->set('title_for_layout', $pages->formatTitle($listName));
                 $lists->displayVisibilityOption($listId, $listVisibility);
                 echo '</p>';
                 echo '<p>';
-                $lists->displayIsEditableByAnyOption($listId, $isEditableByAnyone);
+                $lists->displayEditableByOptions($listId, $editableBy);
                 echo '</p>';
                 ?>
             </ul>
@@ -133,7 +133,7 @@ $this->set('title_for_layout', $pages->formatTitle($listName));
         'data-tooltip' => __('Click to edit...', true),
     ));
 
-    if ($belongsToUser) {
+    if ($belongsToUser && $editableBy !== 'no_one') {
         echo $html->div('edit-list-name', $editImage);
         $lists->displayAddSentenceForm($listId);
     }

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -1853,6 +1853,9 @@ div.hideLink {
     height: 16px;
 }
 
+.listSummary.inactiveList a {
+    color: #AAAAAA;
+}
 
 
 /*

--- a/app/webroot/js/sentences_lists.set_option.js
+++ b/app/webroot/js/sentences_lists.set_option.js
@@ -35,19 +35,19 @@ $(document).ready(function() {
         });
     });
 
-    $("#editableCheckbox").change(function(){
-        var value = $(this).is(':checked') ? 'anyone' : 'creator';
+    $("input[name=editable_by]").change(function(){
+        var value = $(this).val();
         var listId = $(this).attr('data-list-id');
 
         $("#editableCheckbox").hide();
+
         $(".is-editable.loader-container").html(
             "<div class='loader loader-small'></div>"
         );
-
         setOption(listId, 'editable_by', value, function(data){
-            $("#editableCheckbox").show();
-            console.log(data);
-            $("#editableCheckbox").prop('checked', data["editable_by"] === "anyone");
+            $("input[name=editable_by][value="+value+"]").prop(
+                'checked', data["editable_by"] === value
+            );
             $(".is-editable.loader-container").html("");
         });
     });

--- a/docs/database/updates/2016-05-22.sql
+++ b/docs/database/updates/2016-05-22.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sentences_lists MODIFY COLUMN editable_by enum('creator', 'anyone', 'no_one') NOT NULL DEFAULT 'creator';


### PR DESCRIPTION
This pull request addresses issue #654 

As mentioned in the issue comment thread, this fix requires a database update in order to add a third enum option to the sentences_lists editable_by column. I ran this mysql command locally:       
SQL Query: ALTER TABLE sentences_lists MODIFY COLUMN editable_by enum('creator', 'anyone', 'no_one') NOT NULL DEFAULT 'creator'; 