### PR TITLE
Graphical re-design of pagination

### DIFF
--- a/app/views/helpers/pagination.php
+++ b/app/views/helpers/pagination.php
@@ -75,7 +75,8 @@ class PaginationHelper extends AppHelper
         $this->Paginator->options(array('url' => $extramParams));
         // -----------------------------------------------------------
 
-
+        $numberFirstLinks = 1;
+        $numberLastLinks = 1;
         $numbersOptions = array(
             'separator' => '',
             // Print up to 6/2 = 3 numbered links in rectangles on each side
@@ -94,9 +95,8 @@ class PaginationHelper extends AppHelper
             // end of the list of English sentences).
             'modulus' => 6,
             'class' => 'pageNumber',
-            'first' => 1,
-            'last' => 1,
-            'ellipsis' => 'more_horiz'
+            'first' => $numberFirstLinks,
+            'last' => $numberLastLinks,
         );
         ?>
         <div class="paging">

--- a/app/views/helpers/pagination.php
+++ b/app/views/helpers/pagination.php
@@ -93,27 +93,25 @@ class PaginationHelper extends AppHelper
             // the largest numbers (for example, when we're near the
             // end of the list of English sentences).
             'modulus' => 6,
-            'class' => 'pageNumber'
+            'class' => 'pageNumber',
+            'first' => 1,
+            'last' => 1,
+            'ellipsis' => 'more_horiz'
         );
         ?>
         <div class="paging">
-            <?php
-            $first = $this->Paginator->first(
-                '<<',
-                array('title' => __('First page', true))
-            );
-            if (empty($first)) {
-                $first = '<span class="disabled">&lt;&lt;</span>';
-            }
-            echo $first;
+ 
+           <?php
 
             echo $this->Paginator->prev(
-                '<',
+                'keyboard_arrow_left',
                 // @translators Appears on “previous page” links
                 // mouseover. Keyboard shortcut is between brackets.
-                array('title' => __('Previous page [Ctrl+←]', true)),
+                array('title' => __('Previous page [Ctrl+←]', true),
+                  'tag' => 'md-icon'),
                 null,
-                array('class' => 'disabled')
+                array('class' => 'material-icons disabled',
+                  'tag' => 'md-icon')
             );
             ?>
 
@@ -123,22 +121,17 @@ class PaginationHelper extends AppHelper
 
             <?php
             echo $this->Paginator->next(
-                '>',
+                'keyboard_arrow_right',
                 // @translators Appears on “next page” links
                 // mouseover. Keyboard shortcut is between brackets.
-                array('title' => __('Next page [Ctrl+→]', true)),
+                array('title' => __('Next page [Ctrl+→]', true),
+                  'tag' => 'md-icon'),
                 null,
-                array('class' => 'disabled')
+                array('class' => 'material-icons disabled',
+                  'tag' => 'md-icon')
             );
 
-            $last = $this->Paginator->last(
-                '>>',
-                array('title' => __('Last page', true))
-            );
-            if (empty($last)) {
-                $last = '<span class="disabled">&gt;&gt;</span>';
-            }
-            echo $last;
+
             ?>
         </div>
         <?php

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -736,21 +736,22 @@
 /*
  * Pagination
  */
+
 .paging {
     margin: 20px 0;
     text-align: center;
 }
 
 .paging a {
-    padding: 3px 5px;
-    margin: 2px;
-    background: #D3F3B9;
-    color: #257D0C;
+    padding: 5px 8px;
+    margin: 3px;
+    background: #EEEEEE;
+    color: #757575;
 }
 
 .paging a:hover {
-    background: #257D0C;
-    color: white;
+    background: #E0E0E0;
+    color: #757575;
 }
 
 .paging .disabled {
@@ -758,20 +759,29 @@
     padding: 3px 5px;
     margin: 3px;
     background: #EEE;
+    color: #BDBDBD;
 }
 
 .paging .current {
-    padding: 3px 5px;
+    padding: 5px 8px;
     margin: 3px;
-    background: #9FD374;
-    color: white;
+    background: #66AA00;
+    color: #FFFFFF;
     font-weight: bold;
 }
 
 .paging .numbers {
     padding: 0 10px;
+    font-size: 10.5pt;
 }
 
+a.prev {
+    background: #FFFFFF;
+}
+
+a.next {
+   background: #FFFFFF;
+}
 
 /*
  * --------------------------------------------------------------------

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -742,14 +742,14 @@
     text-align: center;
 }
 
-.paging a {
+.numbers a {
     padding: 5px 8px;
     margin: 3px;
     background: #EEEEEE;
     color: #757575;
 }
 
-.paging a:hover {
+.numbers a:hover {
     background: #E0E0E0;
     color: #757575;
 }
@@ -765,7 +765,7 @@
 .paging .current {
     padding: 5px 8px;
     margin: 3px;
-    background: #66AA00;
+    background: #4caf50;
     color: #FFFFFF;
     font-weight: bold;
 }

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -755,9 +755,7 @@
 }
 
 .paging .disabled {
-    display: inline;
-    padding: 3px 5px;
-    margin: 3px;
+
     background: #EEE;
     color: #BDBDBD;
 }
@@ -776,15 +774,15 @@
 }
 
 a.prev {
-    background: #FFFFFF;
+    background: none;
 }
 
 a.next {
-   background: #FFFFFF;
+   background: none;
 }
 
 md-icon.disabled.material-icons {
-   background: #FFFFFF;
+   background: none;
 }
 
 /*

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -783,6 +783,10 @@ a.next {
    background: #FFFFFF;
 }
 
+md-icon.disabled.material-icons {
+   background: #FFFFFF;
+}
+
 /*
  * --------------------------------------------------------------------
  *


### PR DESCRIPTION
This pull request addresses issue #1134 . It is relevant to issue #1180 

I've left out the [Angular Material icon](https://design.google.com/icons/#ic_more_horiz) for the ellipsis. 

The screenshots below show the pagination when the user is on the following pages:

- random page,
- first page, and
- last page.

![screenshot from 2016-06-15 03-13-47](https://cloud.githubusercontent.com/assets/3508975/16056489/574efb78-32a8-11e6-8f55-ca409d456b97.png)
![screenshot from 2016-06-15 03-13-59](https://cloud.githubusercontent.com/assets/3508975/16056490/57553bf0-32a8-11e6-90c1-96ddde039f18.png)
![screenshot from 2016-06-15 03-14-15](https://cloud.githubusercontent.com/assets/3508975/16056491/575b18e0-32a8-11e6-863f-0a5ea20a82cd.png)
