### PR TITLE
Revert Angular Material changes on sentences block

### DIFF
--- a/app/views/helpers/menu.php
+++ b/app/views/helpers/menu.php
@@ -645,7 +645,10 @@ class MenuHelper extends AppHelper
 
         <li>
         <?php
-        echo "<md-progress-circular  md-diameter='16' style='display: none;' id='_" . $sentenceId ."_in_process'></md-progress-circular>";
+        echo $this->Html->div('loader-small loader', '', array(
+            'id' => '_'.$sentenceId.'_in_process',
+            'style' => 'display:none',
+        ));
         echo $this->Html->image(
             IMG_PATH . 'valid_16x16.png',
             array(

--- a/app/views/helpers/sentences.php
+++ b/app/views/helpers/sentences.php
@@ -107,7 +107,10 @@ class SentencesHelper extends AppHelper
 
 
         // Loading icon
-        echo  "<md-progress-circular class='translation-loader' id='_" . $id . "_loading' style='display: none;'></md-progress-circular>";
+        echo $this->Html->div('translation-loader loader', '', array(
+            'id' => '_'.$id.'_loading',
+            'style' => 'display:none',
+        ));
 
         // Form to add a new translation
         $this->_displayNewTranslationForm($id);
@@ -143,7 +146,7 @@ class SentencesHelper extends AppHelper
             = $this->segregateTranslations($translations);
         ?>
         <div id="_<?php echo $id; ?>_translations" class="translations">
-
+            
             <?php
             $this->Javascript->link('sentences.collapse.js', false);
 
@@ -165,19 +168,19 @@ class SentencesHelper extends AppHelper
                 $initiallyDisplayedTranslations = 5;
                 $displayed = $totalTranslations - $initiallyDisplayedTranslations;
             }
-
-            //Split 'allTranslations' array into two, visible & hidden sets of sentences
+            
+            //Split 'allTranslations' array into two, visible & hidden sets of sentences        
             $visibleTranslations = array_slice($allTranslations, 0, $initiallyDisplayedTranslations);
             $hiddenTranslations = array_slice($allTranslations, $initiallyDisplayedTranslations);
-
-            $sentenceCount = 0;
+            
+            $sentenceCount = 0;  
 
             //visible list of translations
             foreach ($visibleTranslations as $translation) {
 
                 if ($sentenceCount < $totalDirectTranslations)
                     $type = 'directTranslation';
-                else
+                else 
                     $type = 'indirectTranslation';
 
                 $this->displayGenericSentence(
@@ -207,12 +210,12 @@ class SentencesHelper extends AppHelper
 
             //expanded list of translations
             echo $this->Html->tag('div', null, array('class' => 'more'));
-
+            
             foreach ($hiddenTranslations as $translation) {
 
                 if ($sentenceCount < $totalDirectTranslations)
                     $type = 'directTranslation';
-                else
+                else 
                     $type = 'indirectTranslation';
 
                 $this->displayGenericSentence(
@@ -233,7 +236,7 @@ class SentencesHelper extends AppHelper
                     array('class' => 'hideLink')
                 );
             ?>
-          </div>
+          </div>  
         </div>
         <?php
     }
@@ -387,22 +390,31 @@ class SentencesHelper extends AppHelper
             )
         );
         echo '</div>';
-        ?>
 
-        <div layout="row" layout-align="end center">
-            <md-button id="<?php echo '_'.$id.'_cancel'; ?>"
-                       class="md-raised">
-                <?php __('Cancel'); ?>
-            </md-button>
+        // Buttons
+        echo '<div class="addTranslation_buttons">';
+        // OK
+        echo $this->Form->button(
+            __('Submit translation', true),
+            array(
+                'id' => '_'.$id.'_submit',
+                'class' => 'submit button'
+            )
+        );
 
-            <md-button id="<?php echo '_'.$id.'_submit'; ?>"
-                       class="md-raised md-primary">
-                <?php __('Submit translation'); ?>
-            </md-button>
-        </div>
+        // Cancel
+        echo $this->Form->button(
+            __('Cancel', true),
+            array(
+                'id' => '_'.$id.'_cancel',
+                'type' => 'reset',
+                'class'=>'cancel button'
+            )
+        );
+        echo '</div>';
 
-        </div>
-        <?php
+        echo '</div>';
+
     }
 
 
