### PR TITLE
Redesign search bar

### DIFF
--- a/app/views/elements/search_bar.ctp
+++ b/app/views/elements/search_bar.ctp
@@ -47,82 +47,80 @@ echo $form->create(
     )
 );
 ?>
-<fieldset class="input text">
-    <label for="SentenceQuery">
-        <?php __('Search'); ?>
-    </label>
-    <?php
-    echo $html->div('search-bar-extra');
-    echo $html->link(
-        __('Help', true),
-        'http://en.wiki.tatoeba.org/articles/show/text-search',
-        array(
-            'target' => '_blank'
-        )
-    );
-    echo $html->link(
-        __p('title', 'Advanced search', true),
-        array(
-            'controller' => 'sentences',
-            'action' => 'advanced_search'
-        )
-    );
-    echo '</div>';
-    $clearButton = $this->Html->tag('button', '✖', array(
-        'id' => 'clearSearch',
-        'type' => 'button',
-        'title' => __('Clear search', true),
-    ));
-    echo $form->input(
-        'query',
-        array(
-            'id' => 'SentenceQuery',
-            'value' => $searchQuery,
-            'label' => '',
-            'accesskey' => 4,
-            'lang' => '',
-            'dir' => 'auto',
-            'after' => $clearButton,
-        )
-    );
-    ?>
-</fieldset>
+<div layout-gt-sm="row" layout-align-gt-sm="center end" layout-margin
+     layout="column" layout-align="center center">
+    <div layout="column" flex>
+        <div layout="row" layout-align="end center" class="search-bar-extra">
+            <?php
+            echo $html->link(
+                __('Help', true),
+                'http://en.wiki.tatoeba.org/articles/show/text-search',
+                array(
+                    'target' => '_blank'
+                )
+            );
+            echo $html->link(
+                __p('title', 'Advanced search', true),
+                array(
+                    'controller' => 'sentences',
+                    'action' => 'advanced_search'
+                )
+            );
+            ?>
+        </div>
 
-<fieldset class="select from">
-    <?php
-    echo $this->Search->selectLang(
-        'from',
-        $selectedLanguageFrom,
-        array(
-            'div' => false,
-            'label' => __('From', true),
-        )
-    );
-    ?>
-</fieldset>
+        <div layout="row">
+            <label for="SentenceQuery">
+                <?php __('Search'); ?>
+            </label>
+            <input id="SentenceQuery"
+                   type="text"
+                   name="query"
+                   value="<?= $searchQuery ?>"
+                   accesskey="4"
+                   lang=""
+                   dir="auto"
+                   flex>
+            <md-icon id="clearSearch">clear</md-icon>
+        </div>
+    </div>
 
-<fieldset class="into">
-    <span id="arrow">&raquo;</span>
-</fieldset>
-    
-<fieldset class="select to">
-    <?php
-    echo $this->Search->selectLang(
-        'to',
-        $selectedLanguageTo,
-        array(
-            'div' => false,
-            'label' => __('To', true),
-        )
-    );
-    ?>
-</fieldset>
+    <div layout="row" layout-align="center end">
+        <div layout="column">
+            <?php
+            echo $this->Search->selectLang(
+                'from',
+                $selectedLanguageFrom,
+                array(
+                    'div' => false,
+                    'label' => __('From', true),
+                )
+            );
+            ?>
+        </div>
 
-<fieldset class="submit">
+        <div id="arrow">
+            <md-icon>swap_horiz</md-icon>
+        </div>
+
+        <div layout="column">
+            <?php
+            echo $this->Search->selectLang(
+                'to',
+                $selectedLanguageTo,
+                array(
+                    'div' => false,
+                    'label' => __('To', true),
+                )
+            );
+            ?>
+        </div>
+    </div>
+
     <md-button type="submit" class="search-submit-button md-raised">
         <md-icon>search</md-icon>
     </md-button>
-</fieldset>
+</div>
 
 <?php
 echo $form->end();

--- a/app/views/elements/search_bar.ctp
+++ b/app/views/elements/search_bar.ctp
@@ -30,7 +30,7 @@ if (isset($this->params['lang'])) {
 }
 ?>
 
