### PR TITLE
Vocabulary list

### DIFF
--- a/app/controllers/vocabulary_controller.php
+++ b/app/controllers/vocabulary_controller.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2016  HO Ngoc Phuong Trang <tranglich@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Tatoeba
+ * @author   HO Ngoc Phuong Trang <tranglich@gmail.com>
+ * @license  Affero General Public License
+ * @link     http://tatoeba.org
+ */
+
+/**
+ * Controller for vocabulary.
+ *
+ * @category Vocabulary
+ * @package  Controllers
+ * @author   HO Ngoc Phuong Trang <tranglich@gmail.com>
+ * @license  Affero General Public License
+ * @link     http://tatoeba.org
+ */
+class VocabularyController extends AppController
+{
+    public $uses = array('UsersVocabulary', 'User', 'Sentence', 'Vocabulary');
+    public $components = array ('CommonSentence');
+
+    /**
+     * Before filter.
+     *
+     * @return void
+     */
+    public function beforeFilter()
+    {
+        parent::beforeFilter();
+
+        // setting actions that are available to everyone, even guests
+        $this->Auth->allowedActions = array('of');
+    }
+
+    /**
+     *
+     */
+    public function of($username, $lang = null)
+    {
+        $this->helpers[] = 'Pagination';
+        $this->helpers[] = 'CommonModules';
+        
+        $userId = $this->User->getIdFromUsername($username);
+        $this->paginate = $this->UsersVocabulary->getPaginatedVocabularyOf(
+            $userId, $lang
+        );
+        $vocabulary = $this->paginate();
+
+        $this->set('vocabulary', $vocabulary);
+        $this->set('username', $username);
+        $this->set('canEdit', $username == CurrentUser::get('username'));
+    }
+
+
+    /**
+     *
+     */
+    public function add()
+    {
+    }
+
+
+    /**
+     *
+     */
+    public function add_sentences($lang = null)
+    {
+        $this->helpers[] = 'Pagination';
+        $this->helpers[] = 'CommonModules';
+        $this->helpers[] = 'Languages';
+
+        $this->paginate = $this->Vocabulary->getPaginatedVocabulary($lang);
+        $vocabulary = $this->paginate('Vocabulary');
+
+        $this->set('vocabulary', $vocabulary);
+        $this->set('lang', $lang);
+    }
+
+
+    /**
+     *
+     */
+    public function save()
+    {
+        $lang = $_POST['lang'];
+        $text = $_POST['text'];
+
+        $result = $this->Vocabulary->addItem($lang, $text);
+        $hexValue = unpack('H*', $result['id']);
+        $result['id'] = str_pad($hexValue[1], 32, '0');
+        $numSentences = $result['numSentences'];
+        $result['numSentencesLabel'] = format(
+            __n('{number} sentence', '{number} sentences', $numSentences, true),
+            array('number' => $numSentences)
+        );
+        $this->set('result', $result);
+
+        $this->layout = 'json';
+    }
+
+
+    /**
+     *
+     */
+    public function remove($id)
+    {
+        $vocabularyId = hex2bin($id);
+
+        $data = $this->UsersVocabulary->find(
+            'first',
+            array(
+                'conditions' => array(
+                    'vocabulary_id' => $vocabularyId,
+                    'user_id' => CurrentUser::get('id')
+                )
+            )
+        );
+
+        if ($data) {
+            $id = $data['UsersVocabulary']['id'];
+            $this->UsersVocabulary->delete($id, false);
+        }
+
+        $this->set('vocabularyId', array('id' => $id));
+
+        $this->layout = 'json';
+    }
+
+
+    /**
+     *
+     */
+    public function save_sentence($vocabularyId)
+    {
+        $sentenceLang = $_POST['lang'];
+        $sentenceText = $_POST['text'];
+        $userId = CurrentUser::get('id');
+        $username = CurrentUser::get('username');
+
+        $isSaved = $this->CommonSentence->wrapper_save_sentence(
+            $sentenceLang,
+            $sentenceText,
+            $userId,
+            null,
+            $username
+        );
+
+        $sentence = null;
+        if ($isSaved) {
+            $sentence = array(
+                'id' => $this->Sentence->id,
+                'text' => $sentenceText,
+            );
+
+            $this->Vocabulary->updateNumSentences($vocabularyId);
+        }
+
+        $this->set('sentence', $sentence);
+
+        $this->layout = 'json';
+    }
+
+}
+?>

--- a/app/controllers/vocabulary_controller.php
+++ b/app/controllers/vocabulary_controller.php
@@ -52,8 +52,12 @@ class VocabularyController extends AppController
         $this->Auth->allowedActions = array('of');
     }
 
