### PR TITLE
Change font to Noto

### DIFF
--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -56,8 +56,45 @@
 /*
  * Generic rules
  */
-body, select, input, textarea, button {
-    font-family: Trebuchet MS, sans-serif;
+body, select, input, textarea, button, option, optgroup {
+    font-family: "Noto Sans", sans-serif;
+
+    /* Fonts for other languages */
+    /*
+    "Noto Kufi Arabic", "Noto Naskh Arabic",
+    "Noto Nastaliq Urdu", "Noto Sans Armenian", "Noto Sans Avestan",
+    "Noto Sans Balinese", "Noto Sans Bamum", "Noto Sans Batak",
+    "Noto Sans Bengali", "Noto Sans Brahmi", "Noto Sans Buginese",
+    "Noto Sans Buhid", "Noto Sans CJK JP", "Noto Sans CJK KR",
+    "Noto Sans CJK SC", "Noto Sans CJK TC", "Noto Sans Canadian Aboriginal",
+    "Noto Sans Carian", "Noto Sans Cham", "Noto Sans Cherokee",
+    "Noto Sans Coptic", "Noto Sans Cuneiform", "Noto Sans Cypriot",
+    "Noto Sans Deseret", "Noto Sans Devanagari", "Noto Sans Egyptian Hieroglyphs",
+    "Noto Sans Ethiopic", "Noto Sans Georgian", "Noto Sans Glagolitic",
+    "Noto Sans Gothic", "Noto Sans Gujarati", "Noto Sans Gurmukhi",
+    "Noto Sans Hanunoo", "Noto Sans Hebrew", "Noto Sans Imperial Aramaic",
+    "Noto Sans Inscriptional Pahlavi", "Noto Sans Inscriptional Parthian",
+    "Noto Sans Javanese", "Noto Sans Kaithi", "Noto Sans Kannada",
+    "Noto Sans Kayah Li", "Noto Sans Kharoshthi", "Noto Sans Khmer",
+    "Noto Sans Lao", "Noto Sans Lepcha", "Noto Sans Limbu", "Noto Sans Linear B",
+    "Noto Sans Lisu", "Noto Sans Lycian", "Noto Sans Lydian",
+    "Noto Sans Malayalam", "Noto Sans Mandaic", "Noto Sans Meetei Mayek",
+    "Noto Sans Mongolian", "Noto Sans Myanmar", "Noto Sans NKo",
+    "Noto Sans New Tai Lue", "Noto Sans Ogham", "Noto Sans Ol Chiki",
+    "Noto Sans Old Italic", "Noto Sans Old Persian", "Noto Sans Old South Arabian",
+    "Noto Sans Old Turkic", "Noto Sans Oriya", "Noto Sans Osmanya",
+    "Noto Sans Phags Pa", "Noto Sans Phoenician", "Noto Sans Rejang",
+    "Noto Sans Runic", "Noto Sans Samaritan", "Noto Sans Saurashtra",
+    "Noto Sans Shavian", "Noto Sans Sinhala", "Noto Sans Sundanese",
+    "Noto Sans Syloti Nagri", "Noto Sans Syriac Eastern",
+    "Noto Sans Syriac Estrangela", "Noto Sans Syriac Western",
+    "Noto Sans Tagalog", "Noto Sans Tagbanwa", "Noto Sans Tai Le",
+    "Noto Sans Tai Tham", "Noto Sans Tai Viet", "Noto Sans Tamil",
+    "Noto Sans Telugu", "Noto Sans Thaana", "Noto Sans Thai", "Noto Sans Tibetan",
+    "Noto Sans Tifinagh", "Noto Sans Ugaritic", "Noto Sans Vai",
+    "Noto Sans Yi", "Noto Serif Armenian", "Noto Serif Georgian",
+    "Noto Serif Khmer", "Noto Serif Lao", "Noto Serif Thai",
+    */
 }
 
 div, p {
@@ -373,12 +410,13 @@ rt {
     font-size: 20px;
     padding: 2px 5px;
     padding-right: 30px;
+    height: 36px;
 }
 
 .search_bar select {
     width: 200px;
     font-size: 14px;
-    height: 30px;
+    height: 36px;
 }
 
 .search_bar .input {
@@ -495,7 +533,7 @@ rt {
 .module {
     padding: 10px 10px 5px 10px;
     margin: 0 0 20px 0;
-    font-size: 13px;
+    font-size: 14px;
     border-bottom: 1px solid #ededed;
     background: linear-gradient(to top, rgba(245, 245, 245, 1) 0%, rgba(255, 255, 255, 0) 100px, rgba(255, 255, 255, 0) 100%);
 }

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -440,7 +440,7 @@
     border: 1px solid #ccc;
     border-bottom: none;
     border-left: none;
-    padding: 10px 10px 1px 10px;
+    padding: 10px 10px 3px 10px;
     background-color: #fff;
     margin-bottom: -1px;
     border-top-right-radius: 4px;
@@ -560,7 +560,6 @@
 .message .body {
     border-top: 1px solid #ddd;
     border-right: 1px solid #ddd;
-    line-height: 18px;
 }
 
 .message .body .sentence {

--- a/app/webroot/css/pages/index.css
+++ b/app/webroot/css/pages/index.css
@@ -78,7 +78,7 @@
 }
 
 #new-search-bar #SentenceQuery {
-    padding: 10px 40px 10px 10px;
+    padding: 5px 40px 5px 10px;
     width: 800px;
     margin-left: -4px;
 }


### PR DESCRIPTION
Ref. #1180 

This pull request modifies the font used in Tatoeba, from Trebuchet MS to Noto. The font sizes have also be readjusted.

Since Noto is not installed by default on most systems, this means that most users will end up seeing Tatoeba with the default sans-serif font of their browser (Arial, Helvetica... who knows), until they download and install Noto.

I hesitated for a long time between using Roboto vs. Noto, and ended up opting for Noto. And this is still not a stable decision.

Roboto is the font which Material Design is designed with, and if we want to be consistent with the spec, we should use Roboto. It offers a larger range of font weights than Noto. The difference is mostly noticeable for buttons and sub-headers, where the font weight is 500. With other fonts, the thickness of the characters appears thinner than with Roboto, which can make the labels for buttons and sub-headers a bit harder to read.

Roboto however doesn't cover all scripts, and Material Design relies on Noto for scripts that are not covered by Roboto.

Noto's base height is slightly bigger than Roboto, and Arial, for that matter. In other words, for the same font-size, the characters in Noto take more vertical space than Roboto. This can make designing the UI a bit more complicated... but this is something we need to deal with anyway for languages like Marathi, one of the languages in which the UI is translated.

With the current setup, we don't include the fonts in the HTML header. Users will have to download and install the fonts if they want to see Tatoeba in its new font. Later on, we can create options for users to have these fonts included. But right now, anyone who wants Tatoeba to look prettier (or more accurate) has to download the fonts and/or configure their browsers settings accordingly. In this context, it feels easier for users to go to only one website (the Noto website) in order to download the whole font set.

In any case, whatever Web font we choose, it won't affect the lambda user at this time.

Also, for now, only Noto Sans is included in the CSS. The other Noto fonts for other languages have not been included yet. They will be introduced slowly, when we can get confirmation from native speakers that the font is appropriate.