### PR TITLE
Redesign sentence comments

### DIFF
--- a/app/controllers/sentence_comments_controller.php
+++ b/app/controllers/sentence_comments_controller.php
@@ -423,7 +423,8 @@ class SentenceCommentsController extends AppController
             return;
         }
 
-        $this->helpers[] = "Messages";
+        $this->helpers[] = 'Messages';
+        $this->helpers[] = 'Members';
 
         // in the same idea, we do not need to do extra request if the user
         // has no comment
@@ -501,7 +502,8 @@ class SentenceCommentsController extends AppController
             return;
         }
 
-        $this->helpers[] = "Messages";
+        $this->helpers[] = 'Messages';
+        $this->helpers[] = 'Members';
 
         $commentsPermissions = $this->Permissions->getCommentsOptions($userComments);
 

--- a/app/controllers/sentence_comments_controller.php
+++ b/app/controllers/sentence_comments_controller.php
@@ -115,6 +115,7 @@ class SentenceCommentsController extends AppController
     public function index($langFilter = 'und')
     {
         $this->helpers[] = 'Messages';
+        $this->helpers[] = 'Members';
 
         $conditions = $this->SentenceComment->getQueryConditionWithExcludedUsers();
         if ($langFilter != 'und') {

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -148,6 +148,7 @@ class SentencesController extends AppController
         $this->helpers[] = 'Tags';
         $this->helpers[] = 'Messages';
         $this->helpers[] = 'Lists';
+        $this->helpers[] = 'Members';
 
         $id = Sanitize::paranoid($id);
 

--- a/app/controllers/users_controller.php
+++ b/app/controllers/users_controller.php
@@ -516,6 +516,7 @@ class UsersController extends AppController
         if ($user != null) {
             $this->helpers[] = 'Wall';
             $this->helpers[] = 'Messages';
+            $this->helpers[] = 'Members';
 
             $commentsPermissions = $this->Permissions->getCommentsOptions(
                 $user['SentenceComments']

--- a/app/views/elements/latest_sentence_comments.ctp
+++ b/app/views/elements/latest_sentence_comments.ctp
@@ -33,15 +33,16 @@ if (isset($this->params['lang'])) {
 foreach ($sentenceComments as $i=>$comment) {
     $menu = $comments->getMenuForComment(
         $comment['SentenceComment'],
-        $comment['User'],
-        $commentsPermissions[$i]
+        $commentsPermissions[$i],
+        true
     );
 
-    $messages->displayMessage(
-        $comment['SentenceComment'],
-        $comment['User'],
-        $comment['Sentence'],
-        $menu
+    echo $this->element(
+        'messages/comment',
+        array(
+            'comment' => $comment,
+            'menu' => $menu
+        )
     );
 }
 ?>

--- a/app/views/elements/latest_sentence_comments.ctp
+++ b/app/views/elements/latest_sentence_comments.ctp
@@ -34,7 +34,7 @@ foreach ($sentenceComments as $i=>$comment) {
     $menu = $comments->getMenuForComment(
         $comment['SentenceComment'],
         $commentsPermissions[$i],
-        true
+        CurrentUser::isMember()
     );
 
     echo $this->element(

--- a/app/views/elements/latest_sentence_comments.ctp
+++ b/app/views/elements/latest_sentence_comments.ctp
@@ -30,18 +30,21 @@ if (isset($this->params['lang'])) {
 ?>
 
 <?php
+$currentUserIsMember = CurrentUser::isMember();
+
 foreach ($sentenceComments as $i=>$comment) {
     $menu = $comments->getMenuForComment(
         $comment['SentenceComment'],
         $commentsPermissions[$i],
-        CurrentUser::isMember()
+        $currentUserIsMember
     );
 
     echo $this->element(
         'messages/comment',
         array(
             'comment' => $comment,
-            'menu' => $menu
+            'menu' => $menu,
+            'replyIcon' => $currentUserIsMember
         )
     );
 }

--- a/app/views/elements/messages/comment.ctp
+++ b/app/views/elements/messages/comment.ctp
@@ -57,7 +57,7 @@ $canViewContent = CurrentUser::isAdmin() || CurrentUser::get('id') == $authorId;
 <? if ($sentence) { ?>
     <div class="comment sentence" md-whiteframe="2"
          layout="row" layout-align="start center">
-        <div class="text" flex>
+        <div class="text" dir="<?= $langDir ?>" flex>
             <?= $sentenceText ?>
         </div>
         <?php
@@ -124,7 +124,9 @@ $canViewContent = CurrentUser::isAdmin() || CurrentUser::get('id') == $authorId;
         <? } ?>
 
         <? if ($canViewContent) { ?>
-            <p class="content"><?= $messages->formatedContent($commentText) ?></p>
+            <p class="content" dir="auto">
+                <?= $messages->formatedContent($commentText) ?>
+            </p>
         <? } ?>
     </md-card-content>
 </md-card>

--- a/app/views/elements/messages/comment.ctp
+++ b/app/views/elements/messages/comment.ctp
@@ -1,0 +1,125 @@
+<?php
+/*
+ * Array
+(
+    [SentenceComment] => Array
+        (
+            [id] => 41850
+            [user_id] => 3746
+            [text] => test
+            [created] => 2016-06-20 23:41:51
+            [modified] => 2016-06-20 23:41:51
+            [sentence_id] => 9999
+            [hidden] => 0
+        )
+
+    [Sentence] => Array
+        (
+            [id] => 9999
+            [text] => D'une part je suis occupé, d'autre part, je ne suis pas intéressé.
+            [lang] => fra
+            [correctness] => 0
+            [user_id] => 5
+            [User] => Array
+                (
+                    [username] => TRANG
+                )
+
+        )
+
+    [User] => Array
+        (
+            [id] => 3746
+            [username] => trang124
+            [image] =>
+        )
+
+)
+*/
+$username = $comment['User']['username'];
+$avatarUrl = $members->imageUrl($comment['User']['image']);
+$createdDate = $comment['SentenceComment']['created'];
+$modifiedDate = $comment['SentenceComment']['modified'];
+$commentId = $comment['SentenceComment']['id'];
+$commentText = $comment['SentenceComment']['text'];
+$sentence = null;
+if (isset($comment['Sentence'])) {
+    $sentence = $comment['Sentence'];
+}
+$sentenceId = $comment['SentenceComment']['sentence_id'];
+$sentenceText = $sentence['text'];
+$sentenceLang = $sentence['lang'];
+$sentenceOwner = null;
+if (!empty($sentence['User'])) {
+    $sentenceOwner = $sentence['User']['username'];
+}
+$langDir = LanguagesLib::getLanguageDirection($sentenceLang);
+
+$editUrl = $html->url(array(
+    'controller' => 'sentence_comments',
+    'action' => 'edit',
+    $commentId
+));
+$sentenceUrl = $html->url(array(
+    'controller' => 'sentences',
+    'action' => 'show',
+    $sentenceId
+));
+$replyUrl = $html->url(array(
+    'controller' => 'sentences',
+    'action' => 'show',
+    $sentenceId.'#comment-'.$commentId
+));
+?>
+<md-card>
+    <md-card-header>
+        <md-card-avatar>
+            <img class="md-user-avatar" src="<?= $avatarUrl ?>"/>
+        </md-card-avatar>
+        <md-card-header-text>
+            <span class="md-title"><?= $username ?></span>
+            <span class="md-subhead"><?= $createdDate ?>, <?= $modifiedDate ?></span>
+        </md-card-header-text>
+
+        <? foreach ($menu as $menuItem) {
+            $confirmation = '';
+            if (isset($menuItem['confirm'])) {
+                $msg = $menuItem['confirm'];
+                $confirmation = 'onclick="return confirm(\''.$msg.'\');"';
+            }
+            ?>
+            <md-button class="md-icon-button"
+                <?= $confirmation ?>
+                       href="<?= $html->url($menuItem['url']) ?>">
+                <md-icon><?= $menuItem['icon'] ?></md-icon>
+            </md-button>
+        <? } ?>
+    </md-card-header>
+
+    <md-divider></md-divider>
+
+    <md-card-content>
+        <? if ($sentence) { ?>
+            <div class="sentence" layout="row" layout-align="start center">
+                <div class="text" flex>
+                    <?= $sentenceText ?>
+                </div>
+                <?php
+                echo $languages->icon(
+                    $sentenceLang,
+                    array(
+                        'width' => 30,
+                        'height' => 20,
+                        'class' => 'lang'
+                    )
+                );
+                ?>
+                <md-button class="md-icon-button" href="<?= $sentenceUrl ?>">
+                    <md-icon>info</md-icon>
+                </md-button>
+            </div>
+        <? } ?>
+
+        <p><?= $messages->formatedContent($commentText) ?></p>
+    </md-card-content>
+</md-card>

--- a/app/views/elements/messages/comment.ctp
+++ b/app/views/elements/messages/comment.ctp
@@ -70,6 +70,20 @@ $replyUrl = $html->url(array(
     'action' => 'show',
     $sentenceId.'#comment-'.$commentId
 ));
+$dateLabel = format(
+    __('{createdDate}, edited {modifiedDate}', true),
+    array(
+        'createdDate' => $date->ago($createdDate),
+        'modifiedDate' => $date->ago($modifiedDate)
+    )
+);
+$fullDateLabel = format(
+    __('{createdDate}, edited {modifiedDate}', true),
+    array(
+        'createdDate' => $createdDate,
+        'modifiedDate' => $modifiedDate
+    )
+);
 ?>
 <? if ($sentence) { ?>
     <div class="comment sentence" md-whiteframe="2"
@@ -99,7 +113,9 @@ $replyUrl = $html->url(array(
         </md-card-avatar>
         <md-card-header-text>
             <span class="md-title"><?= $username ?></span>
-            <span class="md-subhead"><?= $createdDate ?>, <?= $modifiedDate ?></span>
+            <span class="md-subhead ellipsis" title="<?= $fullDateLabel ?>">
+                <?= $dateLabel ?>
+            </span>
         </md-card-header-text>
 
         <? foreach ($menu as $menuItem) {

--- a/app/views/elements/messages/comment.ctp
+++ b/app/views/elements/messages/comment.ctp
@@ -88,16 +88,22 @@ $canViewContent = CurrentUser::isAdmin() || CurrentUser::get('id') == $authorId;
         </md-card-header-text>
 
         <? foreach ($menu as $menuItem) {
+            if ($menuItem['text'] == '#') {
+                $itemLabel = $replyIcon ? __('reply', true) : __('permalink', true);
+            } else {
+                $itemLabel = $menuItem['text'];
+            }
             $confirmation = '';
             if (isset($menuItem['confirm'])) {
                 $msg = $menuItem['confirm'];
                 $confirmation = 'onclick="return confirm(\''.$msg.'\');"';
             }
             ?>
-            <md-button class="md-icon-button"
-                <?= $confirmation ?>
-                       href="<?= $html->url($menuItem['url']) ?>">
+            <md-button class="md-icon-button" <?= $confirmation ?>
+                       href="<?= $html->url($menuItem['url']) ?>"
+                       aria-label="<?= $itemLabel ?>">
                 <md-icon><?= $menuItem['icon'] ?></md-icon>
+                <md-tooltip><?= $itemLabel ?></md-tooltip>
             </md-button>
         <? } ?>
     </md-card-header>

--- a/app/views/elements/messages/comment.ctp
+++ b/app/views/elements/messages/comment.ctp
@@ -123,7 +123,7 @@ $canViewContent = CurrentUser::isAdmin() || CurrentUser::get('id') == $authorId;
             </div>
         <? } ?>
 
-        <? if ($canViewContent) { ?>
+        <? if (!$commentHidden || $canViewContent) { ?>
             <p class="content" dir="auto">
                 <?= $messages->formatedContent($commentText) ?>
             </p>

--- a/app/views/elements/messages/comment.ctp
+++ b/app/views/elements/messages/comment.ctp
@@ -1,53 +1,21 @@
 <?php
-/*
- * Array
-(
-    [SentenceComment] => Array
-        (
-            [id] => 41850
-            [user_id] => 3746
-            [text] => test
-            [created] => 2016-06-20 23:41:51
-            [modified] => 2016-06-20 23:41:51
-            [sentence_id] => 9999
-            [hidden] => 0
-        )
-
-    [Sentence] => Array
-        (
-            [id] => 9999
-            [text] => D'une part je suis occupé, d'autre part, je ne suis pas intéressé.
-            [lang] => fra
-            [correctness] => 0
-            [user_id] => 5
-            [User] => Array
-                (
-                    [username] => TRANG
-                )
-
-        )
-
-    [User] => Array
-        (
-            [id] => 3746
-            [username] => trang124
-            [image] =>
-        )
-
-)
-*/
 $username = $comment['User']['username'];
 $avatarUrl = $members->imageUrl($comment['User']['image']);
 $createdDate = $comment['SentenceComment']['created'];
 $modifiedDate = $comment['SentenceComment']['modified'];
 $commentId = $comment['SentenceComment']['id'];
+$authorId = $comment['SentenceComment']['user_id'];
 $commentText = $comment['SentenceComment']['text'];
+$commentHidden = $comment['SentenceComment']['hidden'];
 $sentence = null;
 if (isset($comment['Sentence'])) {
     $sentence = $comment['Sentence'];
 }
 $sentenceId = $comment['SentenceComment']['sentence_id'];
-$sentenceText = $sentence['text'];
+$sentenceText = '<em>'.__('sentence deleted', true).'</em>';
+if (isset($sentence['text'])) {
+    $sentenceText = $sentence['text'];
+}
 $sentenceLang = $sentence['lang'];
 $sentenceOwner = null;
 if (!empty($sentence['User'])) {
@@ -84,6 +52,7 @@ $fullDateLabel = format(
         'modifiedDate' => $modifiedDate
     )
 );
+$canViewContent = CurrentUser::isAdmin() || CurrentUser::get('id') == $authorId;
 ?>
 <? if ($sentence) { ?>
     <div class="comment sentence" md-whiteframe="2"
@@ -106,7 +75,7 @@ $fullDateLabel = format(
         </md-button>
     </div>
 <? } ?>
-<md-card class="comment">
+<md-card class="comment <?= $commentHidden ? 'inappropriate' : '' ?>">
     <md-card-header>
         <md-card-avatar>
             <img class="md-user-avatar" src="<?= $avatarUrl ?>"/>
@@ -136,6 +105,26 @@ $fullDateLabel = format(
     <md-divider></md-divider>
 
     <md-card-content>
-        <p><?= $messages->formatedContent($commentText) ?></p>
+        <? if ($commentHidden) { ?>
+            <div class="warning-info" layout="row" layout-align="start center">
+                <md-icon>warning</md-icon>
+                <p>
+                    <?= format(
+                        __(
+                            'The content of this message goes against '.
+                            '<a href="{}">our rules</a> and was therefore hidden. '.
+                            'It is displayed only to admins '.
+                            'and to the author of the message.',
+                            true
+                        ),
+                        'http://en.wiki.tatoeba.org/articles/show/rules-against-bad-behavior'
+                    ); ?>
+                </p>
+            </div>
+        <? } ?>
+
+        <? if ($canViewContent) { ?>
+            <p class="content"><?= $messages->formatedContent($commentText) ?></p>
+        <? } ?>
     </md-card-content>
 </md-card>

--- a/app/views/elements/messages/comment.ctp
+++ b/app/views/elements/messages/comment.ctp
@@ -71,7 +71,28 @@ $replyUrl = $html->url(array(
     $sentenceId.'#comment-'.$commentId
 ));
 ?>
-<md-card>
+<? if ($sentence) { ?>
+    <div class="comment sentence" md-whiteframe="2"
+         layout="row" layout-align="start center">
+        <div class="text" flex>
+            <?= $sentenceText ?>
+        </div>
+        <?php
+        echo $languages->icon(
+            $sentenceLang,
+            array(
+                'width' => 30,
+                'height' => 20,
+                'class' => 'lang'
+            )
+        );
+        ?>
+        <md-button class="md-icon-button" href="<?= $sentenceUrl ?>">
+            <md-icon>info</md-icon>
+        </md-button>
+    </div>
+<? } ?>
+<md-card class="comment">
     <md-card-header>
         <md-card-avatar>
             <img class="md-user-avatar" src="<?= $avatarUrl ?>"/>
@@ -99,27 +120,6 @@ $replyUrl = $html->url(array(
     <md-divider></md-divider>
 
     <md-card-content>
-        <? if ($sentence) { ?>
-            <div class="sentence" layout="row" layout-align="start center">
-                <div class="text" flex>
-                    <?= $sentenceText ?>
-                </div>
-                <?php
-                echo $languages->icon(
-                    $sentenceLang,
-                    array(
-                        'width' => 30,
-                        'height' => 20,
-                        'class' => 'lang'
-                    )
-                );
-                ?>
-                <md-button class="md-icon-button" href="<?= $sentenceUrl ?>">
-                    <md-icon>info</md-icon>
-                </md-button>
-            </div>
-        <? } ?>
-
         <p><?= $messages->formatedContent($commentText) ?></p>
     </md-card-content>
 </md-card>

--- a/app/views/helpers/comments.php
+++ b/app/views/helpers/comments.php
@@ -214,7 +214,7 @@ class CommentsHelper extends AppHelper
      *
      *
      */
-    public function getMenuForComment($comment, $user, $permissions)
+    public function getMenuForComment($comment, $permissions, $replyIcon)
     {
         $menu = array(); 
         $commentId = $comment['id'];
@@ -233,6 +233,7 @@ class CommentsHelper extends AppHelper
 
             $menu[] = array(
                 'text' => $hiddenLinkText,
+                'icon' => 'visibility_off',
                 'url' => array(
                     "controller" => "sentence_comments",
                     "action" => $hiddenLinkAction,
@@ -245,6 +246,7 @@ class CommentsHelper extends AppHelper
         if ($permissions['canDelete']) {
             $menu[] = array(
                 'text' => __('delete', true),
+                'icon' => 'delete',
                 'url' => array(
                     "controller" => "sentence_comments",
                     "action" => "delete_comment",
@@ -258,6 +260,7 @@ class CommentsHelper extends AppHelper
         if ($permissions['canEdit']) {
             $menu[] = array(
                 'text' => __('edit', true),
+                'icon' => 'edit',
                 'url' => array(
                     "controller" => "sentence_comments",
                     "action" => "edit",
@@ -268,8 +271,10 @@ class CommentsHelper extends AppHelper
         
         // view
         $sentenceId = $comment['sentence_id'];
+        $viewIcon = $replyIcon ? 'reply' : 'link';
         $menu[] = array(
             'text' => '#',
+            'icon' => $viewIcon,
             'url' => array(
                 "controller" => "sentences",
                 "action" => "show",

--- a/app/views/pages/index.ctp
+++ b/app/views/pages/index.ctp
@@ -105,7 +105,7 @@ $selectedLanguage = $session->read('random_lang_selected');
         </h2>
         <?php echo $this->element('latest_contributions'); ?>
     </div>
-    <div class="module">
+    <div class="section">
         <h2>
         <?php
         __('Latest comments');

--- a/app/views/sentence_comments/index.ctp
+++ b/app/views/sentence_comments/index.ctp
@@ -49,7 +49,7 @@ $paginator->options(
 </div>
 
 <div id="main_content">
-    <div class="module">
+    <div class="section">
         <h2>
             <?php 
             echo $paginator->counter(
@@ -67,18 +67,19 @@ $paginator->options(
         $paginationUrl = array($langFilter);
         $pagination->display($paginationUrl);
 
-        foreach ($sentenceComments as $i=>$comment) {
+        foreach ($sentenceComments as $i => $comment) {
             $menu = $comments->getMenuForComment(
                 $comment['SentenceComment'],
-                $comment['User'],
-                $commentsPermissions[$i]
+                $commentsPermissions[$i],
+                true
             );
-            
-            $messages->displayMessage(
-                $comment['SentenceComment'],
-                $comment['User'],
-                $comment['Sentence'],
-                $menu
+
+            echo $this->element(
+                'messages/comment',
+                array(
+                    'comment' => $comment,
+                    'menu' => $menu
+                )
             );
         }
         

--- a/app/views/sentence_comments/index.ctp
+++ b/app/views/sentence_comments/index.ctp
@@ -71,7 +71,7 @@ $paginator->options(
             $menu = $comments->getMenuForComment(
                 $comment['SentenceComment'],
                 $commentsPermissions[$i],
-                true
+                CurrentUser::isMember()
             );
 
             echo $this->element(

--- a/app/views/sentence_comments/index.ctp
+++ b/app/views/sentence_comments/index.ctp
@@ -66,19 +66,21 @@ $paginator->options(
         <?php
         $paginationUrl = array($langFilter);
         $pagination->display($paginationUrl);
+        $currentUserIsMember = CurrentUser::isMember();
 
         foreach ($sentenceComments as $i => $comment) {
             $menu = $comments->getMenuForComment(
                 $comment['SentenceComment'],
                 $commentsPermissions[$i],
-                CurrentUser::isMember()
+                $currentUserIsMember
             );
 
             echo $this->element(
                 'messages/comment',
                 array(
                     'comment' => $comment,
-                    'menu' => $menu
+                    'menu' => $menu,
+                    'replyIcon' => $currentUserIsMember
                 )
             );
         }

--- a/app/views/sentence_comments/of_user.ctp
+++ b/app/views/sentence_comments/of_user.ctp
@@ -87,18 +87,20 @@ $this->set('title_for_layout', $pages->formatTitle(
         
         <div class="comments">
         <?php
+        $currentUserIsMember = CurrentUser::isMember();
         foreach ($userComments as $i => $comment) {
             $menu = $comments->getMenuForComment(
                 $comment['SentenceComment'],
                 $commentsPermissions[$i],
-                CurrentUser::isMember()
+                $currentUserIsMember
             );
 
             echo $this->element(
                 'messages/comment',
                 array(
                     'comment' => $comment,
-                    'menu' => $menu
+                    'menu' => $menu,
+                    'replyIcon' => $currentUserIsMember
                 )
             );
         }

--- a/app/views/sentence_comments/of_user.ctp
+++ b/app/views/sentence_comments/of_user.ctp
@@ -51,7 +51,7 @@ $this->set('title_for_layout', $pages->formatTitle(
 </div>
 
 <div id="main_content">
-    <div class="module">
+    <div class="section">
     <?php
     if ($userExists === false) {
         $commonModules->displayNoSuchUser($userName, $backLink);
@@ -90,15 +90,16 @@ $this->set('title_for_layout', $pages->formatTitle(
         foreach ($userComments as $i => $comment) {
             $menu = $comments->getMenuForComment(
                 $comment['SentenceComment'],
-                $comment['User'],
-                $commentsPermissions[$i]
+                $commentsPermissions[$i],
+                CurrentUser::isMember()
             );
 
-            $messages->displayMessage(
-                $comment['SentenceComment'],
-                $comment['User'],
-                $comment['Sentence'],
-                $menu
+            echo $this->element(
+                'messages/comment',
+                array(
+                    'comment' => $comment,
+                    'menu' => $menu
+                )
             );
         }
         ?>

--- a/app/views/sentence_comments/on_sentences_of_user.ctp
+++ b/app/views/sentence_comments/on_sentences_of_user.ctp
@@ -94,18 +94,20 @@ $this->set('title_for_layout', $pages->formatTitle(
         
         <div class="comments">
         <?php
+        $currentUserIsMember = CurrentUser::isMember();
         foreach ($userComments as $i=>$comment) {
             $menu = $comments->getMenuForComment(
                 $comment['SentenceComment'],
                 $commentsPermissions[$i],
-                CurrentUser::isMember()
+                $currentUserIsMember
             );
 
             echo $this->element(
                 'messages/comment',
                 array(
                     'comment' => $comment,
-                    'menu' => $menu
+                    'menu' => $menu,
+                    'replyIcon' => $currentUserIsMember
                 )
             );
         }

--- a/app/views/sentence_comments/on_sentences_of_user.ctp
+++ b/app/views/sentence_comments/on_sentences_of_user.ctp
@@ -49,7 +49,7 @@ $this->set('title_for_layout', $pages->formatTitle(
 </div>
 
 <div id="main_content">
-    <div class="module">
+    <div class="section">
     <?php
     if ($userExists === false) {
         echo '<h2>';
@@ -97,15 +97,16 @@ $this->set('title_for_layout', $pages->formatTitle(
         foreach ($userComments as $i=>$comment) {
             $menu = $comments->getMenuForComment(
                 $comment['SentenceComment'],
-                $comment['User'],
-                $commentsPermissions[$i]
+                $commentsPermissions[$i],
+                CurrentUser::isMember()
             );
 
-            $messages->displayMessage(
-                $comment['SentenceComment'],
-                $comment['User'],
-                $comment['Sentence'],
-                $menu
+            echo $this->element(
+                'messages/comment',
+                array(
+                    'comment' => $comment,
+                    'menu' => $menu
+                )
             );
         }
         ?>

--- a/app/views/sentences/show.ctp
+++ b/app/views/sentences/show.ctp
@@ -190,49 +190,45 @@ $navigation->displaySentenceNavigation(
         ?>
     </div>
 
-    <?php
-    echo '<div class="module">';
+    <div class="section">
+        <h2><? __('Comments'); ?></h2>
+        <?php
+        if (!empty($sentenceComments)) {
+            echo '<div class="comments">';
+            foreach ($sentenceComments as $i=>$comment) {
+                $commentId = $comment['SentenceComment']['id'];
+                $menu = $comments->getMenuForComment(
+                    $comment['SentenceComment'],
+                    $commentsPermissions[$i],
+                    false
+                );
 
-    echo '<h2>';
-    __('Comments');
-    echo '</h2>';
+                echo '<a id="comment-'.$commentId.'"></a>';
 
-    if (!empty($sentenceComments)) {
-        echo '<div class="comments">';
-        foreach ($sentenceComments as $i=>$comment) {
-            $commentId = $comment['SentenceComment']['id'];
-            $menu = $comments->getMenuForComment(
-                $comment['SentenceComment'],
-                $comment['User'],
-                $commentsPermissions[$i]
-            );
+                echo $this->element(
+                    'messages/comment',
+                    array(
+                        'comment' => $comment,
+                        'menu' => $menu
+                    )
+                );
+            }
+            echo '</div>';
+        } else {
+            echo '<em>' . __('There are no comments for now.', true) .'</em>';
+        }
 
-            echo '<a id="comment-'.$commentId.'"></a>';
-
-            $messages->displayMessage(
-                $comment['SentenceComment'],
-                $comment['User'],
-                null,
-                $menu
+        if ($canComment) {
+            if(!isset($sentence['Sentence'])) {
+                $sentenceText = __('Sentence deleted', true);
+            }
+            $comments->displayCommentForm(
+                $sentenceId,
+                $sentenceText
             );
         }
-        echo '</div>';
-    } else {
-        echo '<em>' . __('There are no comments for now.', true) .'</em>';
-    }
-
-    if ($canComment) {
-        if(!isset($sentence['Sentence'])) {
-            $sentenceText = __('Sentence deleted', true);
-        }
-        $comments->displayCommentForm(
-            $sentenceId,
-            $sentenceText
-        );
-    }
-
-    echo '</div>';
-    ?>
+        ?>
+    </div>
 </div>
 <?php 
 } else {

--- a/app/views/sentences/show.ctp
+++ b/app/views/sentences/show.ctp
@@ -209,7 +209,8 @@ $navigation->displaySentenceNavigation(
                     'messages/comment',
                     array(
                         'comment' => $comment,
-                        'menu' => $menu
+                        'menu' => $menu,
+                        'replyIcon' => false
                     )
                 );
             }

--- a/app/views/users/show.ctp
+++ b/app/views/users/show.ctp
@@ -97,7 +97,7 @@ $this->set('title_for_layout', $pages->formatTitle(format(
 
     /* Latest comments from the user */
     if (count($user['SentenceComments']) > 0) {
-        echo '<div class="module">';
+        echo '<div class="section">';
             echo '<h2>';
             __('Latest comments');
 
@@ -115,18 +115,22 @@ $this->set('title_for_layout', $pages->formatTitle(format(
             echo '</h2>';
 
             echo '<div class="comments">';
-            foreach ($user['SentenceComments'] as $i => $comment) {
+            foreach ($user['SentenceComments'] as $i => $sentenceComment) {
+                $comment['SentenceComment'] = $sentenceComment;
+                $comment['User'] = $user['User'];
+
                 $menu = $comments->getMenuForComment(
-                    $comment,
-                    $user['User'],
-                    $commentsPermissions[$i]
+                    $sentenceComment,
+                    $commentsPermissions[$i],
+                    CurrentUser::isMember()
                 );
 
-                $messages->displayMessage(
-                    $comment,
-                    $user['User'],
-                    null,
-                    $menu
+                echo $this->element(
+                    'messages/comment',
+                    array(
+                        'comment' => $comment,
+                        'menu' => $menu
+                    )
                 );
             }
             echo '</div>';

--- a/app/views/users/show.ctp
+++ b/app/views/users/show.ctp
@@ -118,18 +118,20 @@ $this->set('title_for_layout', $pages->formatTitle(format(
             foreach ($user['SentenceComments'] as $i => $sentenceComment) {
                 $comment['SentenceComment'] = $sentenceComment;
                 $comment['User'] = $user['User'];
+                $currentUserIsMember = CurrentUser::isMember();
 
                 $menu = $comments->getMenuForComment(
                     $sentenceComment,
                     $commentsPermissions[$i],
-                    CurrentUser::isMember()
+                    $currentUserIsMember
                 );
 
                 echo $this->element(
                     'messages/comment',
                     array(
                         'comment' => $comment,
-                        'menu' => $menu
+                        'menu' => $menu,
+                        'replyIcon' => $currentUserIsMember
                     )
                 );
             }

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -681,6 +681,11 @@ rt {
     margin-right: 3px;
 }
 
+.ellipsis {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 
 /*
  *

--- a/app/webroot/css/layouts/default.css
+++ b/app/webroot/css/layouts/default.css
@@ -725,3 +725,7 @@ md-list-item.md-3-line .md-list-item-text h3,
 md-list-item.md-3-line > ._md-no-style .md-list-item-text h3 {
     line-height: inherit;
 }
+
+md-card md-card-header md-card-avatar .md-user-avatar, md-list-item .md-avatar {
+    border-radius: 10%;
+}

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -244,6 +244,18 @@ html[dir="rtl"] #logs .content {
     margin: 0 10px;
 }
 
+.comment.inappropriate .warning-info p {
+    padding: 0 10px;
+}
+
+.comment.inappropriate {
+    opacity: 0.6;
+}
+
+.comment.inappropriate .content {
+    color: #d50000;
+}
+
 /*
  * --------------------------------------------------------------------
  *

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -231,7 +231,7 @@ html[dir="rtl"] #logs .content {
 
 .comment.sentence {
     background: #f5f5f5;
-    padding: 10px;
+    padding: 10px 16px;
     margin-bottom: -39px;
 }
 

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -224,6 +224,11 @@ html[dir="rtl"] #logs .content {
     font-weight: 700;
 }
 
+.comment .md-subhead {
+    max-width: 340px;
+    cursor: help;
+}
+
 .comment.sentence {
     background: #f5f5f5;
     padding: 10px;

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -242,6 +242,11 @@ html[dir="rtl"] #logs .content {
 
 .comment.sentence .text {
     margin: 0 10px;
+    text-align: left;
+}
+
+html[dir="rtl"] .comment.sentence .text {
+    text-align: right;
 }
 
 .comment.inappropriate .warning-info p {

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -216,25 +216,26 @@ html[dir="rtl"] #logs .content {
  * --------------------------------------------------------------------
  */
 
-md-card {
-    margin: 30px 0px;
+.comment {
+    margin: 40px 0px;
 }
 
-md-card .md-title {
+.comment .md-title {
     font-weight: 700;
 }
 
-md-card .sentence {
+.comment.sentence {
     background: #f5f5f5;
     padding: 10px;
+    margin-bottom: -39px;
 }
 
-md-card .sentence .lang {
+.comment.sentence .lang {
     margin: 0 10px;
     display: block;
 }
 
-md-card .sentence .text {
+.comment.sentence .text {
     margin: 0 10px;
 }
 

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -211,6 +211,36 @@ html[dir="rtl"] #logs .content {
 /*
  * --------------------------------------------------------------------
  *
+ *   Comments
+ *
+ * --------------------------------------------------------------------
+ */
+
+md-card {
+    margin: 30px 0px;
+}
+
+md-card .md-title {
+    font-weight: 700;
+}
+
+md-card .sentence {
+    background: #f5f5f5;
+    padding: 10px;
+}
+
+md-card .sentence .lang {
+    margin: 0 10px;
+    display: block;
+}
+
+md-card .sentence .text {
+    margin: 0 10px;
+}
+
+/*
+ * --------------------------------------------------------------------
+ *
  *   message.css
  *
  * --------------------------------------------------------------------


### PR DESCRIPTION
This issue is part of #1180. This is a redesign of the sentence comments. It is ready to handled RTL (#74).

* The new comments design is based on the [Card component](https://material.google.com/components/cards.html) of Material Design, with simply a header and a body (no rich media).
* On pages where the sentence is displayed, the sentence is now outside of the comment block. It is displayed with a grey background to make it easier to distinguish from the comment. 
* The language icon for the sentence is displayed on the end side of the sentence (right side on LTR and, left on RTL interface). This copies the layout of the contribution logs. I'm still not completely decided on putting the language icon on the end side, but I'd like to give it a try.
* The sentence menu is using icons instead of text:
  * `visibility_off` icon => hidden
  * `delete` icon => delete
  * `edit` icon => edit
  * `reply` icon => # (used on pages other than the sentence's page)
  * `link` icon => # (used for non-authenticated users or on the sentence's page)
* The menu icons are placed in the header, rather than at the bottom of the body in order to keep these options around the same area as they used to be. Later on we might consider using a [menu](https://material.google.com/components/menus.html) instead of displaying the icons straight away.
* The avatars border-radius has been reduced to look like a rounded square instead of a circle, to avoid having a too huge shape inconsistency accross the website.
* The username of the sentence owner has been removed because I don't think it is necessary. It was introduced upon [a request](https://app.assembla.com/spaces/tatoeba2/tickets/292-sentence-owner--39-s-name-in-comments/details) from a user who wanted to see the username to be able to notice when a comment is posted on his sentences. This use case was actually not too relevant back then, but it is even less relevant today. There's much more activity on the website, which makes it unlikely that a user would notice from the homepage a comment on their sentence unless they are looking at the page 24/7. Also, users have a page that lists all the comments on their sentences. Having the username of the owner doesn't bring much value.

**Old comments**

![screenshot_57](https://cloud.githubusercontent.com/assets/221850/18404707/77ce86d8-76ec-11e6-94af-f2a979811343.png)

![screenshot_60](https://cloud.githubusercontent.com/assets/221850/18404715/80cf87aa-76ec-11e6-8a88-b801f1384609.png)

**New comments**

![screenshot_58](https://cloud.githubusercontent.com/assets/221850/18404717/87d47eca-76ec-11e6-90f2-dc41d7885f13.png)

![screenshot_59](https://cloud.githubusercontent.com/assets/221850/18404718/8f07f96a-76ec-11e6-898a-1a5397ab5261.png)

