### PR TITLE
Created space between username and date, in logs sidebar

### DIFF
--- a/app/views/helpers/logs.php
+++ b/app/views/helpers/logs.php
@@ -214,6 +214,7 @@ class LogsHelper extends AppHelper
 
             // date of contribution
             echo '<li class="date">';
+            echo ' ';
             echo $this->Date->ago($datetime);
             echo '</li>';
 
@@ -389,6 +390,7 @@ class LogsHelper extends AppHelper
             echo $this->_getActionLabel($type, $action, $username);
             echo '</li>';
 
+    
             // date of contribution
             echo '<li class="date">';
             echo $this->Html->link(


### PR DESCRIPTION
This pull request addresses issue #1147 