### PR TITLE
Fix http links to avoid mixed-content on https

### DIFF
--- a/app/webroot/50x.html
+++ b/app/webroot/50x.html
@@ -76,12 +76,12 @@
     <div id="content">
         <div  id="logo">
             <img width="72" height="72" alt="Tatoeba" 
-                 src="http://static.tatoeba.org/img/tatoeba.svg" />
+                 src="https://static.tatoeba.org/img/tatoeba.svg" />
         </div>
 
         <div id="links">
             <a class="blogLink" href="http://blog.tatoeba.org">Blog</a>
-            <a class="twitterLink" href="http://twitter.com/tatoeba_org">Twitter</a>
+            <a class="twitterLink" href="https://twitter.com/tatoeba_org">Twitter</a>
         </div>
         
         <div id="info">


### PR DESCRIPTION
The blog is not yet served under https but just the image link should already remove the mixed-content warning.