### PR TITLE
Search by list

### DIFF
--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -777,10 +777,21 @@ class SentencesController extends AppController
         }
 
         // filter by list
+        $searchableLists = $this->SentencesList->getSearchableLists();
         if (!empty($list)) {
             $isSearchable = $this->SentencesList->isSearchableList($list);
             if ($isSearchable) {
                 $sphinx['filter'][] = array('lists_id', $list);
+                $found = false;
+                foreach ($searchableLists as $rec) {
+                    if ($list == $rec['SentencesList']['id']) {
+                        $found = true;
+                        break;
+                    }
+                }
+                if (!$found) {
+                    $searchableLists[] = $isSearchable;
+                }
             } else {
                 $ignored[] = format(
                     /* @translators: This string will be preceded by
@@ -877,7 +888,7 @@ class SentencesController extends AppController
         $vocabulary = $this->Vocabulary->findByText($strippedQuery);
 
         $this->set('vocabulary', $vocabulary);
-        $this->set('searchableLists', $this->SentencesList->getSearchableLists());
+        $this->set('searchableLists', $searchableLists);
         $this->set(compact(array_keys($this->defaultSearchCriteria)));
         $this->set(compact('real_total', 'search_disabled', 'ignored', 'results'));
         $this->set(

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -797,8 +797,8 @@ class SentencesController extends AppController
                     /* @translators: This string will be preceded by
                        “Warning: the following criteria have been
                        ignored:” */
-                    __("“belongs to list number {listId}”, because this list does ".
-                       "not exist or cannot be searched", true),
+                    __("“belongs to list number {listId}”, because list ".
+                       "{listId} is private or does not exist", true),
                     array('listId' => $list)
                 );
                 $list = '';

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -776,6 +776,24 @@ class SentencesController extends AppController
             $tags = implode(',', $tagsArray);
         }
 
+        // filter by list
+        if (!empty($list)) {
+            $isSearchable = $this->SentencesList->isSearchableList($list);
+            if ($isSearchable) {
+                $sphinx['filter'][] = array('lists_id', $list);
+            } else {
+                $ignored[] = format(
+                    /* @translators: This string will be preceded by
+                       “Warning: the following criteria have been
+                       ignored:” */
+                    __("“belongs to list number {listId}”, because this list does ".
+                       "not exist or cannot be searched", true),
+                    array('listId' => $list)
+                );
+                $list = '';
+            }
+        }
+
         // filter orphans
         if (!empty($orphans) && empty($user)) {
             $exclude_orphans = $orphans == 'no';

--- a/app/controllers/sentences_controller.php
+++ b/app/controllers/sentences_controller.php
@@ -49,6 +49,7 @@ class SentencesController extends AppController
     public $helpers = array(
         'Sentences',
         'Menu',
+        'Lists',
         'SentenceButtons',
         'Html',
         'Logs',
@@ -68,6 +69,7 @@ class SentencesController extends AppController
         'Sentence',
         'SentenceNotTranslatedInto',
         'SentencesSentencesLists',
+        'SentencesList',
         'User',
         'UsersLanguages',
         'Tag',
@@ -80,6 +82,7 @@ class SentencesController extends AppController
         'from' => 'und',
         'to' => 'und',
         'tags' => '',
+        'list' => '',
         'user' => '',
         'orphans' => 'no',
         'unapproved' => 'no',
@@ -856,6 +859,7 @@ class SentencesController extends AppController
         $vocabulary = $this->Vocabulary->findByText($strippedQuery);
 
         $this->set('vocabulary', $vocabulary);
+        $this->set('searchableLists', $this->SentencesList->getSearchableLists());
         $this->set(compact(array_keys($this->defaultSearchCriteria)));
         $this->set(compact('real_total', 'search_disabled', 'ignored', 'results'));
         $this->set(
@@ -865,6 +869,7 @@ class SentencesController extends AppController
     }
 
     public function advanced_search() {
+        $this->set('searchableLists', $this->SentencesList->getSearchableLists());
         $this->set($this->defaultSearchCriteria);
     }
 

--- a/app/models/sentences_list.php
+++ b/app/models/sentences_list.php
@@ -73,37 +73,44 @@ class SentencesList extends AppModel
     }
 
     /**
-     * Returns all the sentences lists that can be searched.
+     * Returns all the sentences lists that are displayed as searchable
+     * for the current user. Note that we don't display unlisted lists
+     * while they can actually be searched, for example if the owner of
+     * an unlisted list gives the search link to another user.
      *
      * @return array
      */
     public function getSearchableLists()
     {
-        return $this->findSearchableLists('all');
-    }
-
-    /**
-     * Check if a given sentence list is searchable.
-     *
-     * @return bool
-     */
-    public function isSearchableList($listId)
-    {
-        return (bool)$this->findSearchableLists('first', array(
-            'id' => $listId,
-        ));
-    }
-
-    private function findSearchableLists($type, $conditions = array())
-    {
-        return $this->find($type, array(
+        return $this->find('all', array(
             'conditions' => array(
-                $conditions + array(
-                    'NOT' => array('visibility' => 'private'),
+                'OR' => array(
+                    'user_id' => CurrentUser::get('id'),
+                    'visibility' => 'public',
                 )
             ),
             'fields' => array('id', 'name', 'user_id'),
             'order' => 'name',
+        ));
+    }
+
+    /**
+     * Check if the user is permitted to use the given list
+     * as search criterion.
+     *
+     * @return bool False if the list cannot be searched, the list otherwise.
+     */
+    public function isSearchableList($listId)
+    {
+        return $this->find('first', array(
+            'conditions' => array(
+                'id' => $listId,
+                'OR' => array(
+                    'user_id' => CurrentUser::get('id'),
+                    'NOT' => array('visibility' => 'private')
+                )
+            ),
+            'fields' => array('id', 'user_id', 'name'),
         ));
     }
 

--- a/app/models/sentences_list.php
+++ b/app/models/sentences_list.php
@@ -72,6 +72,21 @@ class SentencesList extends AppModel
         );
     }
 
+    /**
+     * Returns all the sentences lists that can be searched.
+     *
+     * @return array
+     */
+    public function getSearchableLists()
+    {
+        return $this->find('all', array(
+            'conditions' => array(
+                'NOT' => array('visibility' => 'private'),
+            ),
+            'fields' => array('id', 'name', 'user_id'),
+            'order' => 'name',
+        ));
+    }
 
     /**
      * Returns the sentences lists that the given user can add sentences to.

--- a/app/models/sentences_list.php
+++ b/app/models/sentences_list.php
@@ -79,9 +79,28 @@ class SentencesList extends AppModel
      */
     public function getSearchableLists()
     {
-        return $this->find('all', array(
+        return $this->findSearchableLists('all');
+    }
+
+    /**
+     * Check if a given sentence list is searchable.
+     *
+     * @return bool
+     */
+    public function isSearchableList($listId)
+    {
+        return (bool)$this->findSearchableLists('first', array(
+            'id' => $listId,
+        ));
+    }
+
+    private function findSearchableLists($type, $conditions = array())
+    {
+        return $this->find($type, array(
             'conditions' => array(
-                'NOT' => array('visibility' => 'private'),
+                $conditions + array(
+                    'NOT' => array('visibility' => 'private'),
+                )
             ),
             'fields' => array('id', 'name', 'user_id'),
             'order' => 'name',

--- a/app/models/sentences_sentences_lists.php
+++ b/app/models/sentences_sentences_lists.php
@@ -98,7 +98,7 @@ class SentencesSentencesLists extends AppModel
          * As there is no need to join the relations during the deletion, we
          * may skip them as well. Furthermore, this will be faster. 
          */
-        $this->belongsTo = null;
+        $this->belongsTo = array();
         $isDeleted = $this->deleteAll($conditions, false, true);
         $this->belongsTo = $tmp;
 

--- a/app/tests/cases/models/sentences_sentences_lists.test.php
+++ b/app/tests/cases/models/sentences_sentences_lists.test.php
@@ -1,0 +1,53 @@
+<?php
+/* SentencesSentencesLists Test cases generated on: 2016-12-03 08:56:44 : 1480755404*/
+App::import('Model', 'SentencesSentencesLists');
+
+class SentencesSentencesListsTestCase extends CakeTestCase {
+    var $fixtures = array(
+        'app.sentences_sentences_lists',
+        'app.sentence',
+        'app.language',
+        'app.user',
+        'app.group',
+        'app.wall',
+        'app.wall_thread',
+        'app.sentence_comments',
+        'app.contributions',
+        'app.sentences_lists',
+        'app.favorites_user',
+        'app.translation',
+        'app.transcription',
+        'app.contribution',
+        'app.sentence_comment',
+        'app.sentence_annotation',
+        'app.reindex_flag',
+        'app.link',
+        'app.sentences_translation',
+        'app.tag',
+        'app.tag_sentences',
+        'app.tags_sentence',
+        'app.sentences_list',
+        'app.sentences_sentences_list'
+    );
+
+    function startTest() {
+        $this->SentencesSentencesLists =& ClassRegistry::init('SentencesSentencesLists');
+    }
+
+    function endTest() {
+        unset($this->SentencesSentencesLists);
+        ClassRegistry::flush();
+    }
+
+    function testSphinxAttributesChanged() {
+        $expectedValues = array(8 => array(array(1)));
+        $this->SentencesSentencesLists->data['SentencesSentencesLists'] = array(
+            'sentence_id' => '8',
+            'sentences_list_id' => 2,
+        );
+        $this->SentencesSentencesLists->sphinxAttributesChanged($attrs, $values, $isMVA);
+        $this->assertTrue($isMVA);
+        $this->assertEqual(array('lists_id'), $attrs);
+        $this->assertEqual($expectedValues, $values);
+    }
+}

--- a/app/vendors/shells/sphinx_conf.php
+++ b/app/vendors/shells/sphinx_conf.php
@@ -451,6 +451,7 @@ EOT;
             select \
                 r.id, r.text, r.created, r.modified, r.user_id, r.ucorrectness, r.has_audio, \
                 GROUP_CONCAT(distinct tags.tag_id) as tags_id, \
+                GROUP_CONCAT(distinct lists.sentences_list_id) as lists_id, \
                 CONCAT('[', COALESCE(GROUP_CONCAT(distinct r.trans),''), ']') as trans \
             from ( \
                 select \
@@ -490,6 +491,8 @@ EOT;
             ) r \
             left join \
                 tags_sentences tags on tags.sentence_id = r.id \
+            left join \
+                sentences_sentences_lists lists on lists.sentence_id = r.id \
             group by id
 
         sql_attr_timestamp = created
@@ -504,6 +507,7 @@ EOT;
         sql_attr_uint = ucorrectness
         sql_attr_bool = has_audio
         sql_attr_multi = uint tags_id from field; SELECT id FROM tags ;
+        sql_attr_multi = uint lists_id from field; SELECT id FROM sentences_lists ;
         sql_attr_json = trans
     }
 ";

--- a/app/views/elements/advanced_search_form.ctp
+++ b/app/views/elements/advanced_search_form.ctp
@@ -112,6 +112,13 @@ echo $this->Form->create(
         'after' => $tagsNote,
     ));
 
+    $listOptions = $this->Lists->listsAsSelectable($searchableLists);
+    echo $this->Form->input('list', array(
+        'label' => __('Belongs to list:', true),
+        'value' => $list,
+        'options' => $listOptions,
+    ));
+
     echo $this->Form->input('has_audio', array(
         'label' => __('Has audio:', true),
         'options' => array(

--- a/app/views/helpers/languages.php
+++ b/app/views/helpers/languages.php
@@ -487,7 +487,7 @@ class LanguagesHelper extends AppHelper
     {
         if (!isset($__languagesLevels)) {
             $__languagesLevels = array(
-                -1 => __('Unspecified', true),
+                -1 => __p('level', 'Unspecified', true),
                 0 => __('0: Almost no knowledge', true),
                 1 => __('1: Beginner', true),
                 2 => __('2: Intermediate', true),

--- a/app/views/helpers/lists.php
+++ b/app/views/helpers/lists.php
@@ -679,7 +679,7 @@ class ListsHelper extends AppHelper
                 $sortedLists[$where][$listId] = $listName;
             }
 
-            $listsOfCurrentUser = __('Your lists', true);
+            $listsOfCurrentUser = __('My lists', true);
             $othersLists        = __('Other lists', true);
             return array(
                 '' => $unspecified,

--- a/app/views/helpers/lists.php
+++ b/app/views/helpers/lists.php
@@ -668,7 +668,7 @@ class ListsHelper extends AppHelper
      */
     public function listsAsSelectable($lists)
     {
-        $unspecified = __('Unspecified', true);
+        $unspecified = __p('list', 'Unspecified', true);
         if (CurrentUser::isMember()) {
             $sortedLists = array(0 => array(), 1 => array());
             $currentUserId = CurrentUser::get('id');

--- a/app/views/helpers/lists.php
+++ b/app/views/helpers/lists.php
@@ -662,5 +662,31 @@ class ListsHelper extends AppHelper
         </div>
         <?php
     }
+
+    /**
+     * Returns the selectable lists for the current user
+     */
+    public function listsAsSelectable($lists)
+    {
+        if (CurrentUser::isMember()) {
+            $sortedLists = array(0 => array(), 1 => array());
+            $currentUserId = CurrentUser::get('id');
+            foreach ($lists as $list) {
+                $where = (int)($list['SentencesList']['user_id'] != $currentUserId);
+                $listId   = $list['SentencesList']['id'];
+                $listName = $list['SentencesList']['name'];
+                $sortedLists[$where][$listId] = $listName;
+            }
+
+            $listsOfCurrentUser = __('Your lists', true);
+            $othersLists        = __('Other lists', true);
+            $unspecified = __('Unspecified', true);
+            return array(
+                '' => $unspecified,
+                $listsOfCurrentUser => $sortedLists[0],
+                $othersLists        => $sortedLists[1],
+            );
+        }
+    }
 }
 ?>

--- a/app/views/helpers/lists.php
+++ b/app/views/helpers/lists.php
@@ -668,6 +668,7 @@ class ListsHelper extends AppHelper
      */
     public function listsAsSelectable($lists)
     {
+        $unspecified = __('Unspecified', true);
         if (CurrentUser::isMember()) {
             $sortedLists = array(0 => array(), 1 => array());
             $currentUserId = CurrentUser::get('id');
@@ -680,12 +681,18 @@ class ListsHelper extends AppHelper
 
             $listsOfCurrentUser = __('Your lists', true);
             $othersLists        = __('Other lists', true);
-            $unspecified = __('Unspecified', true);
             return array(
                 '' => $unspecified,
                 $listsOfCurrentUser => $sortedLists[0],
                 $othersLists        => $sortedLists[1],
             );
+        } else {
+            $allLists = Set::combine(
+                $lists,
+                '{n}.SentencesList.id',
+                '{n}.SentencesList.name'
+            );
+            return array('' => $unspecified) + $allLists;
         }
     }
 }

--- a/app/views/sentences/advanced_search.ctp
+++ b/app/views/sentences/advanced_search.ctp
@@ -24,7 +24,9 @@ $this->set('title_for_layout', $pages->formatTitle($title));
 <div id="main_content">
     <div class="module advanced-search">
     <h2><?php echo $title; ?></h2>
-    <?php echo $this->element('advanced_search_form'); ?>
+    <?php echo $this->element('advanced_search_form', array(
+              'searchableLists' => $searchableLists,
+          )); ?>
     <div style="clear:both"></div>
     </div>
 </div>

--- a/app/views/sentences/search.ctp
+++ b/app/views/sentences/search.ctp
@@ -75,7 +75,9 @@ if ($ignored) {
 <div id="annexe_content">
     <div class="module advanced-search">
     <h2><?php echo __('More search criteria'); ?></h2>
-    <?php echo $this->element('advanced_search_form'); ?>
+    <?php echo $this->element('advanced_search_form', array(
+                   'searchableLists' => $searchableLists,
+          )); ?>
     </div>
 </div>
 

--- a/app/webroot/css/sentences/search.css
+++ b/app/webroot/css/sentences/search.css
@@ -106,6 +106,7 @@ legend {
 #AdvancedSearchFrom,
 #AdvancedSearchTo,
 #AdvancedSearchTransTo,
+#AdvancedSearchList,
 #AdvancedSearchSort,
 #AdvancedSearchSearchForm input[type="text"] {
     width: 140px;


### PR DESCRIPTION
This aims to solve #767 with a single dropdown (only one list at a time can be specified as search criterion).
* For guests, the dropdown only shows lists marked as public. For logged-in users, it shows public lists and lists owned by the member separately (similarly to the *Add to list* sentence button).
* Unlisted lists can be used as search criterion by anyone by forging the correct URL (using the `list=<id>` GET parameter) or using a URL provided by the owner of the list. Unlisted lists are hidden from the dropdown unless you’re the owner (in which case they will appear under the 'My lists' category) or you’re currently searching on that list (in which case it appears at the very bottom of the dropdown).
* Private lists can only be searched by their owner and are only displayed to them (under the 'My lists' category). Attempting to forge the URL of a private list that you don’t own will result into the same error message as when the list is not found.
* Whenever a list is modified, Sphinx search results are instantly updated accordingly, without needing to wait for reindexation (just like tags).

Deployment instructions:
* Make sure the Sphinx daily merge will not start in the middle of the update (it starts at 5:25 GMT+0).
* Regenerate Sphinx config using the new code but don’t update the code running on production yet
* Update Sphinx main indexes with `cake sphinx_indexes update main`
* Update Sphinx delta indexes with `cake sphinx_indexes update delta`
* Restart Sphinx daemon
* Update the code running on production with `git pull`