### PR TITLE
Include an option to list tags with the newest addition first.

### DIFF
--- a/app/views/tags/show_sentences_with_tag.ctp
+++ b/app/views/tags/show_sentences_with_tag.ctp
@@ -53,6 +53,14 @@ if ($tagExists) {
                 __n('{tagName} ({n} sentence)', '{tagName} ({n} sentences)', $n, true), 
                 compact('tagName', 'n')
             ); ?></h2>
+            
+            <div class="sortBy">
+                <strong><?php __("Sort by:") ?></strong>
+                <?php
+                echo $this->Paginator->sort(__("date of tag", true), 'added_time');
+                ?>
+            </div>
+
             <?php
             $url = array($tagId, $langFilter);
             $pagination->display($url);


### PR DESCRIPTION
This pull request addresses issue #960. 

I didn't change the default sort method to sort by 'date created' because I wasn't sure if that was really agreed upon (and I am not sure how to change the default sort method, so if anyone would like to give me some quick direction that would be great!). 