### PR TITLE
Remove unnecessary join from sentence count query

### DIFF
--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -578,28 +578,13 @@ class Sentence extends AppModel
         $recursive = 0,
         $extra = array()
     ) {
-        if (isset($conditions['hasaudio'])) {
-            $sql = "SELECT COUNT(*) AS `count` FROM `sentences` AS `Sentence`
-                    WHERE `Sentence`.`hasaudio` != 'no'";
-        } else if (isset($conditions['Sentence.lang'])) {
-            $lang = $conditions['Sentence.lang'];
-
-            $lang = Sanitize::paranoid($lang);
-
-            $sql = "SELECT COUNT(*) AS `count` FROM `sentences` AS `Sentence`
-                    WHERE `Sentence`.`lang` = '{$lang}'";
-        } else if (isset($conditions['Sentence.user_id'])) {
-            $id = $conditions['Sentence.user_id'];
-
-            $sql = "SELECT COUNT(*) AS `count` FROM `sentences` AS `Sentence`
-                    WHERE `Sentence`.`user_id` = '{$id}'";
-        }
-
-        $this->recursive = $recursive;
-
-        $results = $this->query($sql);
-
-        return $results[0][0]['count'];
+        return $this->find(
+            'count',
+            array(
+                'contain' => [],
+                'conditions' => $conditions
+            )
+        );
     }
 
     /**

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -588,6 +588,11 @@ class Sentence extends AppModel
 
             $sql = "SELECT COUNT(*) AS `count` FROM `sentences` AS `Sentence`
                     WHERE `Sentence`.`lang` = '{$lang}'";
+        } else if (isset($conditions['Sentence.user_id'])) {
+            $id = $conditions['Sentence.user_id'];
+
+            $sql = "SELECT COUNT(*) AS `count` FROM `sentences` AS `Sentence`
+                    WHERE `Sentence`.`user_id` = '{$id}'";
         }
 
         $this->recursive = $recursive;

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -565,6 +565,39 @@ class Sentence extends AppModel
     }
 
     /**
+     * Override standard paginateCount method to eliminate unnecessary joins.
+     *
+     * @param  array   $conditions
+     * @param  integer $recursive
+     * @param  array   $extra
+     *
+     * @return integer
+     */
+    public function paginateCount(
+        $conditions = null,
+        $recursive = 0,
+        $extra = array()
+    ) {
+        if (isset($conditions['hasaudio'])) {
+            $sql = "SELECT COUNT(*) AS `count` FROM `sentences` AS `Sentence`
+                    WHERE `Sentence`.`hasaudio` != 'no'";
+        } else if (isset($conditions['Sentence.lang'])) {
+            $lang = $conditions['Sentence.lang'];
+
+            $lang = Sanitize::paranoid($lang);
+
+            $sql = "SELECT COUNT(*) AS `count` FROM `sentences` AS `Sentence`
+                    WHERE `Sentence`.`lang` = '{$lang}'";
+        }
+
+        $this->recursive = $recursive;
+
+        $results = $this->query($sql);
+
+        return $results[0][0]['count'];
+    }
+
+    /**
      * Get all the informations needed to display a sentences in show section.
      *
      * @param int $id Id of the sentence asked.


### PR DESCRIPTION
This pull request address issue #1323.    

I overrode the standard count used for pagination by creating a paginateCount method on the sentence model. I simply hardcoded the sql query everything, at least for now. Right now, Im covering the following sentence pagination possibilities:
  - Paginate sentences by `lang`
  - Paginate sentences by `hasaudio`
  - Paginate sentences by `user_id`

Am I missing anything?     

Also, I dont have the audio database set up on my dev machine, so Im not 100% sure if that one works or not.    

Before merging, Id like to refactor this. I want to make sure Im covering all the possibilities before doing the refactor though.