### PR TITLE
Move click handlers out of watch to prevent re-adding.

### DIFF
--- a/app/webroot/js/sentences_lists.menu.js
+++ b/app/webroot/js/sentences_lists.menu.js
@@ -18,127 +18,112 @@
 
 
 $(document).ready(function() {
+    // Clicking on "Add to list" displays the list selection.
+    // Reclicking on it hides the list selection.
+    $(".addToList").click(function(){
+        sentenceId = $(this).attr("data-sentence-id");
+        $("#addToList"+sentenceId).toggle();
+    });    
+
+    // The sentence is added to the list after user has clicked
+    // the button. I was hesitating between this solution and
+    // having the sentence added to the list onChange, that is,
+    // directly after the selection in the <select>.
+    $(".validateButton").click(function(){
+        var listId = $("#listSelection"+sentenceId).val();
+        var rootUrl = get_tatoeba_root_url();
+
+        // Add sentence to selected list
+        if(listId > 0){
+            $("#_"+sentenceId+"_in_process").show();
+
+            $.post(
+                rootUrl
+                + "/sentences_lists/add_sentence_to_list/"
+                + sentenceId + "/" + listId
+                , {}
+                ,function(data){
+                    if(!data.match('error')){
+                        $('#listSelection'+sentenceId).val(-1);
+                        $('#listSelection'+sentenceId+' option[value="'+data+'"]').remove();
+                        feedbackValid(sentenceId);
+                    }
+                    $("#_"+sentenceId+"_in_process").hide();
+                },
+                'html'
+            );
+        }
+        // Create a new list and add sentence to this new list
+        else if(listId == -1){
+            var txt = 'Name of the list : <br />'
+            + '<input type="text" id="listName" name="listName" />';
+
+            // callback for the popup
+            function mycallbackform(value, message, form){
+
+                if(value != undefined){ // need to check this, otherwise it loops indefinitely when canceling...
+
+                    $("#_"+sentenceId+"_in_process").show();
+
+                    $.post(
+                        rootUrl
+                        + "/sentences_lists/add_sentence_to_new_list/"
+                        + sentenceId + "/"+ form.listName
+                        , {}
+                        ,function(data){
+                            if(data != 'error'){
+                                $('#listSelection'+sentenceId).append(
+                                    '<option value="'+ data +'">'
+                                    + form.listName
+                                    +'</option>'
+                                );
+                                $('#listSelection'+sentenceId).val(data);
+                                feedbackValid(sentenceId);
+
+                            }else{
+                                $.prompt("Sorry, an error occured.");
+                            }
+                            $("#_"+sentenceId+"_in_process").hide();
+                        },
+                        'html'
+                    );
+                }
+            }
+            // popup to enter name of new list
+            $.prompt(txt,{
+                callback: mycallbackform,
+                buttons: { Ok: 'OK'}
+            });
+        }
+        // redirect to lists
+        else if(listId == -2){
+            $(location).attr(
+                'href',
+                rootUrl
+                + "/sentences_lists/"
+            );
+        }
+    });
+
     $(document).watch("addrule", function() {
         var sentenceId = -1;
-        
+
         /*
          * Display the "check" green icon for a short time
          * after sentence has been added to list.
          */
         function feedbackValid(){
-            $("#sentence"+sentenceId+"_saved_in_list").show(); // TODO Set up a better system for this thing. 
+            $("#sentence"+sentenceId+"_saved_in_list").show(); // TODO Set up a better system for this thing.
             // Because you can't have the "in process" AND the "valid" at the same time.
             // It will be useful for favoriting as well.
             setTimeout(removeFeedback, 500);
         }
-        
+
         /*
          * Remove the "check" green icon.
          */
         function removeFeedback(){
             $("#sentence"+sentenceId+"_saved_in_list").hide();
         }
-
-        
-        // Clicking on "Add to list" displays the list selection.
-        // Reclicking on it hides the list selection.
-        $(".addToList").click(function(){
-            sentenceId = $(this).attr("data-sentence-id");
-            $("#addToList"+sentenceId).toggle();
-        });
-        
-        
-        // The sentence is added to the list after user has clicked
-        // the button. I was hesitating between this solution and
-        // having the sentence added to the list onChange, that is,
-        // directly after the selection in the <select>.
-        $(".validateButton").click(function(){
-            
-            var listId = $("#listSelection"+sentenceId).val();
-            var rootUrl = get_tatoeba_root_url();
-            
-            // Add sentence to selected list
-            if(listId > 0){
-            
-                $("#_"+sentenceId+"_in_process").show();
-                
-                $.post(
-                    rootUrl 
-                    + "/sentences_lists/add_sentence_to_list/"
-                    + sentenceId + "/" + listId
-                    , {}
-                    ,function(data){
-                        if(!data.match('error')){
-                            $('#listSelection'+sentenceId).val(-1);
-                            $('#listSelection'+sentenceId+' option[value="'+data+'"]').remove();
-                            feedbackValid(sentenceId);
-                        }
-                        $("#_"+sentenceId+"_in_process").hide();
-                    },
-                    'html'
-                );
-                
-            }
-            
-            // Create a new list and add sentence to this new list
-            else if(listId == -1){
-                
-                var txt = 'Name of the list : <br />'
-                + '<input type="text" id="listName" name="listName" />';
-                
-                // callback for the popup
-                function mycallbackform(value, message, form){
-                    
-                    if(value != undefined){ // need to check this, otherwise it loops indefinitely when canceling...
-                    
-                        $("#_"+sentenceId+"_in_process").show();
-                        
-                        $.post(
-                            rootUrl 
-                            + "/sentences_lists/add_sentence_to_new_list/"
-                            + sentenceId + "/"+ form.listName
-                            , {}
-                            ,function(data){
-                                if(data != 'error'){
-                                    $('#listSelection'+sentenceId).append(
-                                        '<option value="'+ data +'">'
-                                        + form.listName 
-                                        +'</option>'
-                                    );
-                                    $('#listSelection'+sentenceId).val(data);
-                                    feedbackValid(sentenceId);
-                                    
-                                }else{
-                                    $.prompt("Sorry, an error occured.");
-                                }
-                                $("#_"+sentenceId+"_in_process").hide();
-                            },
-                            'html'
-                        );
-                        
-                    }
-                    
-                }
-                
-                // popup to enter name of new list
-                $.prompt(txt,{
-                    callback: mycallbackform,
-                    buttons: { Ok: 'OK'}
-                });
-                
-            }
-            
-            // redirect to lists
-            else if(listId == -2){
-                
-                $(location).attr(
-                    'href', 
-                    rootUrl 
-                    + "/sentences_lists/"
-                );
-                
-            }
-            
-        });
     });
 });


### PR DESCRIPTION
closes #1284


The issue here is that adding a new translations triggers the "addrule" event and hence causes the event handler to be added on top of the other, ending up doing a double toggle on the "Add to List" element.

There are a lot of other places where similar things can happen. This fixes the original issue, it does however not address all the other click handlers in other JS files where similar problems will surely occur. If desired I can do a manual audit of the Javascript. 

It's best to remember to always unbind / [off](http://api.jquery.com/off/) events before adding them. This might seem verbose but it will prevent these things from happening.