@@ -518,7 +530,7 @@ class SentencesHelper extends AppHelper
         } else {
             echo '<div class="content column">';
         }
-
+        
         // Link/unlink button
         if (CurrentUser::isTrusted()) {
             $this->_displayLinkOrUnlinkButton(
@@ -550,7 +562,6 @@ class SentencesHelper extends AppHelper
         if( $isFavoritePage && $this->params['pass'][0] == CurrentUser::get('username') ){
             echo '<div class="favorite-page column">';
             $this->Menu->favoriteButton($sentenceId, true, true, true);
-            echo '<li class="option favorite progress" style="display: none;"><md-progress-circular md-diameter="24"></md-progress-circular></li>';
             echo '</div>';
         }
 
@@ -570,11 +581,11 @@ class SentencesHelper extends AppHelper
 
         <?php
     }
-
-
+    
+    
     /**
      * Returns the label for the correctness of a sentence.
-     *
+     * 
      * @param int $correctness Correctness of the sentence.
      *
      * @return String
@@ -582,7 +593,7 @@ class SentencesHelper extends AppHelper
     private function getCorrectnessLabel($correctness)
     {
         $result = 'correctness';
-
+        
         if ($correctness < 0) {
             $result .= 'Negative'.abs($correctness);
         } else if ($correctness == 0) {
@@ -590,11 +601,11 @@ class SentencesHelper extends AppHelper
         } else {
             $result .= 'Positive'.$correctness;
         }
-
+        
         return $result;
     }
 
-
+     
     /**
      * Display the link or unlink button.
      *
@@ -635,7 +646,6 @@ class SentencesHelper extends AppHelper
         $sentence,
         $isEditable
     ) {
-        echo "<md-progress-circular class='sentence-loader' md-diameter='20' id='_" . $sentence['id'] . "_translate_loader' style='display: none;'></md-progress-circular>";
         echo $this->Html->div('sentenceContent', null, array(
             'data-sentence-id' => $sentence['id'],
         ));

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -1252,12 +1252,12 @@ md-icon.disabled.material-icons {
     display: inline-block;
     background-color: #f6f6f6;
     border: 1px solid #ddd;
-    color: #4caf50;
+    color: #000000;
 }
 
 .editableSentence button[type="submit"] {
     background-color: #4caf50;
-    border: 1px solid #339900;
+    border: 1px solid #4caf50;
     color: #fff;
 }
 
@@ -1307,6 +1307,16 @@ input.sentenceId {
     height: 75px;
     width: 100%;
     font-size: 16px;
+}
+
+.addTranslations button{
+    color: #fff;
+    cursor: pointer;
+    font-size: 16px;
+    min-width: 120px;
+    padding: 3px 30px;
+    float:right;
+    line-height: 18px;
 }
 
 .addTranslationsTextInput {
@@ -1606,6 +1616,38 @@ div.hideLink {
     padding: 2px 10px;
 }
 
+
+/*
+ * --------------------------------------------------------------------
+ *
+ *   Buttons
+ *
+ * --------------------------------------------------------------------
+ */
+
+.form .button {
+    display: inline-block;
+    min-width: 120px;
+    padding: 2px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    text-align: center;
+    margin-left: 20px;
+    font-size: 16px;
+    box-sizing: border-box;
+}
+
+.form .button.submit {
+    background-color: #4caf50;
+    border: 1px solid #4caf50;
+    color: #fff;
+}
+
+.form .button.cancel {
+    background-color: #f6f6f6;
+    border: 1px solid #ddd;
+    color: #000000;
+}
 
 /*
  * --------------------------------------------------------------------

--- a/app/webroot/js/collections.add_remove.js
+++ b/app/webroot/js/collections.add_remove.js
@@ -24,7 +24,6 @@ $(document).ready(function(){
         var sentenceId = $(this).attr("data-sentence-id");
         var correctness = $(this).attr("data-sentence-correctness");
         var addToCorpusOption = $(this);
-        var loader = $("#_" + sentenceId + "_in_process");
         var action = "add";
 
         var requestUrl = "/collections";
@@ -35,11 +34,10 @@ $(document).ready(function(){
         }
 
         addToCorpusOptionParent = addToCorpusOption.parent();
-        loader.show();
+        addToCorpusOption.html("<div class='loader-small loader'></div>");
 
         $.post(requestUrl, {}, function(data){
             addToCorpusOptionParent.replaceWith(data);
-            loader.hide();
         });
     });
 });

--- a/app/webroot/js/favorites.add.js
+++ b/app/webroot/js/favorites.add.js
@@ -18,6 +18,7 @@
 
 
 $(document).ready(function(){
+
     var sentenceDictionary = new Array();
     $('.sentenceContent').each(function(){
         var key = $(this).attr("data-sentence-id");
@@ -37,15 +38,9 @@ $(document).ready(function(){
 
         var requestUrl = "/favorites/" + action + "/" + favoriteId;
         if(favoriteOption.parent().hasClass("favorite-page")){
-            requestUrl += "/true"; 
+            requestUrl += "/true";
         }
-        if(favoriteOption.parent().hasClass("favorite-page")){
-            favoriteOption.hide();
-            var loader = favoriteOption.parent().find(".option.favorite.progress");
-            loader.show();    
-        } else {
-            $("#_" + favoriteId + "_in_process").show();
-        }
+        favoriteOption.html("<div class='loader-small loader'></div>");
         $.post(requestUrl, {}, function(data) {
             if(favoriteOption.parent().hasClass("favorite-page")){
                 if(favoriteOption.hasClass("remove")){
@@ -62,15 +57,7 @@ $(document).ready(function(){
                     favoriteOption.parent().parent().find(".lang.column").css("display", "");
                 }
             }
-            
-            if(favoriteOption.parent().hasClass("favorite-page")){
-                loader.hide();
-                favoriteOption.show();     
-            } else {
-               $("#_" + favoriteId + "_in_process").hide();
-            }
             favoriteOption.replaceWith(data);
-            
         });
     });
 

--- a/app/webroot/js/sentences.edit_in_place.js
+++ b/app/webroot/js/sentences.edit_in_place.js
@@ -32,10 +32,9 @@ $(document).ready(function() {
                 if($(this).find('textarea').val().trim().length == 0){
                     return false;
                 } else {
-                    $("#_" + sentenceId + "_translate_loader").show();
-                    return true;   
+                    return true;
                 }
-            }, 
+            },
             cancel    : div.attr('data-cancel'),
             event     : 'edit_sentence',
             data : function(value, settings) {
@@ -56,9 +55,8 @@ $(document).ready(function() {
                         }
                     );
                 }
-                $("#_" + sentenceId + "_translate_loader").hide();
             },
-            indicator : "<div></div>",
+            indicator : "<div class='sentence-loader loader'></div>",
             cssclass  : 'editInPlaceForm',
             onblur    : 'ignore'
         }).bind('edit_sentence', function(e) {


### PR DESCRIPTION
Several users reported a big increase of load time on the search page.

Although I haven't exactly identified what, it is definitely due to the introduction of Angular Material components. Mixing these components with our current jQuery code doesn't seem to play very well.

We cannot introduce Angular Material step by step into the sentences block, we will have to rework it all at once.

Until then, this pull requests reverts changes that introduces Angular Material components (buttons  #1184 and loaders  #1194) in the sentences block.

Parent issue: #1180