### PR TITLE
Redesign flash messages

### DIFF
--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -615,13 +615,13 @@ rt {
 /*
  * Flash message
  */
-#flashMessage, #authMessage {
-    margin: 25px;
-    padding: 10px 20px;
-    color: #E05900;
-    background: #EDE0B8;
-    text-align: center;
-    font-size: 1.2em;
+#flashMessage {
+    margin: 20px 5% 40px 5%;
+    padding: 20px;
+    color: #ffffff;
+    background: #424242;
+    border: none;
+    border-radius: 2px;
 }
 
 /*


### PR DESCRIPTION
This pull request changes the design of the flash messages.

In the long term we will get rid of the flash message pattern. We will be using [toasts](https://material.angularjs.org/latest/demo/toast) instead. In the meantime, this is just making the flash message look similar to a toast, color-wise.

**Old flash message**

![screenshot_29](https://cloud.githubusercontent.com/assets/221850/16822651/42fa0772-495e-11e6-80e0-0601281954ba.png)

**New flash message**

![screenshot_28](https://cloud.githubusercontent.com/assets/221850/16822656/4967b2bc-495e-11e6-84d9-df282614185e.png)

Parent issue: #1180 