### PR TITLE
Fill hash value when adding an UsersVocabulary entity (#1476).

### DIFF
--- a/app/Model/UsersVocabulary.php
+++ b/app/Model/UsersVocabulary.php
@@ -48,10 +48,11 @@ class UsersVocabulary extends AppModel
      *
      * @param string $vocabularyId Binary version of vocabulary_id.
      * @param int    $userId       Id of current user.
+     * @param string $hash         Vocabulary hash
      *
      * @return array               UsersVocabulary item.
      */
-    public function add($vocabularyId, $userId)
+    public function add($vocabularyId, $userId, $hash)
     {
         if ($item = $this->findFirst($vocabularyId, $userId)) {
             return $item;
@@ -59,7 +60,8 @@ class UsersVocabulary extends AppModel
 
         $data = array(
             'vocabulary_id' => $vocabularyId,
-            'user_id' => $userId
+            'user_id' => $userId,
+            'hash' => $hash,
         );
 
         return $this->save($data);

--- a/app/Model/Vocabulary.php
+++ b/app/Model/Vocabulary.php
@@ -81,7 +81,7 @@ class Vocabulary extends AppModel
 
         $data['id'] = $this->id;
 
-        $this->UsersVocabulary->add($this->id, CurrentUser::get('id'));
+        $this->UsersVocabulary->add($this->id, CurrentUser::get('id'), $hash);
 
         return $data;
     }


### PR DESCRIPTION
When adding a new Vocabulary item, an hash is created and filled in both
Vocabulary & UsersVocabulary entity. For any reason, it was not passed in the
last one, leading to the SQL error: "General error: 1364 Field 'hash' doesn't
have a default value".