### PR TITLE
Override paginator count only when conditions are present.

### DIFF
--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -565,6 +565,40 @@ class Sentence extends AppModel
     }
 
     /**
+     * Override standard paginateCount method to eliminate unnecessary joins.
+     * If $conditions is empty, as in Sphinx search, return default behavior.
+     *
+     * @param  array   $conditions
+     * @param  integer $recursive
+     * @param  array   $extra
+     *
+     * @return integer
+     */
+    public function paginateCount(
+        $conditions = null,
+        $recursive = 0,
+        $extra = array()
+    ) {
+        if (empty($conditions)) {
+            $parameters = compact('conditions');
+
+            if ($recursive != $this->recursive) {
+                $parameters['recursive'] = $recursive;
+            }
+
+            return $this->find('count', array_merge($parameters, $extra));
+        }
+
+        return $this->find(
+            'count',
+            array(
+                'contain' => [],
+                'conditions' => $conditions
+            )
+        );
+    }
+
+    /**
      * Get all the informations needed to display a sentences in show section.
      *
      * @param int $id Id of the sentence asked.

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -579,23 +579,10 @@ class Sentence extends AppModel
         $recursive = 0,
         $extra = array()
     ) {
-        if (empty($conditions)) {
-            $parameters = compact('conditions');
+        $parameters = compact('conditions');
+        $extra['contain'] = [];
 
-            if ($recursive != $this->recursive) {
-                $parameters['recursive'] = $recursive;
-            }
-
-            return $this->find('count', array_merge($parameters, $extra));
-        }
-
-        return $this->find(
-            'count',
-            array(
-                'contain' => [],
-                'conditions' => $conditions
-            )
-        );
+        return $this->find('count', array_merge($parameters, $extra));
     }
 
     /**


### PR DESCRIPTION
This pull request addresses issue #1323.    

I played around with this for a while and found that when Sphinx uses paginateCount, $conditions is an empty array. So if $conditions is empty, we will use the default behavior as defined here: https://github.com/Tatoeba/tatoeba2/blob/dev/cake/libs/controller/controller.php#L1205    

I havent found any problems with it, but maybe we should deploy it on the dev site before putting it on production to make sure it doesnt break Sphinx again.