### PR TITLE
Searchable transcriptions

### DIFF
--- a/app/vendors/shells/sphinx_conf.php
+++ b/app/vendors/shells/sphinx_conf.php
@@ -509,6 +509,10 @@ EOT;
         sql_attr_multi = uint tags_id from field; SELECT id FROM tags ;
         sql_attr_multi = uint lists_id from field; SELECT id FROM sentences_lists ;
         sql_attr_json = trans
+
+        sql_joined_field = \
+            transcription from query; \
+            select sentence_id, text from transcriptions order by sentence_id asc
     }
 ";
                 // generate index for this pair

--- a/app/vendors/shells/sphinx_conf.php
+++ b/app/vendors/shells/sphinx_conf.php
@@ -358,7 +358,13 @@ class SphinxConfShell extends Shell {
                 ; }
             )
         ))."\n";
-        
+
+        /* Remove the kanji part in Japanese readings. Note that this regexp
+           will also affect Japanese sentences, but hopefully it will have
+           no effect because they don’t use this [kanji|reading] syntax. */
+        $this->indexExtraOptions['jpn'] =
+            "
+        regexp_filter = \[[^|]*\| =>";
     }
 
     // In the following, the characters U+5B0..U+5C5, U+5C7 within

--- a/app/views/helpers/search.php
+++ b/app/views/helpers/search.php
@@ -56,5 +56,20 @@ class SearchHelper extends AppHelper
             $options
         );
     }
+
+    public function highlightMatches($highlight, $text) {
+        list($markers, $excerpts) = $highlight;
+        foreach ($excerpts as $excerpt) {
+            $excerpt = h($excerpt);
+            $from = str_replace($markers, '', $excerpt);
+            $to = str_replace(
+                $markers,
+                array('<span class="match">', '</span>'),
+                $excerpt
+            );
+            $text = str_replace($from, $to, $text);
+        }
+        return $text;
+    }
 }
 ?>

--- a/app/views/helpers/sentences.php
+++ b/app/views/helpers/sentences.php
@@ -59,6 +59,7 @@ class SentencesHelper extends AppHelper
         'Menu',
         'Images',
         'Transcriptions',
+        'Search',
     );
 
 
@@ -682,21 +683,6 @@ class SentencesHelper extends AppHelper
         echo $this->Html->tag('/div');
     }
 
-    private function highlightMatches($highlight, $text) {
-        list($markers, $excerpts) = $highlight;
-        foreach ($excerpts as $excerpt) {
-            $excerpt = h($excerpt);
-            $from = str_replace($markers, '', $excerpt);
-            $to = str_replace(
-                $markers,
-                array('<span class="match">', '</span>'),
-                $excerpt
-            );
-            $text = str_replace($from, $to, $text);
-        }
-        return $text;
-    }
-
     /**
      * Displays the text of a sentence. This text can be editable or not.
      *
@@ -723,7 +709,7 @@ class SentencesHelper extends AppHelper
         if ($highlight) {
             $sentenceText = h($sentenceText);
             $sentenceEscaped = true;
-            $sentenceText = $this->highlightMatches($highlight, $sentenceText);
+            $sentenceText = $this->Search->highlightMatches($highlight, $sentenceText);
         }
 
         if ($isEditable) {

--- a/app/views/helpers/transcriptions.php
+++ b/app/views/helpers/transcriptions.php
@@ -27,6 +27,7 @@ class TranscriptionsHelper extends AppHelper
         'Javascript',
         'Languages',
         'Pinyin',
+        'Search',
     );
 
     /**
@@ -309,6 +310,9 @@ class TranscriptionsHelper extends AppHelper
     public function transcriptionAsHTML($lang, $transcr) {
         $text = Sanitize::html($transcr['text']);
 
+        if (isset($transcr['highlight'])) {
+            $text = $this->Search->highlightMatches($transcr['highlight'], $text);
+        }
         if ($transcr['script'] == 'Hrkt') {
             $ruby = $this->_rubify($transcr['text']);
             $bracketed = $this->_bracketify($text);


### PR DESCRIPTION
This PR allows to find sentences by their transcriptions. More specifically:
* Chinese (Mandarin) sentences can now be found regardless of being written in simplified or traditional script. It’s also possible to search using pinyin, but one needs to use the numbered notation like ni3hao3 for nǐhǎo (你好) because that’s how we store it in the database. Which is rather counterintuitive, but we may improve that in the future. I just don’t know what would be the best for users. We could ignore the tone numbers so that *nihao* would find ni3hao3, but this would lead to being unable to differentiate words that only vary in tones. I’d like to hear @allan-simon’s opinion on that.
* Uzbek sentences can be now found regardless of being written in Latin or Cyrillic.
* Japanese sentences can be now found using kana, but there’s a catch explained in 9d8515720ecabf2ae81da579e75f118529919394. I [reported the bug](http://sphinxsearch.com/bugs/view.php?id=2586) to the Sphinx project.
* Cantonese sentences can now also be found using jyutping but it’s not very useful because of the way we store these: we use number exponents for tones, which are ignored by Sphinx so they act as word separators. For example one need to type *zung ji* in order to find zung¹ji³. I guess we want to use regular numbers instead of exponents, and then we will have the problem as for Mandarin. [Glancing over Cantonese sentences](https://tatoeba.org/jpn/sentences/show_all_in/yue/none/none/indifferent/page:2) shows a high number of one-syllable words, which are likely to “conflict” with many Latin languages. For example if you search *sin* or *go* on “Any language”, a number of Cantonese sentences are going to come up. Which is not new, but the problem here is that since jyutping is hidden by default, it will certainly confuse users.
* Sphinx makes it possible to search only in the sentence or only the transcription by respectively using the `@text` or `@transcription` field specifier (we may change their names).

### Deployment instructions
* Regenerate Sphinx config.
* Regenerate indexes.