-<md-toolbar class="search_bar md-whiteframe-1dp md-primary">
+<md-toolbar class="search_bar md-whiteframe-1dp md-primary" ng-cloak>
 <?php
 if ($selectedLanguageFrom == null) {
     $selectedLanguageFrom = 'und';

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -134,10 +134,6 @@ a:hover {
     color: #DD8800;
 }
 
-h2 {
-    margin: 0 0 15px 0;
-}
-
 .titleAnnexeLink {
     font-weight: normal;
     font-size: 13px;
@@ -150,20 +146,6 @@ h2 {
 
 .titleAnnexeLink:hover {
     color: #fff;
-}
-
-h3 {
-    border-bottom: 1px dotted;
-    color: #555;
-    padding-left: 10px;
-    font-size: 1.2em;
-    margin-top: 30px;
-}
-
-h4 {
-    margin: 10px 0 5px 20px;
-    color: #555;
-    font-size: 1.1em;
 }
 
 table {
@@ -357,48 +339,22 @@ rt {
  * search bar
  */
 
-.search_bar {
-    position: relative;
-}
-
-.search_bar form {
-    margin-left: 70px;
-}
-
-.search_bar #arrow {
-    font-size: 1.3em;
-    text-align: center;
-    cursor: pointer;
-    line-height: 30px;
-}
-
-.search_bar fieldset {
-    border: none;
-    padding: 0;
-    display: inline-block;
-    text-align: left;
-    vertical-align: bottom;
+.search_bar a {
+    color: white;
 }
 
 .search_bar label {
-    font-size: 13px;
-    display: block;
-    margin-bottom: 2px;
+    color: white;
+    font-size: 15px;
 }
 
 .search_bar label[for="SentenceQuery"] {
     display: none;
 }
 
-.search_bar .select {
-    width: 110px;
-}
-
 #SentenceSearchForm {
-    text-align: center;
-    padding: 2px 10px 10px 10px;
-    margin: 0;
-    position: relative;
+    max-width: 960px;
+    margin: auto;
 }
 
 #SentenceQuery {
@@ -407,9 +363,14 @@ rt {
     padding: 2px 5px;
     padding-right: 30px;
     height: 36px;
+    border: 1px solid #DDDDDD;
 }
 
 .search_bar select {
+    background-color: #FFFFFF;
+    color: #111111;
+    border: 1px solid #DDDDDD;
+    border-radius: 2px;
     width: 200px;
     font-size: 14px;
     height: 36px;
@@ -424,27 +385,10 @@ rt {
     border: none;
     cursor: pointer;
     color: #CCCCCC;
-    position: absolute;
-    right: 2px;
-    line-height: 28px;
-}
-
-#SentenceQuery {
-    padding-right: 30px;
-}
-
-#SentenceQuery,
-.search_bar select {
-    background-color: #FFFFFF;
-    color: #111111;
-    border: 1px solid #DDDDDD;
-    border-radius: 2px;
+    margin-left: -30px;
 }
 
 .search_bar .search-submit-button {
-    cursor: pointer;
-    margin-bottom: 0;
-    margin-right: 0;
     width: 70px;
     min-width: 0;
 }
@@ -453,15 +397,16 @@ rt {
     background-color: #DDDDDD;
 }
 
-.search-bar-extra {
-    text-align: right;
-    padding-right: 2px;
-    padding-bottom: 2px;
+.search_bar #arrow {
+    padding: 0 10px;
+    line-height: 40px;
+    cursor: pointer;
 }
+
 .search-bar-extra a {
     color: #FFFFFF;
-    font-size: 13px;
-    margin-left: 20px;
+    margin: 0 10px;
+    font-size: 15px;
 }
 
 .search-bar-extra a:hover {

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -364,6 +364,7 @@ rt {
     padding-right: 30px;
     height: 36px;
     border: 1px solid #DDDDDD;
+    background-color: #FFFFFF;
 }
 
 .search_bar select {


### PR DESCRIPTION
This pull requests is part of issue #1180. This is a small rework of the search bar. 

Visually, there is no big difference beside the arrow icon which has been replaced with the Material Design icon `swap_horiz`. This makes it clearer for the user that they can swap the languages by clicking on the icon. The icon also takes more space and should be a bit easier to tap on mobile devices.

The re-positioning of the elements based on the width of the window is also a bit different. Before, the elements would take as much space as possible, and the elements that did not have enough space would go to the next line. Now, if the width is lower than 960px, both language dropdowns are displayed on a second line, and the search button is displayed on a third line.

**Old search bar**

![screenshot_44](https://cloud.githubusercontent.com/assets/221850/17982890/238bec16-6b0a-11e6-9419-e835edf83ccf.png)

![screenshot_45](https://cloud.githubusercontent.com/assets/221850/17982892/250d4c4c-6b0a-11e6-8834-e742e5cc78da.png)

![screenshot_46](https://cloud.githubusercontent.com/assets/221850/17982897/2af45c90-6b0a-11e6-8495-5904c90c9970.png)

**New search bar**

![screenshot_42](https://cloud.githubusercontent.com/assets/221850/17982899/2eac6f3a-6b0a-11e6-8ccc-188978a45e21.png)

![screenshot_43](https://cloud.githubusercontent.com/assets/221850/17982901/3096f694-6b0a-11e6-9e5d-6c2efe0c4b03.png)