+
     /**
+     * Page that lists all the vocabulary items of given user in given language.
      *
+     * @param $username string Username of the user.
+     * @param $lang     string Language of the items.
      */
     public function of($username, $lang = null)
     {
@@ -73,7 +77,7 @@ class VocabularyController extends AppController
 
 
     /**
-     *
+     * Page where users can add new vocabulary items to their list.
      */
     public function add()
     {
@@ -81,7 +85,9 @@ class VocabularyController extends AppController
 
 
     /**
+     * Page that lists all the vocabulary items for which sentences are wanted.
      *
+     * @param $lang string Language of the vocabulary items.
      */
     public function add_sentences($lang = null)
     {
@@ -98,7 +104,7 @@ class VocabularyController extends AppController
 
 
     /**
-     *
+     * Saves a vocabulary item.
      */
     public function save()
     {
@@ -120,7 +126,9 @@ class VocabularyController extends AppController
 
 
     /**
+     * Removes vocabulary item of given id.
      *
+     * @param $id int Hexadecimal value of vocabulary id.
      */
     public function remove($id)
     {
@@ -148,7 +156,8 @@ class VocabularyController extends AppController
 
 
     /**
-     *
+     * Saves a sentence for vocabulary of given id and updates the count of
+     * sentences for that vocabulary item.
      */
     public function save_sentence($vocabularyId)
     {

--- a/app/models/users_vocabulary.php
+++ b/app/models/users_vocabulary.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2016  HO Ngoc Phuong Trang <tranglich@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Tatoeba
+ * @author   HO Ngoc Phuong Trang <tranglich@gmail.com>
+ * @license  Affero General Public License
+ * @link     http://tatoeba.org
+ */
+
+/**
+ * Model Class for users vocabulary.
+ *
+ * @package  Models
+ * @author   HO Ngoc Phuong Trang <tranglich@gmail.com>
+ * @license  Affero General Public License
+ * @link     http://tatoeba.org
+ */
+
+class UsersVocabulary extends AppModel
+{
+    public $useTable = 'users_vocabulary';
+    public $actsAs = array('Containable');
+    public $belongsTo = array(
+        'Vocabulary' => array('foreignKey' => 'vocabulary_id'),
+        'User' => array('foreignKey' => 'user_id')
+    );
+
+
+    /**
+     *
+     */
+    public function add($vocabularyId, $userId) {
+        $data = array(
+            'vocabulary_id' => $vocabularyId,
+            'user_id' => $userId
+        );
+        return $this->save($data);
+    }
+
+
+    /**
+     *
+     */
+    public function getPaginatedVocabularyOf($userId, $lang = null)
+    {
+        $conditions = array('UsersVocabulary.user_id' => $userId);
+        if (!empty($lang)) {
+            $conditions['lang'] = $lang;
+        }
+
+        $result = array(
+            'conditions' => $conditions,
+            'fields' => array('created'),
+            'contain' => array(
+                'Vocabulary' => array('id', 'lang', 'text', 'numSentences')
+            ),
+            'limit' => 50,
+            'order' => 'created DESC'
+        );
+
+        return $result;
+    }
+}
+?>

--- a/app/models/vocabulary.php
+++ b/app/models/vocabulary.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2016  HO Ngoc Phuong Trang <tranglich@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Tatoeba
+ * @author   HO Ngoc Phuong Trang <tranglich@gmail.com>
+ * @license  Affero General Public License
+ * @link     http://tatoeba.org
+ */
+
+/**
+ * Model class for vocabulary.
+ *
+ * @package  Models
+ * @author   HO Ngoc Phuong Trang <tranglich@gmail.com>
+ * @license  Affero General Public License
+ * @link     http://tatoeba.org
+ */
+App::import('Vendor', 'murmurhash3');
+
+class Vocabulary extends AppModel
+{
+    public $useTable = 'vocabulary';
+    public $belongsTo = array('UsersVocabulary', 'Sentence');
+
+
+    /**
+     * 
+     */
+    public function addItem($lang, $text) {
+        $text = trim($text);
+        if (empty($text) || empty($lang)) {
+            return null;
+        }
+        $numSentences = $this->_getNumberOfSentences($lang, $text);
+        $hash = murmurhash3($lang.$text);
+        $data = array(
+            'id' => $hash,
+            'lang' => $lang,
+            'text' => $text,
+            'numSentences' => $numSentences
+        );
+
+        $this->save($data);
+        $this->UsersVocabulary->add($hash, CurrentUser::get('id'));
+
+        return $data;
+    }
+
+    private function _getNumberOfSentences($lang, $text) {
+        $this->Behaviors->attach('Sphinx');
+        $index = array($lang . '_main_index', $lang . '_delta_index');
+        $sphinx = array(
+            'index' => $index,
+            'matchMode' => SPH_MATCH_EXTENDED2
+        );
+        $query = '="'.$text.'"';
+        return $this->Sentence->find('count', array(
+            'sphinx' => $sphinx,
+            'search' => $query
+        ));
+    }
+
+
+    /**
+     *
+     */
+    public function getPaginatedVocabulary($lang = null) {
+        $conditions = array(
+            'numSentences <' => 10,
+            'numAdded >' => 0
+        );
+        if (!empty($lang)) {
+            $conditions['lang'] = $lang;
+        }
+
+        $result = array(
+            'conditions' => $conditions,
+            'fields' => array('id', 'lang', 'text', 'numSentences'),
+            'limit' => 50,
+            'order' => 'numSentences ASC'
+        );
+
+        return $result;
+    }
+
+
+    /**
+     *
+     */
+    public function updateNumSentences($id) {
+        $vocabularyId = hex2bin($id);
+        $vocabulary = $this->findById($vocabularyId);
+
+        $numSentences = $this->_getNumberOfSentences(
+            $vocabulary['Vocabulary']['lang'],
+            $vocabulary['Vocabulary']['text']
+        );
+
+        $data = array(
+            'id' => $vocabularyId,
+            'numSentences' => $numSentences
+        );
+
+        if ($numSentences) {
+            $this->save($data);
+        }
+    }
+}
+?>

--- a/app/models/vocabulary.php
+++ b/app/models/vocabulary.php
@@ -42,7 +42,12 @@ class Vocabulary extends AppModel
 
 
     /**
-     * 
+     * Adds an item into the vocabulary list of current user.
+     *
+     * @param $lang string Language of the vocabulary item.
+     * @param $text string Text of the vocabulary item.
+     *
+     * @return $data array
      */
     public function addItem($lang, $text) {
         $text = trim($text);
@@ -64,6 +69,18 @@ class Vocabulary extends AppModel
         return $data;
     }
 
+
+    /**
+     * Returns the number of sentences for $text in language $lang.
+     *
+     * This uses the search engine (Sphinx) to count the number of search result
+     * for an exact search on $text in language $lang.
+     *
+     * @param $lang string Language of the vocabulary item
+     * @param $text string Text of the vocabulary item.
+     *
+     * @return int
+     */
     private function _getNumberOfSentences($lang, $text) {
         $this->Behaviors->attach('Sphinx');
         $index = array($lang . '_main_index', $lang . '_delta_index');
@@ -80,7 +97,15 @@ class Vocabulary extends AppModel
 
 
     /**
+     * Returns array to use in $this->paginate, to retrieve all the vocabulary
+     * items in language $lang for which sentences are needed.
+     * We assume that a vocabulary item needs sentences if there are less than
+     * 10 sentences for it.
+     * The vocabulary items are sorted be number of sentences.
      *
+     * @param $lang string
+     *
+     * @return array
      */
     public function getPaginatedVocabulary($lang = null) {
         $conditions = array(
@@ -103,7 +128,11 @@ class Vocabulary extends AppModel
 
 
     /**
+     * Updates the number of sentences for a vocabulary item.
      *
+     * @param $id int Hexadecimal value of the vocabulary id.
+     *
+     * @return void
      */
     public function updateNumSentences($id) {
         $vocabularyId = hex2bin($id);

--- a/app/vendors/murmurhash3.php
+++ b/app/vendors/murmurhash3.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * PHP Implementation of MurmurHash3
+ *
+ * @author Stefano Azzolini (lastguest@gmail.com)
+ * @see https://github.com/lastguest/murmurhash-php
+ * @author Gary Court (gary.court@gmail.com)
+ * @see http://github.com/garycourt/murmurhash-js
+ * @author Austin Appleby (aappleby@gmail.com)
+ * @see http://sites.google.com/site/murmurhash/
+ *
+ * @param  string $key   Text to hash.
+ * @param  number $seed  Positive integer only
+ * @return number 32-bit (base 32 converted) positive integer hash
+ */
+
+function murmurhash3_int($key,$seed=0){
+  $key  = array_values(unpack('C*',(string) $key));
+  $klen = count($key);
+  $h1   = (int)$seed;
+  for ($i=0,$bytes=$klen-($remainder=$klen&3) ; $i<$bytes ; ) {
+    $k1 = $key[$i]
+      | ($key[++$i] << 8)
+      | ($key[++$i] << 16)
+      | ($key[++$i] << 24);
+    ++$i;
+    $k1  = (((($k1 & 0xffff) * 0xcc9e2d51) + ((((($k1 >= 0 ? $k1 >> 16 : (($k1 & 0x7fffffff) >> 16) | 0x8000)) * 0xcc9e2d51) & 0xffff) << 16))) & 0xffffffff;
+    $k1  = $k1 << 15 | ($k1 >= 0 ? $k1 >> 17 : (($k1 & 0x7fffffff) >> 17) | 0x4000);
+    $k1  = (((($k1 & 0xffff) * 0x1b873593) + ((((($k1 >= 0 ? $k1 >> 16 : (($k1 & 0x7fffffff) >> 16) | 0x8000)) * 0x1b873593) & 0xffff) << 16))) & 0xffffffff;
+    $h1 ^= $k1;
+    $h1  = $h1 << 13 | ($h1 >= 0 ? $h1 >> 19 : (($h1 & 0x7fffffff) >> 19) | 0x1000);
+    $h1b = (((($h1 & 0xffff) * 5) + ((((($h1 >= 0 ? $h1 >> 16 : (($h1 & 0x7fffffff) >> 16) | 0x8000)) * 5) & 0xffff) << 16))) & 0xffffffff;
+    $h1  = ((($h1b & 0xffff) + 0x6b64) + ((((($h1b >= 0 ? $h1b >> 16 : (($h1b & 0x7fffffff) >> 16) | 0x8000)) + 0xe654) & 0xffff) << 16));
+  }
+  $k1 = 0;
+  switch ($remainder) {
+    case 3: $k1 ^= $key[$i + 2] << 16;
+    case 2: $k1 ^= $key[$i + 1] << 8;
+    case 1: $k1 ^= $key[$i];
+    $k1  = ((($k1 & 0xffff) * 0xcc9e2d51) + ((((($k1 >= 0 ? $k1 >> 16 : (($k1 & 0x7fffffff) >> 16) | 0x8000)) * 0xcc9e2d51) & 0xffff) << 16)) & 0xffffffff;
+    $k1  = $k1 << 15 | ($k1 >= 0 ? $k1 >> 17 : (($k1 & 0x7fffffff) >> 17) | 0x4000);
+    $k1  = ((($k1 & 0xffff) * 0x1b873593) + ((((($k1 >= 0 ? $k1 >> 16 : (($k1 & 0x7fffffff) >> 16) | 0x8000)) * 0x1b873593) & 0xffff) << 16)) & 0xffffffff;
+    $h1 ^= $k1;
+  }
+  $h1 ^= $klen;
+  $h1 ^= ($h1 >= 0 ? $h1 >> 16 : (($h1 & 0x7fffffff) >> 16) | 0x8000);
+  $h1  = ((($h1 & 0xffff) * 0x85ebca6b) + ((((($h1 >= 0 ? $h1 >> 16 : (($h1 & 0x7fffffff) >> 16) | 0x8000)) * 0x85ebca6b) & 0xffff) << 16)) & 0xffffffff;
+  $h1 ^= ($h1 >= 0 ? $h1 >> 13 : (($h1 & 0x7fffffff) >> 13) | 0x40000);
+  $h1  = (((($h1 & 0xffff) * 0xc2b2ae35) + ((((($h1 >= 0 ? $h1 >> 16 : (($h1 & 0x7fffffff) >> 16) | 0x8000)) * 0xc2b2ae35) & 0xffff) << 16))) & 0xffffffff;
+  $h1 ^= ($h1 >= 0 ? $h1 >> 16 : (($h1 & 0x7fffffff) >> 16) | 0x8000);
+  return $h1;
+}
+
+function murmurhash3($key,$seed=0){
+  return base_convert(murmurhash3_int($key,$seed),10,32);
+}

--- a/app/views/elements/space.ctp
+++ b/app/views/elements/space.ctp
@@ -88,6 +88,19 @@ if (isset($this->params['lang'])) {
         <li class="item">
             <?php
             echo $html->link(
+                __('My vocabulary', true),
+                array(
+                    'controller' => 'vocabulary',
+                    'action' => 'of',
+                    $username
+                )
+            );
+            ?>
+        </li>
+
+        <li class="item">
+            <?php
+            echo $html->link(
                 __('My collection', true),
                 array(
                     'controller' => 'collections',

--- a/app/views/elements/users_menu.ctp
+++ b/app/views/elements/users_menu.ctp
@@ -57,6 +57,19 @@
     </li>
 
     <li class="item">
+        <?php
+        echo $html->link(
+            __('Vocabulary', true),
+            array(
+                'controller' => 'vocabulary',
+                'action' => 'of',
+                $username
+            )
+        );
+        ?>
+    </li>
+
+    <li class="item">
     <?php
     echo $html->link(
         __('Collection', true),

--- a/app/views/elements/vocabulary/menu.ctp
+++ b/app/views/elements/vocabulary/menu.ctp
@@ -1,0 +1,35 @@
+<?php
+$addUrl = $html->url(
+    array(
+        'controller' => 'vocabulary',
+        'action' => 'add'
+    )
+);
+$indexUrl = $html->url(
+    array(
+        'controller' => 'vocabulary',
+        'action' => 'of',
+        CurrentUser::get('username')
+    )
+);
+$addSentencesUrl = $html->url(
+    array(
+        'controller' => 'vocabulary',
+        'action' => 'add_sentences'
+    )
+);
+?>
+<div class="section" layout="column" md-whiteframe="1">
+    <h2><? __('Vocabulary items'); ?></h2>
+    <div layout="column" flex>
+        <md-button class="md-primary" href="<?= $indexUrl ?>">
+            <? __('My vocabulary items'); ?>
+        </md-button>
+        <md-button class="md-primary" href="<?= $addUrl ?>">
+            <? __('Add vocabulary items'); ?>
+        </md-button>
+        <md-button class="md-primary" href="<?= $addSentencesUrl ?>">
+            <? __('Sentences wanted'); ?>
+        </md-button>
+    </div>
+</div>

--- a/app/views/helpers/common_modules.php
+++ b/app/views/helpers/common_modules.php
@@ -57,7 +57,7 @@ class CommonModulesHelper extends AppHelper
     public function createFilterByLangMod($maxNumberOfParams = 1)
     {
         ?>
-        <div class="module">
+        <div class="section" layout="column" md-whiteframe="1">
             <h2><?php __('Filter by language'); ?></h2>
             <?php
             /*to stay on the same page except language filter option*/

--- a/app/views/layouts/json.ctp
+++ b/app/views/layouts/json.ctp
@@ -1,0 +1,6 @@
+<?php
+header("Pragma: no-cache");
+header("Cache-Control: no-store, no-cache, max-age=0, must-revalidate");
+header('Content-Type: application/json; charset=utf-8');
+echo $content_for_layout;
+?>

--- a/app/views/sentences/add.ctp
+++ b/app/views/sentences/add.ctp
@@ -28,6 +28,11 @@
 $this->set('title_for_layout', $pages->formatTitle(__('Add sentences', true)));
 
 $javascript->link(JS_PATH . 'sentences.contribute.js', false);
+
+$vocabularyUrl = $html->url(array(
+    'controller' => 'vocabulary',
+    'action' => 'add_sentences'
+));
 ?>
 
 <div id="annexe_content">
@@ -124,6 +129,13 @@ $javascript->link(JS_PATH . 'sentences.contribute.js', false);
 
             }
             ?>
+            </div>
+
+            <div layout="row" layout-align="center center">
+                <md-button href="<?= $vocabularyUrl ?>">
+                    <md-icon>keyboard_arrow_right</md-icon>
+                    Check out the vocabulary for which we need sentences
+                </md-button>
             </div>
         </div>
     </div>

--- a/app/views/vocabulary/add.ctp
+++ b/app/views/vocabulary/add.ctp
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2009  HO Ngoc Phuong Trang <tranglich@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Tatoeba
+ * @author   HO Ngoc Phuong Trang <tranglich@gmail.com>
+ * @license  Affero General Public License
+ * @link     http://tatoeba.org
+ */
+?>
+<?php
+$javascript->link('/js/vocabulary/add.ctrl.js', false);
+
+$title = __('Add vocabulary items', true);
+
+$this->set('title_for_layout', $pages->formatTitle($title));
+?>
+
+<div id="annexe_content">
+    <?php echo $this->element('vocabulary/menu'); ?>
+
+    <div class="section" layout="column" md-whiteframe="1">
+        <h2><? __('Tips'); ?></h2>
+        <p><?
+        __(
+            'Add vocabulary that you are learning. If your vocabulary does not '.
+            'exist yet in Tatoeba, other contributors can add sentences for it.'
+        );
+        ?></p>
+    </div>
+</div>
+
+<div ng-controller="VocabularyAddController as ctrl" id="main_content">
+
+    <div class="section" layout="column" md-whiteframe="1">
+        <h2><?= $title ?></h2>
+        <form ng-submit="ctrl.add()">
+            <div layout="row">
+                <div class="language" layout="column">
+                    <label for="lang-select"><? __('Language'); ?></label>
+                    <?php
+                    $langArray = $this->Languages->profileLanguagesArray(
+                        false, false
+                    );
+                    $selectedLang = key($langArray);
+                    echo $form->select(
+                        null,
+                        $langArray,
+                        null,
+                        array(
+                            'id' => 'lang-select',
+                            'ng-model' => 'ctrl.data.lang',
+                            'ng-init' => "ctrl.data.lang = '$selectedLang'",
+                            'empty' => false
+                        ),
+                        false
+                    );
+                    ?>
+                </div>
+
+                <md-input-container flex>
+                    <label><? __('Vocabulary item'); ?></label>
+                    <input type="text" ng-model="ctrl.data.text"
+                           ng-disabled="ctrl.isAdding">
+                </md-input-container>
+            </div>
+
+            <div layout="row" layout-align="center center">
+                <md-button type="submit" class="md-raised md-primary"
+                           ng-disabled="ctrl.isAdding || !ctrl.data.text || !ctrl.data.lang">
+                    <? __('Add'); ?>
+                </md-button>
+            </div>
+        </form>
+
+    </div>
+
+    <div class="section" md-whiteframe="1">
+        <div layout="row">
+            <h2 flex><? __('Vocabulary items added'); ?></h2>
+            <md-progress-circular md-mode="indeterminate"
+                                  md-diameter="32"
+                                  ng-show="ctrl.isAdding">
+            </md-progress-circular>
+        </div>
+
+        <md-list flex ng-show="ctrl.vocabularyAdded.length > 0">
+            <md-list-item id="vocabulary_{{item.id}}"
+                          ng-repeat="item in ctrl.vocabularyAdded">
+                <img class="vocabulary-lang" ng-src="/img/flags/{{item.lang}}.png"/>
+                <div class="vocabulary-text" flex>{{item.text}}</div>
+                <md-button class="md-primary" href="{{item.url}}">
+                    {{item.numSentencesLabel}}
+                </md-button>
+                <md-button ng-click="ctrl.remove(item.id)" class="md-icon-button">
+                    <md-icon aria-label="Remove">delete</md-icon>
+                </md-button>
+            </md-list-item>
+        </md-list>
+    </div>
+
+</div>

--- a/app/views/vocabulary/add_sentences.ctp
+++ b/app/views/vocabulary/add_sentences.ctp
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2009  HO Ngoc Phuong Trang <tranglich@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Tatoeba
+ * @author   HO Ngoc Phuong Trang <tranglich@gmail.com>
+ * @license  Affero General Public License
+ * @link     http://tatoeba.org
+ */
+?>
+<?php
+$javascript->link('/js/vocabulary/add-sentences.ctrl.js', false);
+
+$title = __('Vocabulary that needs sentences', true);
+
+$this->set('title_for_layout', $pages->formatTitle($title));
+?>
+
+<div id="annexe_content">
+    <?php echo $this->element('vocabulary/menu'); ?>
+
+    <?php $commonModules->createFilterByLangMod(); ?>
+</div>
+
+<div id="main_content" ng-controller="VocabularyAddSentencesController as ctrl">
+    <div class="section" md-whiteframe="1">
+        <h2><?= $title ?></h2>
+
+        <p>
+            <?
+            __(
+                'Only vocabulary items that have less than 10 sentences are '.
+                'displayed here.'
+            )
+            ?>
+        </p>
+        <?php
+        $paginationUrl = array($lang);
+        $pagination->display($paginationUrl);
+        ?>
+
+        <md-list flex>
+            <?php
+            foreach($vocabulary as $item) {
+                $id = $item['Vocabulary']['id'];
+                $hexId = bin2hex($id);
+                $lang = $item['Vocabulary']['lang'];
+                $text = $item['Vocabulary']['text'];
+                $numSentences = $item['Vocabulary']['numSentences'];
+                $url = $html->url(array(
+                    'controller' => 'sentences',
+                    'action' => 'search',
+                    '?' => array(
+                        'query' => '="' . $text . '"',
+                        'from' => $lang
+                    )
+                ));
+                ?>
+                <md-list-item id="vocabulary_<?= $hexId ?>">
+                    <img class="vocabulary-lang" src="/img/flags/<?= $lang ?>.png"/>
+                    <div class="vocabulary-text" flex><?= $text ?></div>
+                    <md-button class="md-primary" href="<?= $url ?>">
+                        <?= format(
+                            __n(
+                                '{number} sentence', '{number} sentences',
+                                $numSentences,
+                                true
+                            ),
+                            array('number' => $numSentences)
+                        ); ?>
+                    </md-button>
+                    <md-button ng-click="ctrl.showForm('<?= $hexId ?>')"
+                               class="md-icon-button">
+                        <md-icon aria-label="Add">add</md-icon>
+                    </md-button>
+                </md-list-item>
+                <div id="sentences_<?= $hexId ?>" class="new-sentences"
+                     ng-show="ctrl.sentencesAdded['<?= $hexId ?>']">
+                    <div ng-repeat="sentence in ctrl.sentencesAdded['<?= $hexId ?>']"
+                         class="new-sentence"
+                         layout="row" layout-align="start center">
+                        <md-button class="md-icon-button"
+                                   ng-href="{{sentence.url}}">
+                            <md-icon>forward</md-icon>
+                        </md-button>
+                        <div class="text" flex>{{sentence.text}}</div>
+                    </div>
+                </div>
+
+                <div id="loader_<?= $hexId ?>" flex ng-show="false">
+                    <md-progress-linear></md-progress-linear>
+                </div>
+
+                <form id="form_<?= $hexId ?>" class="sentence-form"
+                      layout="column" flex ng-show="false"
+                      ng-submit="ctrl.saveSentence('<?= $hexId ?>', '<?= $lang ?>')">
+                    <md-input-container flex>
+                        <label><? __('Sentence'); ?></label>
+                        <input type="text" ng-disabled="ctrl.isAdding"
+                               ng-model="ctrl.sentence['<?= $hexId ?>']">
+                    </md-input-container>
+                    <div layout="row" layout-align="end center">
+                        <md-button class="md-raised"
+                                   ng-disabled="ctrl.isAdding"
+                                   ng-click="ctrl.hideForm('<?= $hexId ?>')">
+                            <? __('Cancel') ?>
+                        </md-button>
+                        <md-button type="submit" class="md-raised md-primary"
+                                   ng-disabled="ctrl.isAdding">
+                            <? __('Submit') ?>
+                        </md-button>
+                    </div>
+                </form>
+                <?php
+            }
+            ?>
+        </md-list>
+
+        <?php
+        $paginationUrl = array($lang);
+        $pagination->display($paginationUrl);
+        ?>
+    </div>
+
+</div>

--- a/app/views/vocabulary/of.ctp
+++ b/app/views/vocabulary/of.ctp
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2009  HO Ngoc Phuong Trang <tranglich@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Tatoeba
+ * @author   HO Ngoc Phuong Trang <tranglich@gmail.com>
+ * @license  Affero General Public License
+ * @link     http://tatoeba.org
+ */
+?>
+<?php
+$javascript->link('/js/vocabulary/of.ctrl.js', false);
+
+$count = $paginator->counter('%count%');
+$title = format(
+    __("{username}'s vocabulary items ({number})", $count, true),
+    array('username' => $username, 'number' => $count)
+);
+
+$this->set('title_for_layout', $pages->formatTitle($title));
+?>
+
+<div id="annexe_content">
+    <?php echo $this->element('vocabulary/menu'); ?>
+
+    <?php $commonModules->createFilterByLangMod(2); ?>
+</div>
+
+<div id="main_content" ng-controller="VocabularyOfController as ctrl">
+    <div class="section" md-whiteframe="1">
+        <h2><?= $title ?></h2>
+
+        <?php
+        $paginationUrl = array($username);
+        $pagination->display($paginationUrl);
+        ?>
+
+        <md-list flex>
+            <?php
+            foreach($vocabulary as $item) {
+                $id = $item['Vocabulary']['id'];
+                $divId = bin2hex($id);
+                $lang = $item['Vocabulary']['lang'];
+                $text = $item['Vocabulary']['text'];
+                $numSentences = $item['Vocabulary']['numSentences'];
+                $numSentencesLabel = $numSentences == 1000 ? '1000+' : $numSentences;
+                $url = $html->url(array(
+                    'controller' => 'sentences',
+                    'action' => 'search',
+                    '?' => array(
+                        'query' => '="' . $text . '"',
+                        'from' => $lang
+                    )
+                ));
+                ?>
+                <md-list-item id="vocabulary_<?= $divId ?>">
+                    <img class="vocabulary-lang" src="/img/flags/<?= $lang ?>.png"/>
+                    <div class="vocabulary-text" flex><?= $text ?></div>
+                    <md-button class="md-primary" href="<?= $url ?>">
+                        <?= format(
+                            __n(
+                                '{number} sentence', '{number} sentences',
+                                $numSentences,
+                                true
+                            ),
+                            array('number' => $numSentencesLabel)
+                        ); ?>
+                    </md-button>
+                    <? if ($canEdit) { ?>
+                        <md-button ng-click="ctrl.remove('<?= $divId ?>')"
+                                   class="md-icon-button">
+                            <md-icon aria-label="Remove">delete</md-icon>
+                        </md-button>
+                    <? } ?>
+                </md-list-item>
+                <?php
+            }
+            ?>
+        </md-list>
+
+        <?php
+        $paginationUrl = array($username);
+        $pagination->display($paginationUrl);
+        ?>
+    </div>
+
+</div>

--- a/app/views/vocabulary/remove.ctp
+++ b/app/views/vocabulary/remove.ctp
@@ -1,0 +1,3 @@
+<?php
+echo json_encode($vocabularyId);
+?>

--- a/app/views/vocabulary/save.ctp
+++ b/app/views/vocabulary/save.ctp
@@ -1,0 +1,3 @@
+<?php
+echo json_encode($result);
+?>

--- a/app/views/vocabulary/save_sentence.ctp
+++ b/app/views/vocabulary/save_sentence.ctp
@@ -1,0 +1,8 @@
+<?php
+$sentence['url'] = $html->url(array(
+    'controller' => 'sentences',
+    'action' => 'show',
+    $sentence['id']
+));
+echo json_encode($sentence);
+?>

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -483,6 +483,11 @@ rt {
     margin-right: 290px;
 }
 
+.section {
+    padding: 20px;
+    margin-bottom: 20px;
+}
+
 .module {
     padding: 10px 10px 5px 10px;
     margin: 0 0 20px 0;
@@ -721,4 +726,5 @@ md-toolbar {
 
 .md-button {
     padding: 0 10px;
+    font-size: 16px;
 }

--- a/app/webroot/css/vocabulary/add.css
+++ b/app/webroot/css/vocabulary/add.css
@@ -1,0 +1,45 @@
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2010  HO Ngoc Phuong Trang <tranglich@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.vocabulary-lang,
+.vocabulary-text {
+    margin: 0 5px;
+}
+
+#annexe_content .md-button {
+    text-transform: none;
+    font-size: 16px;
+}
+
+md-list-item {
+    border-top: 1px solid #f1f1f1;
+}
+
+.language {
+    padding: 2px 10px;
+    margin-top: 2px;
+}
+
+.language label {
+    font-size: 13px;
+}
+
+.language select {
+    margin-top: 5px;
+    width: 150px;
+}

--- a/app/webroot/css/vocabulary/add_sentences.css
+++ b/app/webroot/css/vocabulary/add_sentences.css
@@ -1,0 +1,43 @@
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2010  HO Ngoc Phuong Trang <tranglich@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.vocabulary-lang,
+.vocabulary-text {
+    margin: 0 5px;
+}
+
+#annexe_content .md-button {
+    text-transform: none;
+    font-size: 16px;
+}
+
+md-list-item {
+    border-top: 1px solid #f1f1f1;
+}
+
+md-input-container .md-errors-spacer {
+    display: none;
+}
+
+.sentence-form {
+    margin-bottom: 10px;
+}
+
+.new-sentences {
+    margin-bottom: 5px;
+}

--- a/app/webroot/css/vocabulary/of.css
+++ b/app/webroot/css/vocabulary/of.css
@@ -1,0 +1,31 @@
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2010  HO Ngoc Phuong Trang <tranglich@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.vocabulary-lang,
+.vocabulary-text {
+    margin: 0 5px;
+}
+
+#annexe_content .md-button {
+    text-transform: none;
+    font-size: 16px;
+}
+
+md-list-item {
+    border-top: 1px solid #f1f1f1;
+}

--- a/app/webroot/js/vocabulary/add-sentences.ctrl.js
+++ b/app/webroot/js/vocabulary/add-sentences.ctrl.js
@@ -1,0 +1,55 @@
+(function() {
+    'use strict';
+
+    angular
+        .module('app')
+        .controller('VocabularyAddSentencesController', [
+            '$http', VocabularyAddSentencesController
+        ]);
+
+    function VocabularyAddSentencesController($http) {
+        var vm = this;
+
+        vm.showForm = showForm;
+        vm.hideForm = hideForm;
+        vm.saveSentence = saveSentence;
+
+        vm.sentencesAdded = {};
+
+        ///////////////////////////////////////////////////////////////////////////
+
+        function showForm(id) {
+            $('#form_' + id).removeClass('ng-hide');
+            $('#form_' + id + ' input').focus();
+        }
+
+        function hideForm(id) {
+            $('#form_' + id).addClass('ng-hide');
+        }
+
+        function saveSentence(id, lang) {
+            var loader = $('#loader_' + id);
+            var body = {
+                'text': vm.sentence[id],
+                'lang': lang
+            };
+
+            if (!vm.sentencesAdded[id]) {
+                vm.sentencesAdded[id] = [];
+            }
+
+            loader.removeClass('ng-hide');
+            hideForm(id);
+
+            $http.post('/vocabulary/save_sentence/' + id, body).then(
+                function(response) {
+                    loader.addClass('ng-hide');
+
+                    vm.sentencesAdded[id].push(response.data);
+                    vm.sentence[id] = null;
+                }
+            );
+        }
+
+    }
+})();

--- a/app/webroot/js/vocabulary/add-sentences.ctrl.js
+++ b/app/webroot/js/vocabulary/add-sentences.ctrl.js
@@ -1,3 +1,20 @@
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 (function() {
     'use strict';
 

--- a/app/webroot/js/vocabulary/add.ctrl.js
+++ b/app/webroot/js/vocabulary/add.ctrl.js
@@ -1,0 +1,45 @@
+(function() {
+    'use strict';
+
+    angular
+        .module('app')
+        .controller('VocabularyAddController', ['$http', VocabularyAddController]);
+
+    function VocabularyAddController($http) {
+        var vm = this;
+
+        vm.data = {};
+        vm.vocabularyAdded = [];
+
+        vm.add = add;
+        vm.remove = remove;
+        vm.isAdding = false;
+
+        ///////////////////////////////////////////////////////////////////////////
+
+        function add() {
+            vm.isAdding = true;
+            $http.post('/vocabulary/save', vm.data).then(
+                function(response) {
+                    var data = response.data;
+                    var query = encodeURIComponent('="' + data.text + '"');
+                    data.url = '/sentences/search?' +
+                        'query=' + query + '&' +
+                        'from=' + data.lang;
+
+                    vm.vocabularyAdded.unshift(data);
+                    vm.data.text = '';
+                    vm.isAdding = false;
+                }
+            );
+        }
+
+        function remove(id) {
+            $http.post('/vocabulary/remove/' + id).then(
+                function(response) {
+                    $('#vocabulary_' + id).hide();
+                }
+            );
+        }
+    }
+})();

--- a/app/webroot/js/vocabulary/add.ctrl.js
+++ b/app/webroot/js/vocabulary/add.ctrl.js
@@ -1,3 +1,20 @@
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 (function() {
     'use strict';
 

--- a/app/webroot/js/vocabulary/of.ctrl.js
+++ b/app/webroot/js/vocabulary/of.ctrl.js
@@ -1,0 +1,23 @@
+(function() {
+    'use strict';
+
+    angular
+        .module('app')
+        .controller('VocabularyOfController', ['$http', VocabularyOfController]);
+
+    function VocabularyOfController($http) {
+        var vm = this;
+
+        vm.remove = remove;
+
+        ///////////////////////////////////////////////////////////////////////////
+
+        function remove(id) {
+            $http.post('/vocabulary/remove/' + id).then(
+                function(response) {
+                    $('#vocabulary_' + id).hide();
+                }
+            );
+        }
+    }
+})();

--- a/app/webroot/js/vocabulary/of.ctrl.js
+++ b/app/webroot/js/vocabulary/of.ctrl.js
@@ -1,3 +1,19 @@
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 (function() {
     'use strict';
 

--- a/docs/database/acl/acos
+++ b/docs/database/acl/acos
@@ -107,3 +107,10 @@ cake acl create aco Transcriptions reset
 
 cake acl create aco controllers Recordings
 cake acl create aco Recordings import
+
+cake acl create aco controllers Vocabulary
+cake acl create aco Vocabulary add
+cake acl create aco Vocabulary add_sentences
+cake acl create aco Vocabulary save
+cake acl create aco Vocabulary remove
+cake acl create aco Vocabulary save_sentence

--- a/docs/database/acl/aros_acos
+++ b/docs/database/acl/aros_acos
@@ -23,6 +23,7 @@ cake acl deny  Group.2 Wall/unhide_message all
 cake acl grant Group.2 Transcriptions all
 cake acl grant Group.2 Recordings all
 cake acl deny  Group.2 Recordings/import all
+cake acl grant Group.2 Vocabulary all
 
 cake acl grant Group.3 Favorites all
 cake acl grant Group.3 Links all
@@ -47,6 +48,7 @@ cake acl deny  Group.3 Wall/unhide_message all
 cake acl grant Group.3 Transcriptions all
 cake acl grant Group.3 Recordings all
 cake acl deny  Group.3 Recordings/import all
+cake acl grant Group.3 Vocabulary all
 
 cake acl grant Group.4 Favorites all
 cake acl grant Group.4 PrivateMessages all
@@ -69,3 +71,4 @@ cake acl deny  Group.4 Wall/unhide_message all
 cake acl grant Group.4 Transcriptions all
 cake acl grant Group.4 Recordings all
 cake acl deny  Group.4 Recordings/import all
+cake acl grant Group.4 Vocabulary all

--- a/docs/database/tables/users_vocabulary.sql
+++ b/docs/database/tables/users_vocabulary.sql
@@ -1,0 +1,19 @@
+--
+-- Table structure for table `users_vocabulary`
+--
+-- This table represents each user's vocabulary list.
+--
+-- id
+-- user_id       ID of the user.
+-- vocabulary_id ID of the vocabulary item.
+-- created       Date when the vocabulary item was added.
+--
+
+DROP TABLE IF EXISTS `users_vocabulary`;
+CREATE TABLE `users_vocabulary` (
+  `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `user_id` int(11) NOT NULL,
+  `vocabulary_id` binary(16) NOT NULL,
+  `created` datetime DEFAULT NULL,
+  UNIQUE KEY `user_vocabulary` (`user_id`,`vocabulary_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/docs/database/tables/vocabulary.sql
+++ b/docs/database/tables/vocabulary.sql
@@ -1,0 +1,23 @@
+--
+-- Table structure for table `vocabulary`
+--
+-- This table stores the vocabulary items of users.
+--
+-- id           Contains the hash value of (lang + text).
+-- lang         Language of the vocabulary item.
+-- text         Text of the vocabulary item. Using varbinary in order to support UTF-8
+--                characters encoded on 4 bytes.
+-- numSentences Number of search results for the vocabulary item.
+-- numAdded     Number of vocabulary lists where the item was added.
+-- created      Date and time when the vocabulary item was added.
+--
+
+DROP TABLE IF EXISTS `vocabulary`;
+CREATE TABLE `vocabulary` (
+  `id` binary(16) PRIMARY KEY,
+  `lang` varchar(4) DEFAULT NULL,
+  `text` varbinary(1500) NOT NULL,
+  `numSentences` int(10) DEFAULT 0,
+  `numAdded` int(10) DEFAULT 0,
+  `created` datetime DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/docs/database/triggers/update_vocabulary_count.sql
+++ b/docs/database/triggers/update_vocabulary_count.sql
@@ -1,0 +1,18 @@
+DROP TRIGGER IF EXISTS increment_vocabulary_count;
+DROP TRIGGER IF EXISTS decrement_vocabulary_count;
+
+delimiter |
+
+CREATE TRIGGER increment_vocabulary_count AFTER INSERT ON users_vocabulary
+FOR EACH ROW BEGIN
+    UPDATE vocabulary SET numAdded = numAdded + 1 WHERE id = NEW.vocabulary_id;
+END;
+
+CREATE TRIGGER decrement_vocabulary_count AFTER DELETE ON users_vocabulary
+FOR EACH ROW BEGIN
+    UPDATE vocabulary SET numAdded = numAdded - 1 WHERE id = OLD.vocabulary_id;
+END;
+
+|
+
+delimiter ;


### PR DESCRIPTION
This pull request addresses issue #1166.

**Technical notes**

Just like for the sentences, we don't want duplicates in the vocabulary items. The vocabulary items are stored in a table called `vocabulary` which has a column `lang` and `text`. The constraint is that (lang + text) must be unique.

In order to achieve this, the `id` column is a hash of `lang` + `text`. As suggested by @allan-simon in an email, we're using the Murmur algorithm to generate this hash. It seems indeed to be the [most efficient one][1].

[1]: http://programmers.stackexchange.com/questions/49550/which-hashing-algorithm-is-best-for-uniqueness-and-speed

This mechamish can be more or less reused for issue #577.