### PR TITLE
Add additional check for duplicate sentences.

### DIFF
--- a/app/models/behaviors/hashable.php
+++ b/app/models/behaviors/hashable.php
@@ -57,6 +57,24 @@ class HashableBehavior extends ModelBehavior
     }
 
     /**
+     * Find all records by binary hash value.
+     *
+     * @param  object $model  Model
+     * @param  string $binary Binary id value.
+     * @param  string $column Column on table to search.
+     *
+     * @return array
+     */
+    public function findAllByBinary($model, $binary, $column)
+    {
+        $binary = $this->padHashBinary($model, $binary);
+
+        $method = 'findAllBy'.$column;
+
+        return $model->{$method}($binary);
+    }
+
+    /**
      * Convert a binary id to a padded binary id.
      *
      * @param  object $model  Model.

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -768,14 +768,14 @@ class Sentence extends AppModel
 
         $hash = $this->makeHash($lang, $text);
 
-        $sentence = $this->findByBinary($hash, 'hash');
+        $sentences = $this->findAllByBinary($hash, 'hash');
 
-        if ($sentence && $this->_confirmDuplicate($text, $lang, $sentence)) {
-            $this->id = $sentence['Sentence']['id'];
+        foreach ($sentences as $sentence) {
+            if ($this->_confirmDuplicate($text, $lang, $sentence)) {
+                $this->id = $sentence['Sentence']['id'];
 
-            $this->duplicate = true;
-
-            return true;
+                return $this->duplicate = true;
+            }
         }
 
         $this->create();

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -768,7 +768,9 @@ class Sentence extends AppModel
 
         $hash = $this->makeHash($lang, $text);
 
-        if ($sentence = $this->findByBinary($hash, 'hash')) {
+        $sentence = $this->findByBinary($hash, 'hash');
+
+        if ($sentence && $this->_confirmDuplicate($text, $lang, $sentence)) {
             $this->id = $sentence['Sentence']['id'];
 
             $this->duplicate = true;
@@ -790,6 +792,28 @@ class Sentence extends AppModel
         }
 
         return $this->save($data);
+    }
+
+    /**
+     * Return true if text and lang match sentence text and lang.
+     * 
+     * @param  string $text     New sentence text.
+     * @param  string $lang     New sentence lang.
+     * @param  array  $sentence Existing sentence.
+     *
+     * @return Boolean
+     */
+    private function _confirmDuplicate($text, $lang, $sentence)
+    {
+        $sentenceText = $sentence['Sentence']['text'];
+
+        $sentenceLang = $sentence['Sentence']['lang'];
+
+        if ($sentenceText === $text && $sentenceLang === $lang) {
+            return true;
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
This pull request address issue #1336.   

I added checks for both the text and language of the new sentence. If these two conditions are met, it will be marked as a true duplicate.