### PR TITLE
Fix issue 1434

### DIFF
--- a/app/Lib/Autotranscription.php
+++ b/app/Lib/Autotranscription.php
@@ -255,7 +255,7 @@ class Autotranscription
     private function _sino_detectScript($text) {
         $map = array('simplified' => 'Hans', 'traditional' => 'Hant');
         $guessed = $this->_call_sinoparserd('guess_script', $text);
-        return isset($map[$guessed]) ? $map[$guessed] : false;
+        return isset($map[$guessed]) ? $map[$guessed] : null;
     }
 
     private function _call_sinoparserd($action, $text) {
@@ -360,7 +360,7 @@ class Autotranscription
      */
     public function uzb_detectScript($text) {
         if (empty($text)) {
-            return false;
+            return null;
         }
 
         $needles = array(

--- a/app/Model/Behavior/TranscriptableBehavior.php
+++ b/app/Model/Behavior/TranscriptableBehavior.php
@@ -103,7 +103,7 @@ class TranscriptableBehavior extends ModelBehavior
             } else {
                 $sentence = $result;
             }
-            if (isset($result['Transcription']) && !empty($result['Transciption'])
+            if (isset($result['Transcription'])
                 && isset($sentence['lang'])
                 && isset($sentence['text'])) {
                 $result['Transcription'] =

--- a/app/Model/Behavior/TranscriptableBehavior.php
+++ b/app/Model/Behavior/TranscriptableBehavior.php
@@ -103,6 +103,19 @@ class TranscriptableBehavior extends ModelBehavior
             } else {
                 $sentence = $result;
             }
+
+            /* Add script on the fly if missing */
+            if (isset($result['Sentence'])
+                && !isset($sentence['script'])
+                && isset($sentence['lang'])
+                && isset($sentence['text'])) {
+                $sentence['script'] = $model->Transcription->detectScript(
+                    $sentence['lang'],
+                    $sentence['text']
+                );
+            }
+
+            /* Add transcriptions on the fly if missing */
             if (isset($result['Transcription'])
                 && isset($sentence['lang'])
                 && isset($sentence['text'])) {

--- a/app/Model/Transcription.php
+++ b/app/Model/Transcription.php
@@ -480,7 +480,7 @@ class Transcription extends AppModel
 
     public function addGeneratedTranscriptions($transcriptions, $sentence) {
         $possibleScripts = $this->transcriptableToWhat($sentence);
-        $existingScripts = Set::classicExtract($transcriptions, '{n}.script');
+        $existingScripts = (array)Set::classicExtract($transcriptions, '{n}.script');
         $scriptsToGenerate = array_diff_key($possibleScripts, array_flip($existingScripts));
 
         foreach ($scriptsToGenerate as $script => $process) {


### PR DESCRIPTION
This fixes #1434. Additionally, I fixed on-the-fly autogeneration of Chinese transcriptions so that Chinese sentences (as well as Uzbek and Cantonese) that were create while we had `AutoTranscriptions.enabled` set to false, and are thus lacking transcriptions in the database, will have transcriptions displayed. Those transcriptions won’t be however searchable until we run the script `cake transcriptions autogen`.