### PR TITLE
Fixed Pashto and Sindhi script from LTR to RTL

### DIFF
--- a/app/vendors/languages_lib.php
+++ b/app/vendors/languages_lib.php
@@ -604,6 +604,7 @@ class LanguagesLib
             "aii",
             "afb",
             "pus"
+            "snd"
         );
 
         if (in_array($lang, $rightToLeftLangs)) {

--- a/app/vendors/languages_lib.php
+++ b/app/vendors/languages_lib.php
@@ -603,8 +603,8 @@ class LanguagesLib
             "ary",
             "aii",
             "afb",
-            "pus"
-            "snd"
+            "pus",
+            "snd",
         );
 
         if (in_array($lang, $rightToLeftLangs)) {

--- a/app/vendors/languages_lib.php
+++ b/app/vendors/languages_lib.php
@@ -603,6 +603,7 @@ class LanguagesLib
             "ary",
             "aii",
             "afb",
+            "pus"
         );
 
         if (in_array($lang, $rightToLeftLangs)) {


### PR DESCRIPTION
This pull request addresses #1252 

It fixes Pashto script which, like other Arabic languages, should be written Right to Left. Currently, it is Left to Right. 