### PR TITLE
Comments readjustments

### DIFF
--- a/app/views/elements/messages/comment.ctp
+++ b/app/views/elements/messages/comment.ctp
@@ -58,7 +58,7 @@ $replyUrl = $html->url(array(
     'action' => 'show',
     $sentenceId.'#comment-'.$commentId
 ));
-if ($createdDate == $modifiedDate) {
+if (empty($modifiedDate) || $createdDate == $modifiedDate) {
     $dateLabel = $date->ago($createdDate);
     $fullDateLabel = $createdDate;
 } else {

--- a/app/views/elements/messages/comment.ctp
+++ b/app/views/elements/messages/comment.ctp
@@ -8,10 +8,30 @@ $authorId = $comment['SentenceComment']['user_id'];
 $commentText = $comment['SentenceComment']['text'];
 $commentHidden = $comment['SentenceComment']['hidden'];
 $sentence = null;
+$sentenceOwnerLink = null;
 if (isset($comment['Sentence'])) {
     $sentence = $comment['Sentence'];
 }
+if ($sentence && isset($sentence['User']['username'])) {
+    $sentenceOwner = $sentence['User']['username'];
+    $sentenceOwnerLink = $html->link(
+        $sentenceOwner,
+        array(
+            'controller' => 'user',
+            'action' => 'profile',
+            $sentenceOwner
+        )
+    );
+}
 $sentenceId = $comment['SentenceComment']['sentence_id'];
+$sentenceLink = $html->link(
+    '#'.$sentenceId,
+    array(
+        'controller' => 'sentences',
+        'action' => 'show',
+        $sentenceId
+    )
+);
 $sentenceText = '<em>'.__('sentence deleted', true).'</em>';
 if (isset($sentence['text'])) {
     $sentenceText = $sentence['text'];
@@ -63,26 +83,42 @@ $userProfileUrl = $html->url(array(
     'action' => 'profile',
     $username
 ));
+if ($sentenceOwnerLink) {
+    $sentenceInfoLabel = __('Sentence {number} — belongs to {username}', true);
+} else {
+    $sentenceInfoLabel = __('Sentence {number}', true);
+}
+
 ?>
 <? if ($sentence) { ?>
-    <div class="comment sentence" md-whiteframe="2"
-         layout="row" layout-align="start center">
-        <div class="text" dir="<?= $langDir ?>" flex>
-            <?= $sentenceText ?>
+    <div class="comment sentence" md-whiteframe="2">
+        <div class="info">
+            <?= format(
+                $sentenceInfoLabel,
+                array(
+                    'number' => $sentenceLink,
+                    'username' => $sentenceOwnerLink
+                )
+            ); ?>
         </div>
-        <?php
-        echo $languages->icon(
-            $sentenceLang,
-            array(
-                'width' => 30,
-                'height' => 20,
-                'class' => 'lang'
-            )
-        );
-        ?>
-        <md-button class="md-icon-button" href="<?= $sentenceUrl ?>">
-            <md-icon>info</md-icon>
-        </md-button>
+        <div layout="row" layout-align="start center">
+            <div class="text" dir="<?= $langDir ?>" flex>
+                <?= $sentenceText ?>
+            </div>
+            <?php
+            echo $languages->icon(
+                $sentenceLang,
+                array(
+                    'width' => 30,
+                    'height' => 20,
+                    'class' => 'lang'
+                )
+            );
+            ?>
+            <md-button class="md-icon-button" href="<?= $sentenceUrl ?>">
+                <md-icon>info</md-icon>
+            </md-button>
+        </div>
     </div>
 <? } ?>
 <md-card class="comment <?= $commentHidden ? 'inappropriate' : '' ?>">

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -234,9 +234,14 @@ html[dir="rtl"] #logs .content {
 }
 
 .comment.sentence {
-    background: #f5f5f5;
+    background: #fafafa;
     padding: 10px 16px;
-    margin-bottom: -39px;
+    margin-bottom: -38px;
+}
+
+.comment.sentence .info {
+    font-size: 14px;
+    margin: 0 10px;
 }
 
 .comment.sentence .lang {
@@ -245,7 +250,7 @@ html[dir="rtl"] #logs .content {
 }
 
 .comment.sentence .text {
-    margin: 0 10px;
+    margin: 5px 10px;
     text-align: left;
 }
 
@@ -836,7 +841,7 @@ md-icon.disabled.material-icons {
     padding: 4px 0px;
 }
 
-.sentence:hover {
+.sentences_set .sentence:hover {
     background: #f1f1f1;
 }
 


### PR DESCRIPTION
This pull request contains readjustments of the comments (continuation of #1306).

* The sentence owner is displayed again, after being removed. Although this information doesn't seem to influence much the activity of reading and replying to comments, it looks like users highly rely on the comments as a sentence feed, to perform activities on the sentences. In some case, the sentence owner serves as a faster connection to discover more sentences from a contributor, in other case, it serves as an indicator for the user to decide whether or not they want to invest more time on that sentence. Related Wall thread: http://tatoeba.org/eng/wall/show_message/27200#message_27200
* The sentence number is displayed as well. This sentence meta information is displayed under with the label `Sentence {number} - belongs to {username}`. This clarifies that the sentence is a sentence of the corpus, and that the username refers to the owner of the sentence.
* The sentence modified date has been fixed to not be displayed when the date is null.