### PR TITLE
Improve vocabulary list number of sentences functionality

### DIFF
--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -72,6 +72,7 @@ class SentencesController extends AppController
         'UsersLanguages',
         'Tag',
         'UsersSentences',
+        'Vocabulary'
     );
 
     private $defaultSearchCriteria = array(
@@ -811,7 +812,11 @@ class SentencesController extends AppController
                 $real_total
             );
         }
+        
+        $strippedQuery = preg_replace('/"|=/', '', $query);
+        $vocabulary = $this->Vocabulary->findByText($strippedQuery);
 
+        $this->set('vocabulary', $vocabulary);
         $this->set(compact(array_keys($this->defaultSearchCriteria)));
         $this->set(compact('real_total', 'search_disabled', 'ignored', 'results'));
         $this->set(

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -569,7 +569,7 @@ class SentencesController extends AppController
             );
             $native = '';
         }
-        
+
         // Session variables for search bar
         $this->Session->write('search_query', $query);
         $this->Session->write('search_from', $from);

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -569,7 +569,7 @@ class SentencesController extends AppController
             );
             $native = '';
         }
-
+        
         // Session variables for search bar
         $this->Session->write('search_query', $query);
         $this->Session->write('search_from', $from);

--- a/app/controllers/vocabulary_controller.php
+++ b/app/controllers/vocabulary_controller.php
@@ -171,6 +171,8 @@ class VocabularyController extends AppController
     /**
      * Saves a sentence for vocabulary of given id and updates the count of
      * sentences for that vocabulary item.
+     *
+     * @param int $vocabularyId Hexadecimal value of the vocabulary id.
      */
     public function save_sentence($vocabularyId)
     {
@@ -189,18 +191,21 @@ class VocabularyController extends AppController
 
         $sentence = null;
         if ($isSaved) {
+            $numSentences = $this->Vocabulary->incrementNumSentences(
+                $vocabularyId,
+                $sentenceText
+            );
+
             $sentence = array(
                 'id' => $this->Sentence->id,
                 'text' => $sentenceText,
+                // 'numSentences' => $numSentences
             );
-
-            $this->Vocabulary->updateNumSentences($vocabularyId);
         }
 
         $this->set('sentence', $sentence);
 
         $this->layout = 'json';
     }
-
 }
 ?>

--- a/app/controllers/vocabulary_controller.php
+++ b/app/controllers/vocabulary_controller.php
@@ -83,7 +83,9 @@ class VocabularyController extends AppController
             $lang
         );
 
-        $this->set('vocabulary', $this->paginate());
+        $vocabulary = $this->Vocabulary->syncNumSentences($this->paginate());
+
+        $this->set('vocabulary', $vocabulary);
         $this->set('username', $username);
         $this->set('canEdit', $username == CurrentUser::get('username'));
     }
@@ -190,6 +192,7 @@ class VocabularyController extends AppController
         );
 
         $sentence = null;
+
         if ($isSaved) {
             $numSentences = $this->Vocabulary->incrementNumSentences(
                 $vocabularyId,
@@ -199,7 +202,7 @@ class VocabularyController extends AppController
             $sentence = array(
                 'id' => $this->Sentence->id,
                 'text' => $sentenceText,
-                // 'numSentences' => $numSentences
+                'numSentences' => $numSentences
             );
         }
 

--- a/app/controllers/vocabulary_controller.php
+++ b/app/controllers/vocabulary_controller.php
@@ -201,8 +201,7 @@ class VocabularyController extends AppController
 
             $sentence = array(
                 'id' => $this->Sentence->id,
-                'text' => $sentenceText,
-                'numSentences' => $numSentences
+                'text' => $sentenceText
             );
         }
 

--- a/app/models/vocabulary.php
+++ b/app/models/vocabulary.php
@@ -126,7 +126,6 @@ class Vocabulary extends AppModel
         return $result;
     }
 
