### PR TITLE
Redesign sentences

### DIFF
--- a/app/controllers/activities_controller.php
+++ b/app/controllers/activities_controller.php
@@ -185,11 +185,16 @@ class ActivitiesController extends AppController
             $conditions['Sentence.lang'] = $lang;
         }
 
+        if (CurrentUser::isMember()) {
+            $contain = $this->Sentence->contain();
+        } else {
+            $contain = $this->Sentence->minimalContain();
+        }
         $this->paginate = array(
             'Sentence' => array(
                 'fields' => $this->Sentence->fields(),
                 'conditions' => $conditions,
-                'contain' => $this->Sentence->contain(),
+                'contain' => $contain,
                 'limit' => CurrentUser::getSetting('sentences_per_page'),
                 'order' => 'created DESC'
             )

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -910,10 +910,16 @@ class SentencesController extends AppController
         $this->addLastUsedLang($translationLang);
         $this->addLastUsedLang($notTranslatedInto);
 
+        if (CurrentUser::isMember()) {
+            $contain = $this->Sentence->contain();
+        } else {
+            $contain = $this->Sentence->minimalContain();
+        }
+
         $pagination = array(
             'Sentence' => array(
                 'fields' => $this->Sentence->fields(),
-                'contain' => $this->Sentence->contain(),
+                'contain' => $contain,
                 'conditions' => array(
                     'Sentence.lang' => $lang,
                 ),
@@ -931,7 +937,6 @@ class SentencesController extends AppController
 
 
         if (!empty($notTranslatedInto) && $notTranslatedInto != 'none') {
-
             $model = 'SentenceNotTranslatedInto';
             $pagination = array(
                 'SentenceNotTranslatedInto' => array(
@@ -942,7 +947,7 @@ class SentencesController extends AppController
                         'notTranslatedInto' => $notTranslatedInto,
                         'audioOnly' => $audioOnly,
                     ),
-                    'contain' => $this->Sentence->contain(),
+                    'contain' => $contain,
                     'order' => 'Sentence.id DESC',
                     'limit' => 10,
                 )

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -827,10 +827,15 @@ class SentencesController extends AppController
         $search_disabled = !Configure::read('Search.enabled');
         if (!$search_disabled) {
             $model = 'Sentence';
+            if (CurrentUser::isMember()) {
+                $contain = $this->Sentence->contain();
+            } else {
+                $contain = $this->Sentence->minimalContain();
+            }
             $pagination = array(
                 'Sentence' => array(
                     'fields' => $this->Sentence->fields(),
-                    'contain' => $this->Sentence->contain(),
+                    'contain' => $contain,
                     'limit' => CurrentUser::getSetting('sentences_per_page'),
                     'sphinx' => $sphinx,
                     'search' => $query

--- a/app/models/sentence.php
+++ b/app/models/sentence.php
@@ -555,11 +555,28 @@ class Sentence extends AppModel
 
     /**
      * Returns the appropriate value for the 'contain' parameter
+     * for the most basic display of the sentence groups.
+     */
+    public function minimalContain() {
+        return array(
+            'User' => array(
+                'fields' => array('id', 'username', 'group_id', 'level')
+            ),
+            'Translation' => array(),
+        );
+    }
+
+    /**
+     * Returns the appropriate value for the 'contain' parameter
      * of typical a pagination of sentences.
      */
     public function paginateContain()
     {
-        $params = $this->contain();
+        if (CurrentUser::isMember()) {
+            $params = $this->contain();
+        } else {
+            $params = $this->minimalContain();
+        }
         $params['fields'] = $this->fields();
         return $params;
     }

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -117,7 +117,8 @@ class User extends AppModel
         'users_collections_ratings' => false,
         'native_indicator' => false,
         'copy_button' => false,
-        'hide_random_sentence' => false
+        'hide_random_sentence' => false,
+        'use_new_design' => false
     );
 
     private $settingsValidation = array(

--- a/app/views/activities/translate_sentences_of.ctp
+++ b/app/views/activities/translate_sentences_of.ctp
@@ -66,16 +66,7 @@ $this->set('title_for_layout', $pages->formatTitle($title));
         );
         $pagination->display($paginationUrl);
 
-        if (CurrentUser::isMember()) {
-            foreach ($results as $sentence) {
-                $sentences->displaySentencesGroup(
-                    $sentence['Sentence'],
-                    $sentence['Transcription'],
-                    $sentence['Translation'],
-                    $sentence['User']
-                );
-            }
-        } else {
+        if (!CurrentUser::isMember() || CurrentUser::getSetting('use_new_design')) {
             foreach ($results as $sentence) {
                 echo $this->element(
                     'sentences/sentence_and_translations',
@@ -84,6 +75,15 @@ $this->set('title_for_layout', $pages->formatTitle($title));
                         'translations' => $sentence['Translation'],
                         'user' => $sentence['User']
                     )
+                );
+            }
+        } else {
+            foreach ($results as $sentence) {
+                $sentences->displaySentencesGroup(
+                    $sentence['Sentence'],
+                    $sentence['Transcription'],
+                    $sentence['Translation'],
+                    $sentence['User']
                 );
             }
         }

--- a/app/views/activities/translate_sentences_of.ctp
+++ b/app/views/activities/translate_sentences_of.ctp
@@ -55,7 +55,7 @@ $this->set('title_for_layout', $pages->formatTitle($title));
 
 <div id="main_content">    
     
-    <div class="module">
+    <div class="section">
     <?php 
     echo $this->Pages->formatTitleWithResultCount($paginator, $title);
 
@@ -65,14 +65,27 @@ $this->set('title_for_layout', $pages->formatTitle($title));
             $lang
         );
         $pagination->display($paginationUrl);
-        
-        foreach ($results as $sentence) {
-            $sentences->displaySentencesGroup(
-                $sentence['Sentence'],
-                $sentence['Transcription'],
-                $sentence['Translation'],
-                $sentence['User']
-            );
+
+        if (CurrentUser::isMember()) {
+            foreach ($results as $sentence) {
+                $sentences->displaySentencesGroup(
+                    $sentence['Sentence'],
+                    $sentence['Transcription'],
+                    $sentence['Translation'],
+                    $sentence['User']
+                );
+            }
+        } else {
+            foreach ($results as $sentence) {
+                echo $this->element(
+                    'sentences/sentence_and_translations',
+                    array(
+                        'sentence' => $sentence['Sentence'],
+                        'translations' => $sentence['Translation'],
+                        'user' => $sentence['User']
+                    )
+                );
+            }
         }
         
         $pagination->display($paginationUrl);

--- a/app/views/elements/random_sentence_header.ctp
+++ b/app/views/elements/random_sentence_header.ctp
@@ -34,34 +34,51 @@ if ($selectedLanguage == null) {
     $selectedLanguage == 'und';
 }
 ?>
-<div layout="row" layout-align="start center">
-    <h2 layout="row" layout-align="start center" flex>
-        <?php __('Random sentence'); ?>
-        <? if ($session->read('Auth.User.id')) {
-            $showMoreUrl = $html->url(array(
-                'controller' => 'sentences',
-                'action' => 'several_random_sentences'
-            ));
-            ?>
-            <md-button class="md-icon-button" href="<?= $showMoreUrl ?>">
-                <md-icon>more_horiz</md-icon>
-            </md-button>
-        <? } ?>
-    </h2>
-    <?php
-    echo $form->select(
-        "randomLangChoice",
-        $langArray,
-        $selectedLanguage,
-        array(
-            'class' => 'language-selector',
-            "empty" => false
-        ),
-        false
-    );
-    ?>
-    <md-button class="md-icon-button" id="showRandom" onclick="return false;">
-        <md-icon>refresh</md-icon>
-    </md-button>
-</div>
 
+<h2>
+    <?php __('Random sentence'); ?>
+    <span>
+        <?php
+        echo $form->select(
+            "randomLangChoice",
+            $langArray,
+            $selectedLanguage,
+            array(
+                'class' => 'language-selector',
+                "empty" => false
+            ),
+            false
+        );
+        echo ' ';
+        echo $html->link(
+            __('show another ', true),
+            array(),
+            array(
+                "id" => "showRandom",
+                "class" => "titleAnnexeLink",
+                "onclick" => "return false;"
+            )
+        );
+        ?>
+    </span>
+    <?php
+    if ($session->read('Auth.User.id')) {
+        ?>
+        <span>
+            <?php
+             echo $html->link(
+                 __('show more...', true),
+                 array(
+                     "controller" => "sentences",
+                     "action" => "several_random_sentences"
+                 ),
+                 array(
+                     "class" => "titleAnnexeLink"
+                 )
+             );
+             ?>
+        </span>
+    <?php
+    }
+    ?>
+</h2>

--- a/app/views/elements/random_sentence_header.ctp
+++ b/app/views/elements/random_sentence_header.ctp
@@ -34,51 +34,34 @@ if ($selectedLanguage == null) {
     $selectedLanguage == 'und';
 }
 ?>
-
-<h2>
-    <?php __('Random sentence'); ?>
-    <span>
-        <?php
-        echo $form->select(
-            "randomLangChoice",
-            $langArray,
-            $selectedLanguage,
-            array(
-                'class' => 'language-selector',
-                "empty" => false
-            ),
-            false
-        );
-        echo ' ';
-        echo $html->link(
-            __('show another ', true),
-            array(),
-            array(
-                "id" => "showRandom",
-                "class" => "titleAnnexeLink",
-                "onclick" => "return false;"
-            )
-        );
-        ?>
-    </span>
+<div layout="row" layout-align="start center">
+    <h2 layout="row" layout-align="start center" flex>
+        <?php __('Random sentence'); ?>
+        <? if ($session->read('Auth.User.id')) {
+            $showMoreUrl = $html->url(array(
+                'controller' => 'sentences',
+                'action' => 'several_random_sentences'
+            ));
+            ?>
+            <md-button class="md-icon-button" href="<?= $showMoreUrl ?>">
+                <md-icon>more_horiz</md-icon>
+            </md-button>
+        <? } ?>
+    </h2>
     <?php
-    if ($session->read('Auth.User.id')) {
-        ?>
-        <span>
-            <?php
-             echo $html->link(
-                 __('show more...', true),
-                 array(
-                     "controller" => "sentences",
-                     "action" => "several_random_sentences"
-                 ),
-                 array(
-                     "class" => "titleAnnexeLink"
-                 )
-             );
-             ?>
-        </span>
-    <?php
-    }
+    echo $form->select(
+        "randomLangChoice",
+        $langArray,
+        $selectedLanguage,
+        array(
+            'class' => 'language-selector',
+            "empty" => false
+        ),
+        false
+    );
     ?>
-</h2>
+    <md-button class="md-icon-button" id="showRandom" onclick="return false;">
+        <md-icon>refresh</md-icon>
+    </md-button>
+</div>
+

--- a/app/views/elements/sentences/sentence_and_translations.ctp
+++ b/app/views/elements/sentences/sentence_and_translations.ctp
@@ -48,8 +48,7 @@ $sentenceUrl = $html->url(array(
                     $sentence['lang'],
                     array(
                         'width' => 30,
-                        'height' => 20,
-                        'class' => 'md-secondary'
+                        'height' => 20
                     )
                 );
                 ?>
@@ -68,39 +67,15 @@ $sentenceUrl = $html->url(array(
             <md-divider></md-divider>
             <md-subheader><? __('Translations') ?></md-subheader>
             <? foreach ($directTranslations as $translation) {
-                if ($numExtra > 1 && $displayedTranslations >= $maxDisplayed) {
-                    $showExtra = 'ng-if="sentence.showExtra"';
-                }
-                $translationUrl = $html->url(array(
-                    'controller' => 'sentences',
-                    'action' => 'show',
-                    $translation['id']
-                ));
-                ?>
-                <div layout="row" layout-align="start center" <?= $showExtra ?>
-                     class="translation">
-                    <md-icon class="chevron">chevron_right</md-icon>
-                    <div class="lang">
-                        <?
-                        echo $languages->icon(
-                            $translation['lang'],
-                            array(
-                                'width' => 30,
-                                'height' => 20,
-                                'class' => 'md-secondary'
-                            )
-                        );
-                        ?>
-                    </div>
-                    <div class="text" flex>
-                        <?= $translation['text'] ?>
-                    </div>
-                    <md-button class="md-icon-button"
-                               href="<?= $translationUrl ?>">
-                        <md-icon>info</md-icon>
-                    </md-button>
-                </div>
-                <?
+                $isExtra = $numExtra > 1 && $displayedTranslations >= $maxDisplayed;
+                echo $this->element(
+                    'sentences/translation',
+                    array(
+                        'sentenceId' => $sentence['id'],
+                        'translation' => $translation,
+                        'isExtra' => $isExtra
+                    )
+                );
                 $displayedTranslations++;
             }
             ?>
@@ -109,45 +84,21 @@ $sentenceUrl = $html->url(array(
 
     <? if (count($indirectTranslations) > 0) {
         if ($numExtra > 1 && $displayedTranslations >= $maxDisplayed) {
-            $showExtra = 'ng-if="sentence.showExtra"';
+            $showExtra = 'ng-if="sentence.showExtra['.$sentence['id'].']"';
         }
         ?>
         <div layout="column" <?= $showExtra ?> class="indirect translations">
             <md-subheader><? __('Translations of translations') ?></md-subheader>
             <? foreach ($indirectTranslations as $translation) {
-                if ($numExtra > 1 && $displayedTranslations >= $maxDisplayed) {
-                    $showExtra = 'ng-if="sentence.showExtra"';
-                }
-                $translationUrl = $html->url(array(
-                    'controller' => 'sentences',
-                    'action' => 'show',
-                    $translation['id']
-                ));
-                ?>
-                <div layout="row" layout-align="start center" <?= $showExtra ?>
-                     class="translation">
-                    <md-icon class="chevron">chevron_right</md-icon>
-                    <div class="lang">
-                        <?
-                        echo $languages->icon(
-                            $translation['lang'],
-                            array(
-                                'width' => 30,
-                                'height' => 20,
-                                'class' => 'md-secondary'
-                            )
-                        );
-                        ?>
-                    </div>
-                    <div class="text" flex>
-                        <?= $translation['text'] ?>
-                    </div>
-                    <md-button class="md-icon-button"
-                               href="<?= $translationUrl ?>">
-                        <md-icon>info</md-icon>
-                    </md-button>
-                </div>
-                <?
+                $isExtra = $numExtra > 1 && $displayedTranslations >= $maxDisplayed;
+                echo $this->element(
+                    'sentences/translation',
+                    array(
+                        'sentenceId' => $sentence['id'],
+                        'translation' => $translation,
+                        'isExtra' => $isExtra
+                    )
+                );
                 $displayedTranslations++;
             } ?>
         </div>
@@ -155,9 +106,12 @@ $sentenceUrl = $html->url(array(
 
     <? if ($numExtra > 1) { ?>
         <div layout="column">
-            <md-button ng-click="sentence.showExtra = !sentence.showExtra">
-                <md-icon ng-if="!sentence.showExtra">expand_more</md-icon>
-                <span ng-if="!sentence.showExtra">
+            <md-button ng-click="sentence.showExtra[<?= $sentence['id'] ?>]
+                              = !sentence.showExtra[<?= $sentence['id'] ?>]">
+                <md-icon ng-if="!sentence.showExtra[<?= $sentence['id'] ?>]">
+                    expand_more
+                </md-icon>
+                <span ng-if="!sentence.showExtra[<?= $sentence['id'] ?>]">
                     <?php
                     echo format(__n(
                         'Show 1 more translation',
@@ -167,8 +121,10 @@ $sentenceUrl = $html->url(array(
                     ), array('number' => $numExtra))
                     ?>
                 </span>
-                <md-icon ng-if="sentence.showExtra">expand_less</md-icon>
-                <span ng-if="sentence.showExtra">
+                <md-icon ng-if="sentence.showExtra[<?= $sentence['id'] ?>]">
+                    expand_less
+                </md-icon>
+                <span ng-if="sentence.showExtra[<?= $sentence['id'] ?>]">
                     <?php __('Fewer translations') ?>
                 </span>
             </md-button>

--- a/app/views/elements/sentences/sentence_and_translations.ctp
+++ b/app/views/elements/sentences/sentence_and_translations.ctp
@@ -58,7 +58,7 @@ $notReliable = $sentence['correctness'] == -1;
                 ?>
             </div>
             <div class="text" flex>
-                <?= $sentence['text'] ?>
+                <?= Sanitize::html($sentence['text']) ?>
             </div>
             <? if ($notReliable) { ?>
                 <md-icon class="md-warn">warning</md-icon>

--- a/app/views/elements/sentences/sentence_and_translations.ctp
+++ b/app/views/elements/sentences/sentence_and_translations.ctp
@@ -27,6 +27,7 @@ $sentenceUrl = $html->url(array(
     'action' => 'show',
     $sentence['id']
 ));
+$notReliable = $sentence['correctness'] == -1;
 ?>
 <div class="sentence-and-translations" md-whiteframe="1" ng-cloak>
     <div layout="column">
@@ -41,7 +42,8 @@ $sentenceUrl = $html->url(array(
             );
             ?>
         </md-subheader>
-        <div class="sentence" layout="row" layout-align="start center">
+        <div class="sentence <?= $notReliable ? 'not-reliable' : '' ?>"
+             layout="row" layout-align="start center">
             <div class="lang">
                 <?
                 echo $languages->icon(
@@ -56,6 +58,12 @@ $sentenceUrl = $html->url(array(
             <div class="text" flex>
                 <?= $sentence['text'] ?>
             </div>
+            <? if ($notReliable) { ?>
+                <md-icon class="md-warn">warning</md-icon>
+                <md-tooltip md-direction="top">
+                    <? __('This sentence is not reliable.') ?>
+                </md-tooltip>
+            <? } ?>
             <md-button class="md-icon-button" href="<?= $sentenceUrl ?>">
                 <md-icon>info</md-icon>
             </md-button>

--- a/app/views/elements/sentences/sentence_and_translations.ctp
+++ b/app/views/elements/sentences/sentence_and_translations.ctp
@@ -1,4 +1,6 @@
 <?php
+$javascript->link('/js/directives/sentence-and-translations.dir.js', false);
+
 list($directTranslations, $indirectTranslations) = $sentences->segregateTranslations(
     $translations
 );
@@ -29,7 +31,7 @@ $sentenceUrl = $html->url(array(
 ));
 $notReliable = $sentence['correctness'] == -1;
 ?>
-<div class="sentence-and-translations" md-whiteframe="1" ng-cloak>
+<div sentence-and-translations class="sentence-and-translations" md-whiteframe="1">
     <div layout="column">
         <md-subheader>
             <?=
@@ -92,7 +94,7 @@ $notReliable = $sentence['correctness'] == -1;
 
     <? if (count($indirectTranslations) > 0) {
         if ($numExtra > 1 && $displayedTranslations >= $maxDisplayed) {
-            $showExtra = 'ng-if="sentence.showExtra['.$sentence['id'].']"';
+            $showExtra = 'ng-if="vm.isExpanded"';
         }
         ?>
         <div layout="column" <?= $showExtra ?> class="indirect translations">
@@ -114,12 +116,9 @@ $notReliable = $sentence['correctness'] == -1;
 
     <? if ($numExtra > 1) { ?>
         <div layout="column">
-            <md-button ng-click="sentence.showExtra[<?= $sentence['id'] ?>]
-                              = !sentence.showExtra[<?= $sentence['id'] ?>]">
-                <md-icon ng-if="!sentence.showExtra[<?= $sentence['id'] ?>]">
-                    expand_more
-                </md-icon>
-                <span ng-if="!sentence.showExtra[<?= $sentence['id'] ?>]">
+            <md-button ng-click="vm.expandOrCollapse()">
+                <md-icon>{{vm.expandableIcon}}</md-icon>
+                <span ng-if="!vm.isExpanded">
                     <?php
                     echo format(__n(
                         'Show 1 more translation',
@@ -129,10 +128,7 @@ $notReliable = $sentence['correctness'] == -1;
                     ), array('number' => $numExtra))
                     ?>
                 </span>
-                <md-icon ng-if="sentence.showExtra[<?= $sentence['id'] ?>]">
-                    expand_less
-                </md-icon>
-                <span ng-if="sentence.showExtra[<?= $sentence['id'] ?>]">
+                <span ng-if="vm.isExpanded">
                     <?php __('Fewer translations') ?>
                 </span>
             </md-button>

--- a/app/views/elements/sentences/sentence_and_translations.ctp
+++ b/app/views/elements/sentences/sentence_and_translations.ctp
@@ -1,0 +1,177 @@
+<?php
+list($directTranslations, $indirectTranslations) = $sentences->segregateTranslations(
+    $translations
+);
+$maxDisplayed = 5;
+$displayedTranslations = 0;
+$showExtra = '';
+$numExtra = count($directTranslations) + count($indirectTranslations) - $maxDisplayed;
+$sentenceLink = $html->link(
+    '#'.$sentence['id'],
+    array(
+        'controller' => 'sentences',
+        'action' => 'show',
+        $sentence['id']
+    )
+);
+$userLink = $html->link(
+    $user['username'],
+    array(
+        'controller' => 'user',
+        'action' => 'profile',
+        $user['username']
+    )
+);
+$sentenceUrl = $html->url(array(
+    'controller' => 'sentences',
+    'action' => 'show',
+    $sentence['id']
+));
+?>
+<div class="sentence-and-translations" md-whiteframe="1" ng-cloak>
+    <div layout="column">
+        <md-subheader>
+            <?=
+            format(
+                __('Sentence {number} — belongs to {username}', true),
+                array(
+                    'number' => $sentenceLink,
+                    'username' => $userLink
+                )
+            );
+            ?>
+        </md-subheader>
+        <div class="sentence" layout="row" layout-align="start center">
+            <div class="lang">
+                <?
+                echo $languages->icon(
+                    $sentence['lang'],
+                    array(
+                        'width' => 30,
+                        'height' => 20,
+                        'class' => 'md-secondary'
+                    )
+                );
+                ?>
+            </div>
+            <div class="text" flex>
+                <?= $sentence['text'] ?>
+            </div>
+            <md-button class="md-icon-button" href="<?= $sentenceUrl ?>">
+                <md-icon>info</md-icon>
+            </md-button>
+        </div>
+    </div>
+
+    <? if (count($directTranslations) > 0) { ?>
+        <div layout="column" class="direct translations">
+            <md-divider></md-divider>
+            <md-subheader><? __('Translations') ?></md-subheader>
+            <? foreach ($directTranslations as $translation) {
+                if ($numExtra > 1 && $displayedTranslations >= $maxDisplayed) {
+                    $showExtra = 'ng-if="sentence.showExtra"';
+                }
+                $translationUrl = $html->url(array(
+                    'controller' => 'sentences',
+                    'action' => 'show',
+                    $translation['id']
+                ));
+                ?>
+                <div layout="row" layout-align="start center" <?= $showExtra ?>
+                     class="translation">
+                    <md-icon class="chevron">chevron_right</md-icon>
+                    <div class="lang">
+                        <?
+                        echo $languages->icon(
+                            $translation['lang'],
+                            array(
+                                'width' => 30,
+                                'height' => 20,
+                                'class' => 'md-secondary'
+                            )
+                        );
+                        ?>
+                    </div>
+                    <div class="text" flex>
+                        <?= $translation['text'] ?>
+                    </div>
+                    <md-button class="md-icon-button"
+                               href="<?= $translationUrl ?>">
+                        <md-icon>info</md-icon>
+                    </md-button>
+                </div>
+                <?
+                $displayedTranslations++;
+            }
+            ?>
+        </div>
+    <? } ?>
+
+    <? if (count($indirectTranslations) > 0) {
+        if ($numExtra > 1 && $displayedTranslations >= $maxDisplayed) {
+            $showExtra = 'ng-if="sentence.showExtra"';
+        }
+        ?>
+        <div layout="column" <?= $showExtra ?> class="indirect translations">
+            <md-subheader><? __('Translations of translations') ?></md-subheader>
+            <? foreach ($indirectTranslations as $translation) {
+                if ($numExtra > 1 && $displayedTranslations >= $maxDisplayed) {
+                    $showExtra = 'ng-if="sentence.showExtra"';
+                }
+                $translationUrl = $html->url(array(
+                    'controller' => 'sentences',
+                    'action' => 'show',
+                    $translation['id']
+                ));
+                ?>
+                <div layout="row" layout-align="start center" <?= $showExtra ?>
+                     class="translation">
+                    <md-icon class="chevron">chevron_right</md-icon>
+                    <div class="lang">
+                        <?
+                        echo $languages->icon(
+                            $translation['lang'],
+                            array(
+                                'width' => 30,
+                                'height' => 20,
+                                'class' => 'md-secondary'
+                            )
+                        );
+                        ?>
+                    </div>
+                    <div class="text" flex>
+                        <?= $translation['text'] ?>
+                    </div>
+                    <md-button class="md-icon-button"
+                               href="<?= $translationUrl ?>">
+                        <md-icon>info</md-icon>
+                    </md-button>
+                </div>
+                <?
+                $displayedTranslations++;
+            } ?>
+        </div>
+    <? } ?>
+
+    <? if ($numExtra > 1) { ?>
+        <div layout="column">
+            <md-button ng-click="sentence.showExtra = !sentence.showExtra">
+                <md-icon ng-if="!sentence.showExtra">expand_more</md-icon>
+                <span ng-if="!sentence.showExtra">
+                    <?php
+                    echo format(__n(
+                        'Show 1 more translation',
+                        'Show {number} more translations',
+                        $numExtra,
+                        true
+                    ), array('number' => $numExtra))
+                    ?>
+                </span>
+                <md-icon ng-if="sentence.showExtra">expand_less</md-icon>
+                <span ng-if="sentence.showExtra">
+                    <?php __('Fewer translations') ?>
+                </span>
+            </md-button>
+        </div>
+    <? } ?>
+</div>

--- a/app/views/elements/sentences/translation.ctp
+++ b/app/views/elements/sentences/translation.ctp
@@ -8,9 +8,10 @@ $translationUrl = $this->Html->url(array(
     'action' => 'show',
     $translation['id']
 ));
+$notReliable = $translation['correctness'] == -1;
 ?>
 <div layout="row" layout-align="start center" <?= $showExtra ?>
-     class="translation">
+     class="translation <?= $notReliable ? 'not-reliable' : '' ?>">
     <md-icon class="chevron">chevron_right</md-icon>
     <div class="lang">
         <?
@@ -26,6 +27,12 @@ $translationUrl = $this->Html->url(array(
     <div class="text" flex>
         <?= $translation['text'] ?>
     </div>
+    <? if ($notReliable) { ?>
+        <md-icon class="md-warn">warning</md-icon>
+        <md-tooltip md-direction="top">
+            <? __('This sentence is not reliable.') ?>
+        </md-tooltip>
+    <? } ?>
     <md-button class="md-icon-button"
                href="<?= $translationUrl ?>">
         <md-icon>info</md-icon>

--- a/app/views/elements/sentences/translation.ctp
+++ b/app/views/elements/sentences/translation.ctp
@@ -1,0 +1,33 @@
+<?php
+$showExtra = '';
+if ($isExtra) {
+    $showExtra = 'ng-if="sentence.showExtra['.$sentenceId.']"';
+}
+$translationUrl = $this->Html->url(array(
+    'controller' => 'sentences',
+    'action' => 'show',
+    $translation['id']
+));
+?>
+<div layout="row" layout-align="start center" <?= $showExtra ?>
+     class="translation">
+    <md-icon class="chevron">chevron_right</md-icon>
+    <div class="lang">
+        <?
+        echo $this->Languages->icon(
+            $translation['lang'],
+            array(
+                'width' => 30,
+                'height' => 20
+            )
+        );
+        ?>
+    </div>
+    <div class="text" flex>
+        <?= $translation['text'] ?>
+    </div>
+    <md-button class="md-icon-button"
+               href="<?= $translationUrl ?>">
+        <md-icon>info</md-icon>
+    </md-button>
+</div>

--- a/app/views/elements/sentences/translation.ctp
+++ b/app/views/elements/sentences/translation.ctp
@@ -25,7 +25,7 @@ $notReliable = $translation['correctness'] == -1;
         ?>
     </div>
     <div class="text" flex>
-        <?= $translation['text'] ?>
+        <?= Sanitize::html($translation['text']) ?>
     </div>
     <? if ($notReliable) { ?>
         <md-icon class="md-warn">warning</md-icon>

--- a/app/views/elements/sentences/translation.ctp
+++ b/app/views/elements/sentences/translation.ctp
@@ -1,7 +1,7 @@
 <?php
 $showExtra = '';
 if ($isExtra) {
-    $showExtra = 'ng-if="sentence.showExtra['.$sentenceId.']"';
+    $showExtra = 'ng-if="vm.isExpanded"';
 }
 $translationUrl = $this->Html->url(array(
     'controller' => 'sentences',

--- a/app/views/helpers/sentences.php
+++ b/app/views/helpers/sentences.php
@@ -137,7 +137,7 @@ class SentencesHelper extends AppHelper
         <?php
     }
 
-    private function segregateTranslations($translations) {
+    public function segregateTranslations($translations) {
         $result = array(0 => array(), 1 => array());
         foreach ($translations as $translation) {
             if (isset($translation['Translation'])) {

--- a/app/views/pages/index.ctp
+++ b/app/views/pages/index.ctp
@@ -63,7 +63,7 @@ $selectedLanguage = $session->read('random_lang_selected');
 
 <div id="main_content">
     <?php if(!isset($searchProblem) && !$hideRandomSentence) { ?>
-        <div class="section">
+        <div class="module">
             <?php echo $this->element('random_sentence_header'); ?>
             <div class="random_sentences_set">
                 <md-progress-circular md-mode="indeterminate" class="block-loader" id="random-progress" style="display: none;"></md-progress-circular>
@@ -74,13 +74,11 @@ $selectedLanguage = $session->read('random_lang_selected');
                     $translations = $random['Translation'];
                     $sentenceOwner = $random['User'];
 
-                    echo $this->element(
-                        'sentences/sentence_and_translations',
-                        array(
-                            'sentence' => $sentence,
-                            'translations' => $translations,
-                            'user' => $sentenceOwner
-                        )
+                    $sentences->displaySentencesGroup(
+                        $sentence,
+                        $transcrs,
+                        $translations,
+                        $sentenceOwner
                     );
                     ?>
                 </div>

--- a/app/views/pages/index.ctp
+++ b/app/views/pages/index.ctp
@@ -63,7 +63,7 @@ $selectedLanguage = $session->read('random_lang_selected');
 
 <div id="main_content">
     <?php if(!isset($searchProblem) && !$hideRandomSentence) { ?>
-        <div class="module">
+        <div class="section">
             <?php echo $this->element('random_sentence_header'); ?>
             <div class="random_sentences_set">
                 <md-progress-circular md-mode="indeterminate" class="block-loader" id="random-progress" style="display: none;"></md-progress-circular>
@@ -74,11 +74,13 @@ $selectedLanguage = $session->read('random_lang_selected');
                     $translations = $random['Translation'];
                     $sentenceOwner = $random['User'];
 
-                    $sentences->displaySentencesGroup(
-                        $sentence,
-                        $transcrs,
-                        $translations,
-                        $sentenceOwner
+                    echo $this->element(
+                        'sentences/sentence_and_translations',
+                        array(
+                            'sentence' => $sentence,
+                            'translations' => $translations,
+                            'user' => $sentenceOwner
+                        )
                     );
                     ?>
                 </div>

--- a/app/views/pages/index_for_guests.ctp
+++ b/app/views/pages/index_for_guests.ctp
@@ -122,22 +122,22 @@ $this->set('title_for_layout', __('Tatoeba: Collection of sentences and translat
 </div>
 <div id="main_content">
     <?php if(!isset($searchProblem)) { ?>
-    <div class="module">
-        <?php echo $this->element('random_sentence_header'); ?>
+    <div class="section">
+        <h2><? __('Random sentence'); ?></h2>
         <div class="random_sentences_set">
-            <md-progress-circular md-mode="indeterminate" class="block-loader" id="random-progress" style="display: none;"></md-progress-circular>
             <div id="random_sentence_display">
                 <?php
                 $sentence = $random['Sentence'];
-                $transcrs = $random['Transcription'];
                 $translations = $random['Translation'];
                 $sentenceOwner = $random['User'];
 
-                $sentences->displaySentencesGroup(
-                    $sentence,
-                    $transcrs,
-                    $translations,
-                    $sentenceOwner
+                echo $this->element(
+                    'sentences/sentence_and_translations',
+                    array(
+                        'sentence' => $sentence,
+                        'translations' => $translations,
+                        'user' => $sentenceOwner
+                    )
                 );
                 ?>
             </div>

--- a/app/views/sentences/search.ctp
+++ b/app/views/sentences/search.ctp
@@ -80,7 +80,7 @@ if ($ignored) {
 </div>
 
 <div id="main_content">
-<div class="module">
+<div class="section">
 <?php
 if ($search_disabled) {
 ?>
@@ -135,17 +135,33 @@ if ($search_disabled) {
 
     $pagination->display();
 
-    foreach ($results as $sentence) {
-        $translations = isset($sentence['Translation']) ?
-                        $sentence['Translation'] :
-                        array();
-        $sentences->displaySentencesGroup(
-            $sentence['Sentence'],
-            $sentence['Transcription'],
-            $translations,
-            $sentence['User'],
-            array('langFilter' => $to)
-        );
+    if (CurrentUser::isMember()) {
+        foreach ($results as $sentence) {
+            $translations = isset($sentence['Translation']) ?
+                $sentence['Translation'] :
+                array();
+            $sentences->displaySentencesGroup(
+                $sentence['Sentence'],
+                $sentence['Transcription'],
+                $translations,
+                $sentence['User'],
+                array('langFilter' => $to)
+            );
+        }
+    } else {
+        foreach ($results as $sentence) {
+            $translations = isset($sentence['Translation']) ?
+                $sentence['Translation'] :
+                array();
+            echo $this->element(
+                'sentences/sentence_and_translations',
+                array(
+                    'sentence' => $sentence['Sentence'],
+                    'translations' => $translations,
+                    'user' => $sentence['User']
+                )
+            );
+        }
     }
 
     $pagination->display();

--- a/app/views/sentences/search.ctp
+++ b/app/views/sentences/search.ctp
@@ -135,20 +135,7 @@ if ($search_disabled) {
 
     $pagination->display();
 
-    if (CurrentUser::isMember()) {
-        foreach ($results as $sentence) {
-            $translations = isset($sentence['Translation']) ?
-                $sentence['Translation'] :
-                array();
-            $sentences->displaySentencesGroup(
-                $sentence['Sentence'],
-                $sentence['Transcription'],
-                $translations,
-                $sentence['User'],
-                array('langFilter' => $to)
-            );
-        }
-    } else {
+    if (!CurrentUser::isMember() || CurrentUser::getSetting('use_new_design')) {
         foreach ($results as $sentence) {
             $translations = isset($sentence['Translation']) ?
                 $sentence['Translation'] :
@@ -160,6 +147,19 @@ if ($search_disabled) {
                     'translations' => $translations,
                     'user' => $sentence['User']
                 )
+            );
+        }
+    } else {
+        foreach ($results as $sentence) {
+            $translations = isset($sentence['Translation']) ?
+                $sentence['Translation'] :
+                array();
+            $sentences->displaySentencesGroup(
+                $sentence['Sentence'],
+                $sentence['Transcription'],
+                $translations,
+                $sentence['User'],
+                array('langFilter' => $to)
             );
         }
     }

--- a/app/views/sentences/show_all_in.ctp
+++ b/app/views/sentences/show_all_in.ctp
@@ -82,20 +82,7 @@ $this->set('title_for_layout', $pages->formatTitle($title));
         );
         $pagination->display($paginationUrl);
 
-        if (CurrentUser::isMember()) {
-            foreach ($results as $sentence) {
-                $translations = isset($sentence['Translation']) ?
-                    $sentence['Translation'] :
-                    array();
-                $sentences->displaySentencesGroup(
-                    $sentence['Sentence'],
-                    $sentence['Transcription'],
-                    $translations,
-                    $sentence['User'],
-                    array('langFilter' => $translationLang)
-                );
-            }
-        } else {
+        if (!CurrentUser::isMember() || CurrentUser::getSetting('use_new_design')) {
             foreach ($results as $sentence) {
                 $translations = isset($sentence['Translation']) ?
                     $sentence['Translation'] :
@@ -107,6 +94,19 @@ $this->set('title_for_layout', $pages->formatTitle($title));
                         'translations' => $translations,
                         'user' => $sentence['User']
                     )
+                );
+            }
+        } else {
+            foreach ($results as $sentence) {
+                $translations = isset($sentence['Translation']) ?
+                    $sentence['Translation'] :
+                    array();
+                $sentences->displaySentencesGroup(
+                    $sentence['Sentence'],
+                    $sentence['Transcription'],
+                    $translations,
+                    $sentence['User'],
+                    array('langFilter' => $translationLang)
                 );
             }
         }

--- a/app/views/sentences/show_all_in.ctp
+++ b/app/views/sentences/show_all_in.ctp
@@ -68,7 +68,7 @@ $this->set('title_for_layout', $pages->formatTitle($title));
 
 </div> 
 <div id="main_content">
-    <div class="module">
+    <div class="section">
     <?php
     if (!empty($results)) {
 
@@ -82,18 +82,35 @@ $this->set('title_for_layout', $pages->formatTitle($title));
         );
         $pagination->display($paginationUrl);
 
-        foreach ($results as $sentence) {
-            $translations = isset($sentence['Translation']) ?
-                            $sentence['Translation'] :
-                            array();
-            $sentences->displaySentencesGroup(
-                $sentence['Sentence'], 
-                $sentence['Transcription'],
-                $translations,
-                $sentence['User'],
-                array('langFilter' => $translationLang)
-            );
+        if (CurrentUser::isMember()) {
+            foreach ($results as $sentence) {
+                $translations = isset($sentence['Translation']) ?
+                    $sentence['Translation'] :
+                    array();
+                $sentences->displaySentencesGroup(
+                    $sentence['Sentence'],
+                    $sentence['Transcription'],
+                    $translations,
+                    $sentence['User'],
+                    array('langFilter' => $translationLang)
+                );
+            }
+        } else {
+            foreach ($results as $sentence) {
+                $translations = isset($sentence['Translation']) ?
+                    $sentence['Translation'] :
+                    array();
+                echo $this->element(
+                    'sentences/sentence_and_translations',
+                    array(
+                        'sentence' => $sentence['Sentence'],
+                        'translations' => $translations,
+                        'user' => $sentence['User']
+                    )
+                );
+            }
         }
+
         
         $pagination->display($paginationUrl);
     } 

--- a/app/views/sentences_lists/show.ctp
+++ b/app/views/sentences_lists/show.ctp
@@ -107,7 +107,7 @@ $this->set('title_for_layout', $pages->formatTitle($listName));
 </div>
 
 <div id="main_content">
-    <div class="module">
+    <div class="section">
     <?php
     $class = '';
     if ($belongsToUser) {
@@ -158,8 +158,24 @@ $this->set('title_for_layout', $pages->formatTitle($listName));
     <div class="sentencesList" id="sentencesList"
          data-list-id="<?php echo $listId; ?>">
     <?php
-    foreach ($sentencesInList as $sentence) {
-        $lists->displaySentence($sentence['Sentence'], $canRemoveSentence);
+    if (CurrentUser::isMember()) {
+        foreach ($sentencesInList as $sentence) {
+            $lists->displaySentence($sentence['Sentence'], $canRemoveSentence);
+        }
+    } else {
+        foreach ($sentencesInList as $sentence) {
+            $translations = isset($sentence['Sentence']['Translation']) ?
+                $sentence['Sentence']['Translation'] :
+                array();
+            echo $this->element(
+                'sentences/sentence_and_translations',
+                array(
+                    'sentence' => $sentence['Sentence'],
+                    'translations' => $translations,
+                    'user' => $sentence['Sentence']['User']
+                )
+            );
+        }
     }
     ?>
     </div>

--- a/app/views/sentences_lists/show.ctp
+++ b/app/views/sentences_lists/show.ctp
@@ -158,11 +158,7 @@ $this->set('title_for_layout', $pages->formatTitle($listName));
     <div class="sentencesList" id="sentencesList"
          data-list-id="<?php echo $listId; ?>">
     <?php
-    if (CurrentUser::isMember()) {
-        foreach ($sentencesInList as $sentence) {
-            $lists->displaySentence($sentence['Sentence'], $canRemoveSentence);
-        }
-    } else {
+    if (!CurrentUser::isMember() || CurrentUser::getSetting('use_new_design')) {
         foreach ($sentencesInList as $sentence) {
             $translations = isset($sentence['Sentence']['Translation']) ?
                 $sentence['Sentence']['Translation'] :
@@ -175,6 +171,10 @@ $this->set('title_for_layout', $pages->formatTitle($listName));
                     'user' => $sentence['Sentence']['User']
                 )
             );
+        }
+    } else {
+        foreach ($sentencesInList as $sentence) {
+            $lists->displaySentence($sentence['Sentence'], $canRemoveSentence);
         }
     }
     ?>

--- a/app/views/tags/show_sentences_with_tag.ctp
+++ b/app/views/tags/show_sentences_with_tag.ctp
@@ -46,7 +46,7 @@ if ($tagExists) {
     </div>
 
     <div id="main_content">
-        <div class="module">
+        <div class="section">
             <h2><?php 
             $n = $paginator->counter(array('format' => '%count%'));
             echo format(
@@ -68,21 +68,35 @@ if ($tagExists) {
 
             <div class="sentencesList" id="sentencesList">
                 <?php
-                foreach ($allSentences as $i=>$sentence) {
-                    // this should be done in the controller but this way
-                    // we avoid another full loop on the sentence Array
-                    $canUserRemove = CurrentUser::canRemoveTagFromSentence(
-                        $taggerIds[$i]
-                    );
-                    $sentence = $sentence['Sentence'];
-                    $tags->displaySentence(
-                        $sentence,
-                        $sentence['Transcription'],
-                        $sentence['User'],
-                        $sentence['Translation'],
-                        $canUserRemove,
-                        $tagId
-                    );
+                if (CurrentUser::isMember()) {
+                    foreach ($allSentences as $i=>$sentence) {
+                        // this should be done in the controller but this way
+                        // we avoid another full loop on the sentence Array
+                        $canUserRemove = CurrentUser::canRemoveTagFromSentence(
+                            $taggerIds[$i]
+                        );
+                        $sentence = $sentence['Sentence'];
+                        $tags->displaySentence(
+                            $sentence,
+                            $sentence['Transcription'],
+                            $sentence['User'],
+                            $sentence['Translation'],
+                            $canUserRemove,
+                            $tagId
+                        );
+                    }
+                } else {
+                    foreach ($allSentences as $i=>$item) {
+                        $sentence = $item['Sentence'];
+                        echo $this->element(
+                            'sentences/sentence_and_translations',
+                            array(
+                                'sentence' => $sentence,
+                                'translations' => $sentence['Translation'],
+                                'user' => $sentence['User']
+                            )
+                        );
+                    }
                 }
                 ?>
             </div>

--- a/app/views/tags/show_sentences_with_tag.ctp
+++ b/app/views/tags/show_sentences_with_tag.ctp
@@ -68,7 +68,21 @@ if ($tagExists) {
 
             <div class="sentencesList" id="sentencesList">
                 <?php
-                if (CurrentUser::isMember()) {
+                $useNewDesign = !CurrentUser::isMember()
+                    || CurrentUser::getSetting('use_new_design');
+                if ($useNewDesign) {
+                    foreach ($allSentences as $i=>$item) {
+                        $sentence = $item['Sentence'];
+                        echo $this->element(
+                            'sentences/sentence_and_translations',
+                            array(
+                                'sentence' => $sentence,
+                                'translations' => $sentence['Translation'],
+                                'user' => $sentence['User']
+                            )
+                        );
+                    }
+                } else {
                     foreach ($allSentences as $i=>$sentence) {
                         // this should be done in the controller but this way
                         // we avoid another full loop on the sentence Array
@@ -83,18 +97,6 @@ if ($tagExists) {
                             $sentence['Translation'],
                             $canUserRemove,
                             $tagId
-                        );
-                    }
-                } else {
-                    foreach ($allSentences as $i=>$item) {
-                        $sentence = $item['Sentence'];
-                        echo $this->element(
-                            'sentences/sentence_and_translations',
-                            array(
-                                'sentence' => $sentence,
-                                'translations' => $sentence['Translation'],
-                                'user' => $sentence['User']
-                            )
                         );
                     }
                 }

--- a/app/views/user/settings.ctp
+++ b/app/views/user/settings.ctp
@@ -280,6 +280,29 @@ $this->set('title_for_layout', $pages->formatTitle(__('Settings', true)));
                     );
                 ?>
             </md-list-item>
+            <md-list-item>
+                <?php $useNewDesign = $this->data['User']['settings']['use_new_design']; ?>
+                <md-checkbox
+                    ng-false-value="0"
+                    ng-true-value="1"
+                    ng-model="useNewDesign"
+                    ng-init="useNewDesign = <?= $useNewDesign ?>"
+                    class="md-primary">
+                </md-checkbox>
+                <p><?php __(
+                    'Display sentences with the new design. '.
+                    'Note that you will not have all the features '.
+                    'from the old design.'
+                ) ?></p>
+                <?php
+                echo $form->hidden(
+                    'settings.use_new_design',
+                    array(
+                        'value' => '{{useNewDesign}}'
+                    )
+                );
+                ?>
+            </md-list-item>
         </md-list>
 
         <div layout="row" layout-align="center center">

--- a/app/webroot/css/activities/translate_sentences_of.css
+++ b/app/webroot/css/activities/translate_sentences_of.css
@@ -20,6 +20,7 @@
 /*
  * List of sentences
  */
+.sentence-and-translations,
 .sentences_set {
-    margin: 60px 0;
+    margin: 40px 0;
 }

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -1084,10 +1084,6 @@ md-icon.disabled.material-icons {
  * Translations
  */
 
-.translations {
-    font-size: 15px;
-}
-
 .indirectTranslation {
     color: #998778;
 }
@@ -1337,6 +1333,51 @@ div.hideLink {
     color: #fff;
     padding: 3px 10px;
 }
+
+
+/*
+ *
+ */
+
+.sentence-and-translations {
+    padding: 10px;
+}
+
+.sentence-and-translations .text,
+.sentence-and-translations .lang {
+    margin: 3px 0;
+    padding: 0 10px;
+}
+
+.sentence-and-translations .sentence {
+    font-size: 24px;
+}
+
+.sentence-and-translations .md-subheader {
+    background: transparent;
+}
+
+.sentence-and-translations .md-subheader ._md-subheader-inner {
+    padding: 10px 5px;
+}
+
+.sentence-and-translations .direct.translations .chevron {
+    color: #000000;
+}
+
+.sentence-and-translations .indirect.translations .chevron {
+    color: #bdbdbd;
+}
+
+.sentence-and-translations .sentence:hover,
+.sentence-and-translations .translation:hover {
+    background-color: #f5f5f5;
+}
+
+.sentence-and-translations .lang img {
+    display: block;
+}
+
 
 /*
  * --------------------------------------------------------------------

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -1378,6 +1378,10 @@ div.hideLink {
     display: block;
 }
 
+.sentence-and-translations .not-reliable .text {
+    color: #D32F2F;
+}
+
 
 /*
  * --------------------------------------------------------------------

--- a/app/webroot/css/layouts/elements.css
+++ b/app/webroot/css/layouts/elements.css
@@ -760,6 +760,7 @@ md-icon.disabled.material-icons {
     height: 16px;
     margin: 2px;
     font-weight: bold;
+    font-size: 14px;
 }
 
 .sentences_set .menu .is-native {
@@ -824,7 +825,6 @@ md-icon.disabled.material-icons {
 /*
  * Sentence
  */
-
 .addTranslations .navigationIcon,
 .sentence .navigationIcon {
     width: 25px;

--- a/app/webroot/css/sentences/search.css
+++ b/app/webroot/css/sentences/search.css
@@ -20,6 +20,7 @@
 /*
  * Search results
  */
+.sentence-and-translations,
 .sentences_set {
     margin: 40px 0;
 }

--- a/app/webroot/css/sentences/show_all_in.css
+++ b/app/webroot/css/sentences/show_all_in.css
@@ -20,6 +20,7 @@
 /*
  * List of sentences
  */
+.sentence-and-translations,
 .sentences_set {
     margin: 60px 0;
 }

--- a/app/webroot/css/sentences_lists/show.css
+++ b/app/webroot/css/sentences_lists/show.css
@@ -48,6 +48,7 @@
 /*
  * List
  */
+.sentence-and-translations,
 .sentenceInList {
     margin: 40px 0;
 }

--- a/app/webroot/css/tags/show_sentences_with_tag.css
+++ b/app/webroot/css/tags/show_sentences_with_tag.css
@@ -21,6 +21,7 @@
 /*
  * List
  */
+.sentence-and-translations,
 .sentenceInList {
     margin: 40px 0;
 }

--- a/app/webroot/js/directives/sentence-and-translations.dir.js
+++ b/app/webroot/js/directives/sentence-and-translations.dir.js
@@ -1,0 +1,57 @@
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+(function() {
+    'use strict';
+
+    angular
+        .module('app')
+        .directive(
+            'sentenceAndTranslations',
+            sentenceAndTranslations
+        );
+
+    function sentenceAndTranslations() {
+        return {
+            scope: true,
+            controller: SentenceAndTranslationsController,
+            controllerAs: 'vm'
+        };
+    }
+
+    function SentenceAndTranslationsController() {
+        var vm = this;
+
+        vm.isExpanded = false;
+        vm.expandableIcon = 'expand_more';
+
+        vm.expandOrCollapse = expandOrCollapse;
+
+        /////////////////////////////////////////////////////////////////////////
+
+        function expandOrCollapse() {
+            vm.isExpanded = !vm.isExpanded;
+
+            if (vm.isExpanded) {
+                vm.expandableIcon = 'expand_less';
+            } else {
+                vm.expandableIcon = 'expand_more';
+            }
+        }
+    }
+
+})();


### PR DESCRIPTION
This pull request is part of #1180. It also addresses #1324.

The sentences have been redesigned for non-authenticated users.

* The icons to translate, add to favorite, add to list have been removed. For non-authenticated users, they just redirect to a page to log in. Although they do give a hint to users what are the features of Tatoeba, I think they mostly pollute the UI which is why they were removed.
* There are now a explicit labels for the sentence (`Sentence {number} - belongs to {user}`), the translations (`Translations`) and the indirect translations (`Translations of translations`). Hopefully users will understand better why some translations are in grey.
* Users no longer navigate to the sentence by clicking on the `#` or arrow icons, but on the info icon that is at the end of each sentence/translation.
* An arrow icon has been added in front of each translation in order to help distinguish between direct and indirect translations when there are a lot of translations. Direct translations have a black arrow. Indirect translations have a grey arrow.
* The text of the indirect translations are kept in black for better readability. There is now a label that says explicitly "Translations of translations", so there is less need to have it grey.
* Unapproved sentences are displayed the same as before (grey + warning icon), with a tooltip that says `This sentence is not reliable.` when hovering over the sentence. I'm not very satisfied with this tooltip text, but I'd like to find something else than "unapproved".
* The language icon is kept on the left side. We cannot have it on the right side because the language icon is a pillar in the structure of the sentences. It helps users find more easily the translations in the lanugages they are more specifically interested. And for sentences that have several translations in a same language, it helps users identify more quickly which blocks of translations are in which language.
* The sentence in the comments will be re-adapted later on to be consistent with the new sentence design. It's not in the scope of this pull request.

Authenticated users still have by default the old design, but can activate the new one from their settings if they wish to try to it out. Some pages will still keep the old design no matter what the setting is:

* The random sentence on the homepage for authenticated users, because the feature to load another random sentence doesn't work yet with the new design. Non-authenticated users have the new design of the random sentence, but do not have the reload option.
* The sentence details page, because the new sentence design does not have the sentence menu (translate, edit, etc), and users should still have access to a page where they can access every sentence feature without switching back and forth between old and new design. Also, the audio icon was not re-added (yet?) in the new design, so the sentence details would allow to listen to the audio of a specific sentence.

The new design is notably faster to render than the old one. For instance someone who has their settings set to 100 sentences per page will have some noticeable lag while searching sentences (the page will stay grey for a few seconds, or even freeze). The new design doesn't have this lag. So for users who mostly browse Tatoeba and use the sentence menu only punctually, it can be more advantageous to switch to the new design.

The features of the sentence menu will be introduced into the new design progressively. This will probably take until end of December. Once every feature has been implemented in the new design, the old design will be removed for everyone.