### PR TITLE
Fix POT generation script

### DIFF
--- a/app/View/Audio/import.ctp
+++ b/app/View/Audio/import.ctp
@@ -124,8 +124,8 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__d('admin', 'Import re
     ?>
     </table>
 <?php else: ?>
-    <p><?php echo __('admin', 'No files have been detected '.
-                         'inside the import directory.'); ?></p>
+    <p><?php echo __d('admin', 'No files have been detected '.
+                      'inside the import directory.'); ?></p>
 <?php endif; ?>
 <?php
 echo $this->Form->create();

--- a/app/View/Helper/AudioHelper.php
+++ b/app/View/Helper/AudioHelper.php
@@ -90,7 +90,7 @@ class AudioHelper extends AppHelper
             $username = $this->Html->link($username, $attribUrl);
         }
         if (empty($license) || !isset($this->licenses[$license])) {
-            $license = __d('license', 'unknown');
+            $license = __p('license', 'unknown');
         } elseif (isset($this->licenses[$license]['url'])) {
             $license = $this->licenseLink($license);
         } elseif (isset($this->licenses[$license]['name'])) {

--- a/tools/generate_pot.sh
+++ b/tools/generate_pot.sh
@@ -8,7 +8,10 @@ POT_TMP=$(mktemp --suffix=.po)
 trap "rm -f $POT_TMP; exit" SIGHUP SIGINT SIGTERM
 
 list_source_files() {
-    find app/ -iname '*.ctp' -o -iname '*.php' | LC_ALL=C sort
+    find app/ -path app/Vendor/cakephp -prune \
+        -o -iname '*.ctp' -print \
+        -o -iname '*.php' -print \
+        | LC_ALL=C sort
 }
 
 throw_to_gettext() {


### PR DESCRIPTION
Fixes #1436. For some reason, when `xgettext` is provided with lots of files to scan, it inserts some duplicate translatable strings. Excluding the CakePHP directory from the scanned files fixed the problem.