### PR TITLE
Fix regression that forced users to enter birthday when saving profile.

### DIFF
--- a/app/controllers/user_controller.php
+++ b/app/controllers/user_controller.php
@@ -363,7 +363,7 @@ class UserController extends AppController
     }
 
     /**
-     * Return true if entered birthday is a valid date.
+     * Return true if entered birthday is a valid date or is not complete/set.
      *
      * @param  array  $data
      *
@@ -378,7 +378,9 @@ class UserController extends AppController
 
             $year = $data['User']['birthday']['year'];
 
-            return checkdate($month, $day, $year);
+            if ($day && $month && $year) {
+                return checkdate($month, $day, $year);
+            }
         }
 
         return true;


### PR DESCRIPTION
This pull request addresses issue #1249.      
     
This allows users to save profiles with an incomplete or unset birthday. The only problem I can see is that if a user tries to save an incomplete birthday (only the year, for example), the database won't save it and they won't get any error message explaining why. If this is a problem, we can add an additional check for incomplete birthdays and give users an appropriate error message.