### PR TITLE
Got rid of duplicate binding of language change event

### DIFF
--- a/app/webroot/js/sentences.change_language.js
+++ b/app/webroot/js/sentences.change_language.js
@@ -34,6 +34,7 @@ $(document).ready(function() {
         
         $("#selectLangContainer_" + sentenceId).toggle();
         
+        $("#selectLang_" + sentenceId).unbind('change');
         $("#selectLang_" + sentenceId).change(function(){
         
             var newLang = $(this).val();


### PR DESCRIPTION
This PR addresses the issue #566.

Although click handlers were bound only once, additional change event was bound at each click. These kind of issues will go away once we migrate to AngularJS.

NB, this PR will conflict with PR #1251