-
     /**
      * Updates the number of sentences for a vocabulary item.
      *
@@ -151,6 +150,52 @@ class Vocabulary extends AppModel
         if ($numSentences) {
             $this->save($data);
         }
+    }
+
+    /**
+     * Increment vocabulary numSentences value by one if sentence contains
+     * vocabulary.
+     *
+     * @param  int    $id       Hexadecimal value of the vocabulary id.
+     * @param  string $sentence Sentence which should contain vocabulary text.
+     *
+     * @return int              Vocaubualry numSentences value.
+     */
+    public function incrementNumSentences($id, $sentence)
+    {
+        $vocabularyId = hex2bin($id);
+        $vocabulary = $this->findById($vocabularyId);
+
+        $vocabularyText = $vocabulary['Vocabulary']['text'];
+        $numSentences = intval($vocabulary['Vocabulary']['numSentences']);
+
+        if ($this->_sentenceContainsText($sentence, $vocabularyText)) {
+            $numSentences ++;
+
+            $data = array(
+                'id' => $vocabularyId,
+                'numSentences' => $numSentences
+            );
+
+            if ($numSentences) {
+                $this->save($data);
+            }
+        }
+
+        return $numSentences;
+    }
+
+    /**
+     * Return true if sentence contains given text.
+     *
+     * @param  string $sentence Haystack to be searched.
+     * @param  string $text     Needle to be searched for.
+     *
+     * @return boolean
+     */
+    private function _sentenceContainsText($sentence, $text)
+    {
+        return mb_stripos($sentence, $text) !== false;
     }
 }
 ?>

--- a/app/views/helpers/pages.php
+++ b/app/views/helpers/pages.php
@@ -55,5 +55,28 @@ class PagesHelper extends AppHelper
         $params = array_diff_key($this->params, array_flip(array("_Token")));
         return Router::reverse($params);
     }
+
+    /**
+     * Display a message if a vocabulary item exists and its numSentences count
+     * is different than the Sphinx real total.
+     *
+     * @param  array $vocabulary Vocabulary item.
+     * @param  int   $real_total Total number of sentences found by Sphinx.
+     *
+     * @return string
+     */
+    public function sentencesMayNotAppear($vocabulary, $real_total)
+    {
+        if ($real_total == null) {
+            $real_total = 0;
+        }
+        
+        if (!empty($vocabulary) && $real_total != $vocabulary['Vocabulary']['numSentences']) {
+            echo format(__(
+                'Recently added sentences may not appear in search results.',
+                true
+            ));
+        }
+    }
 }
 ?>

--- a/app/views/sentences/search.ctp
+++ b/app/views/sentences/search.ctp
@@ -131,6 +131,8 @@ if ($search_disabled) {
     }
     echo $this->Pages->formatTitleWithResultCount($paginator, $title, $real_total);
 
+    echo $this->Pages->sentencesMayNotAppear($vocabulary, $real_total);
+
     $pagination->display();
 
     foreach ($results as $sentence) {
@@ -150,6 +152,8 @@ if ($search_disabled) {
 
 } else {
     echo $this->element('search_with_no_result');
+
+    echo $this->Pages->sentencesMayNotAppear($vocabulary, $real_total);
 }
 ?>
 </div>


### PR DESCRIPTION
This pull request address issue #1278.

### Behavior
  - When a user adds a new sentence to a vocabulary item, the numSentence value on the item is incremented by one if the sentence contains the vocabulary item.
  - In order to avoid data consistency issues, when a user visits the vocabulary/of/username page, the vocabulary numSentences values are synced with the Sphinx index count. This way, users who regularly use and keep track of their vocabulary will have more accurate numSentence values.
  - When searching for a word, if a vocabulary item exists and its numSentence count differs from the Sphinx count, this message will appear below the search title: 'Recently added sentences may not appear in search results.’ This should help avoid confusion when users dont see their sentences immediately after adding them.

## Notes
  - In the end, I decided to us a simple `mb_stripos` statement instead of a regex to determine if a sentence contains a word. The logic has been extracted to its own method so if we want to improve it now or in the future, it should be easy.
  - I wanted some way to keep the numSentence values and the actual Sphinx count synced. Doing a cron job would be another option, but it may be overkill. By doing it when a user loads their vocabulary page, we can push responsibility for this to the user so only vocabulary for active users will be regularly synced. Possible downside is that it could make loading the page a little slower but I havent noticed any significant slowdown on production.