### PR TITLE
Stripped '$' sign off numbers only

### DIFF
--- a/app/vendors/shells/sphinx_conf.php
+++ b/app/vendors/shells/sphinx_conf.php
@@ -201,8 +201,8 @@ class SphinxConfShell extends Shell {
     );
 
     public $regexpFilter = array(
-      '\$(\w+) => $ \1', 
-      '(\w+)\$ => \1 $' 
+      '\$(\d+) => $ \1', 
+      '(\d+)\$ => \1 $' 
     );
 
     public $indexExtraOptions = array();


### PR DESCRIPTION
This PR addresses issue #1243.

Because `$` sign was stripped off its adjacent words during search by regexp_filter, `$` was ignored as query hint. Now this sign is ignored was query hint only if it is adjacent to string of digits.