### PR TITLE
Cache the audio stats query

### DIFF
--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -987,18 +987,22 @@ class Sentence extends AppModel
      */
     public function getTotalNumberOfSentencesWithAudio()
     {
-        $results = $this->query(
-            "SELECT lang, COUNT(*) total FROM sentences AS `Sentence`
-              WHERE hasaudio IN ('shtooka', 'from_users')
-              GROUP BY lang ORDER BY total DESC;"
-        );
-
-        $stats = array();
-        foreach ($results as $result) {
-            $stats[] = array(
-                'lang' => $result['Sentence']['lang'],
-                'total' => $result[0]['total']
+        $key = 'audio_stats';
+        $stats = Cache::read($key);
+        if ($stats === false) {
+            $results = $this->query(
+                "SELECT lang, COUNT(*) total FROM sentences AS `Sentence`
+                  WHERE hasaudio IN ('shtooka', 'from_users')
+                  GROUP BY lang ORDER BY total DESC;"
             );
+            $stats = array();
+            foreach ($results as $result) {
+                $stats[] = array(
+                    'lang' => $result['Sentence']['lang'],
+                    'total' => $result[0]['total']
+                );
+            }
+            Cache::write($key, $stats);
         }
 
         return $stats;


### PR DESCRIPTION
While investigating on the server slowdown, I found that the audio stats query is taking up to 11 seconds (averaging on 4~5 seconds). This query is triggered by https://tatoeba.org/stats/sentences_by_language and https://tatoeba.org/sentences/with_audio.

This probably won’t solve the whole slowdown problem, but it will surely improve performance.