### PR TITLE
New password hashing algorithm

### DIFF
--- a/app/Console/Command/AppShell.php
+++ b/app/Console/Command/AppShell.php
@@ -26,5 +26,24 @@ App::uses('Shell', 'Console');
  * @package       app.Console.Command
  */
 class AppShell extends Shell {
+    protected function batchOperation($model, $operation, $options) {
+        $batchSize = 1000;
+        $proceeded = 0;
+        $options = array_merge(
+            array(
+                'contain' => array(),
+                'limit' => $batchSize,
+                'offset' => 0,
+            ),
+            $options
+        );
 
+        do {
+            $data = $this->{$model}->find('all', $options);
+            $proceeded += $this->{$operation}($data, $model);
+            echo ".";
+            $options['offset'] += $batchSize;
+        } while ($data);
+        return $proceeded;
+    }
 }

--- a/app/Console/Command/TranscriptionsShell.php
+++ b/app/Console/Command/TranscriptionsShell.php
@@ -20,7 +20,7 @@
 App::import('Model', 'Sentence');
 App::import('Model', 'Transcription');
 
-class TranscriptionsShell extends Shell {
+class TranscriptionsShell extends AppShell {
 
     public $uses = array('Sentence', 'Transcription', 'Contribution');
 
@@ -58,7 +58,7 @@ class TranscriptionsShell extends Shell {
         }
     }
 
-    private function _autogen($sentences) {
+    protected function _autogen($sentences) {
         $sentenceIds = Set::classicExtract($sentences, '{n}.Sentence.id');
         $this->Transcription->deleteAll(
             array(
@@ -102,7 +102,7 @@ class TranscriptionsShell extends Shell {
         echo "\nScript set for $proceeded sentences in lang(s) $lang.\n";
     }
 
-    private function _setScript($rows, $model) {
+    protected function _setScript($rows, $model) {
         $proceeded = 0;
         $data = $this->detectTranscriptionsFor($rows);
         $options = array(
@@ -120,27 +120,6 @@ class TranscriptionsShell extends Shell {
             'conditions' => $conditions,
             'fields' => array('id', 'lang', 'script', 'text'),
         ));
-    }
-
-    private function batchOperation($model, $operation, $options) {
-        $batchSize = 1000;
-        $proceeded = 0;
-        $options = array_merge(
-            array(
-                'contain' => array(),
-                'limit' => $batchSize,
-                'offset' => 0,
-            ),
-            $options
-        );
-
-        do {
-            $data = $this->{$model}->find('all', $options);
-            $proceeded += $this->{$operation}($data, $model);
-            echo ".";
-            $options['offset'] += $batchSize;
-        } while ($data);
-        return $proceeded;
     }
 
     private function die_usage() {

--- a/app/Console/Command/UpdatePasswordVersionShell.php
+++ b/app/Console/Command/UpdatePasswordVersionShell.php
@@ -1,0 +1,46 @@
+<?php
+
+App::import('Security', 'Utility');
+
+class UpdatePasswordVersionShell extends AppShell {
+
+    public $uses = array('User');
+
+    public function main() {
+        echo "Updating password hashes";
+        $proceeded = $this->batchOperation(
+            'User',
+            '_updateHash',
+            array(
+                'conditions' => array('CHAR_LENGTH(password) = 32'),
+                'fields' => array('id', 'password')
+            )
+        );
+        echo "\n$proceeded password hashes updated.\n";
+    }
+
+    private function updateHashesFor($data, $model) {
+        $result = array();
+        foreach ($data as $row) {
+            $newHash = '0 '.Security::hash($row[$model]['password'], 'blowfish');
+
+            $result[] = array(
+                'id' => $row[$model]['id'],
+                'password' => $newHash,
+            );
+        }
+        return $result;
+    }
+
+    protected function _updateHash($rows, $model) {
+        $proceeded = 0;
+        $data = $this->updateHashesFor($rows, $model);
+        $options = array(
+            'validate' => false,
+            'callbacks' => false,
+        );
+        if ($data && $this->{$model}->saveAll($data, $options))
+            $proceeded += count($data);
+        return $proceeded;
+    }
+}

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -44,7 +44,11 @@ class AppController extends Controller
 {
     public $components = array(
         'Acl',
-        'Auth',
+        'Auth' => array(
+		'authenticate' => array(
+			'Form' => array('passwordHasher' => 'Versioned')
+		)
+	),
         'Flash',
         'Permissions',
         'RememberMe',

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -127,7 +127,6 @@ class AppController extends Controller
      */
     public function beforeFilter()
     {
-        Security::setHash('md5');
         // only prevent CSRF for logins and registration in the users controller
         $this->Security->csrfCheck = false;
         $this->Security->blackHoleCallback = 'blackhole';

--- a/app/Controller/Component/Auth/VersionedPasswordHasher.php
+++ b/app/Controller/Component/Auth/VersionedPasswordHasher.php
@@ -4,8 +4,19 @@ App::uses('Security', 'Utility');
 
 class VersionedPasswordHasher extends AbstractPasswordHasher {
 
+	const LATEST_VERSION = 1;
+
 	public function hash($password) {
 		return '1 '.Security::hash($password, 'blowfish');
+	}
+
+	public function isOutdated($hash) {
+		$versionedHash = explode(' ', $hash, 2);
+		if (count($versionedHash) != 2) {
+			return true;
+		} else {
+			return $versionedHash[0] < self::LATEST_VERSION;
+		}
 	}
 
 	public function check($plainTextPassword, $storedHash) {

--- a/app/Controller/Component/Auth/VersionedPasswordHasher.php
+++ b/app/Controller/Component/Auth/VersionedPasswordHasher.php
@@ -26,8 +26,10 @@ class VersionedPasswordHasher extends AbstractPasswordHasher {
 		}
 
 		list($hashVersion, $storedHash) = $versionedHash;
+		// help mitigate timing attacks by computing md5 regardless of $hashVersion
+		$V0hash = md5(Configure::read('Security.salt') . $plainTextPassword);
 		if ($hashVersion == 0) {
-			$plainTextPassword = md5(Configure::read('Security.salt') . $plainTextPassword);
+			$plainTextPassword = $V0hash;
 		}
 		$calculatedHash = Security::hash($plainTextPassword, 'blowfish', $storedHash);
 		return $storedHash === $calculatedHash;

--- a/app/Controller/Component/Auth/VersionedPasswordHasher.php
+++ b/app/Controller/Component/Auth/VersionedPasswordHasher.php
@@ -1,0 +1,25 @@
+<?php
+App::uses('AbstractPasswordHasher', 'Controller/Component/Auth');
+App::uses('Security', 'Utility');
+
+class VersionedPasswordHasher extends AbstractPasswordHasher {
+
+	public function hash($password) {
+		return '1 '.Security::hash($password, 'blowfish');
+	}
+
+	public function check($plainTextPassword, $storedHash) {
+		$versionedHash = explode(' ', $storedHash, 2);
+		if (count($versionedHash) != 2) {
+			return false;
+		}
+
+		list($hashVersion, $storedHash) = $versionedHash;
+		if ($hashVersion == 0) {
+			$plainTextPassword = md5(Configure::read('Security.salt') . $plainTextPassword);
+		}
+		$calculatedHash = Security::hash($plainTextPassword, 'blowfish', $storedHash);
+		return $storedHash === $calculatedHash;
+	}
+
+}

--- a/app/Controller/Component/RememberMeComponent.php
+++ b/app/Controller/Component/RememberMeComponent.php
@@ -91,7 +91,6 @@ class RememberMeComponent extends Component
         $user = $model->find('first', array(
             'conditions' => array(
                 'username' => $cookie['username'],
-                'password' => $this->Auth->password($cookie['password'])
             )
         ));
 

--- a/app/Controller/Component/RememberMeComponent.php
+++ b/app/Controller/Component/RememberMeComponent.php
@@ -91,6 +91,7 @@ class RememberMeComponent extends Component
         $user = $model->find('first', array(
             'conditions' => array(
                 'username' => $cookie['username'],
+                'password' => $cookie['password'],
             )
         ));
 

--- a/app/Controller/UserController.php
+++ b/app/Controller/UserController.php
@@ -613,8 +613,8 @@ class UserController extends AppController
             if (empty($newPassword1) || empty($newPassword2)) {
                 $flashMsg = __('New password cannot be empty.');
             }
-            elseif ($passwordHasher->check($submittedPassword, $actualPassword)
-                && $newPassword1 == $newPassword2
+            elseif ($newPassword1 == $newPassword2
+                && $passwordHasher->check($submittedPassword, $actualPassword)
             ) {
 
                 $this->User->id = $userId;

--- a/app/Controller/UserController.php
+++ b/app/Controller/UserController.php
@@ -25,6 +25,9 @@
  * @link     http://tatoeba.org
  */
 
+App::uses('AppController', 'Controller');
+App::uses('VersionedPasswordHasher', 'Controller/Component/Auth');
+
 /**
  * Controller for sentence comments.
  *
@@ -600,9 +603,8 @@ class UserController extends AppController
 
             $userId = $this->Auth->user('id');
 
-            $submittedPassword = $this->Auth->password(
-                $this->request->data['User']['old_password']
-            );
+            $passwordHasher = new VersionedPasswordHasher();
+            $submittedPassword = $this->request->data['User']['old_password'];
             $actualPassword = $this->User->getPassword($userId);
 
             $newPassword1 = $this->request->data['User']['new_password'];
@@ -611,11 +613,9 @@ class UserController extends AppController
             if (empty($newPassword1) || empty($newPassword2)) {
                 $flashMsg = __('New password cannot be empty.');
             }
-            elseif ($submittedPassword == $actualPassword
+            elseif ($passwordHasher->check($submittedPassword, $actualPassword)
                 && $newPassword1 == $newPassword2
             ) {
-
-                $newPassword1 = $this->Auth->password($newPassword1);
 
                 $this->User->id = $userId;
                 if ($this->User->saveField('password', $newPassword1)) {

--- a/app/Controller/UserController.php
+++ b/app/Controller/UserController.php
@@ -613,10 +613,10 @@ class UserController extends AppController
             if (empty($newPassword1)) {
                 $flashMsg = __('New password cannot be empty.');
             }
-            elseif ($newPassword1 == $newPassword2
-                && $passwordHasher->check($submittedPassword, $actualPassword)
-            ) {
-
+            elseif ($newPassword1 != $newPassword2) {
+                $flashMsg = __("New passwords do not match.");
+            }
+            elseif ($passwordHasher->check($submittedPassword, $actualPassword)) {
                 $this->User->id = $userId;
                 if ($this->User->saveField('password', $newPassword1)) {
                     $flashMsg = __('New password has been saved.');

--- a/app/Controller/UserController.php
+++ b/app/Controller/UserController.php
@@ -610,7 +610,7 @@ class UserController extends AppController
             $newPassword1 = $this->request->data['User']['new_password'];
             $newPassword2 = $this->request->data['User']['new_password2'];
 
-            if (empty($newPassword1) || empty($newPassword2)) {
+            if (empty($newPassword1)) {
                 $flashMsg = __('New password cannot be empty.');
             }
             elseif ($newPassword1 == $newPassword2

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -268,6 +268,10 @@ class UsersController extends AppController
         $data['User']['last_time_active'] = time();
         $this->User->save($data);
 
+        $this->User->updatePasswordVersion(
+            $this->Auth->user('id'),
+            $this->request->data['User']['password']
+        );
         if (empty($this->request->data['User']['rememberMe'])) {
             $this->RememberMe->delete();
         } else {

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -437,7 +437,7 @@ class UsersController extends AppController
                 // data to save
                 $updatePasswordData = array(
                     'id' => $user['User']['id'],
-                    'password' => $this->Auth->password($newPassword)
+                    'password' => $newPassword,
                 );
 
                 if ($this->User->save($updatePasswordData)) { // if saved

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -329,10 +329,7 @@ class UsersController extends AppController
         }
 
         // Password is empty
-        $emptyPasswordMd5 = md5(Configure::read('Security.salt'));
-        if ($this->request->data['User']['password'] == ''
-            || $this->request->data['User']['password'] == $emptyPasswordMd5
-        ) {
+        if ($this->request->data['User']['password'] == '') {
             $this->Session->setFlash(
                 __('Password cannot be empty.')
             );

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -272,7 +272,7 @@ class UsersController extends AppController
             $this->RememberMe->delete();
         } else {
             $this->RememberMe->remember(
-                $this->request->data['User']['username'], $this->request->data['User']['password']
+                $this->request->data['User']['username'], $this->User->field('password')
             );
         }
 

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -366,7 +366,6 @@ class UsersController extends AppController
         $this->User->create();
         $allowedFields = array('username', 'password', 'email');
         $newUser = $this->filterKeys($this->request->data['User'], $allowedFields);
-        $newUser['password'] = Security::hash($newUser['password'], 'md5', Configure::read('Security.salt'));
         $newUser['since']    = date("Y-m-d H:i:s");
         $newUser['group_id'] = 4;
 

--- a/app/Model/Behavior/SphinxBehavior.php
+++ b/app/Model/Behavior/SphinxBehavior.php
@@ -29,7 +29,7 @@ class SphinxBehavior extends ModelBehavior
 
     function setup(Model $model, $options = array())
     {
-        $databases = get_class_vars('DATABASE_CONFIG');
+        $databases = ConnectionManager::enumConnectionObjects();
         $config = array_merge(
             $this->_defaults,
             $databases['sphinx']

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -25,6 +25,8 @@
  * @link     http://tatoeba.org
  */
 
+App::uses('VersionedPasswordHasher', 'Controller/Component/Auth');
+
 /**
  * Model for users.
  *
@@ -150,6 +152,12 @@ class User extends AppModel
     }
 
     public function beforeSave($options = array()) {
+        if (isset($this->data['User']['password'])) {
+            $passwordHasher = new VersionedPasswordHasher();
+            $this->data['User']['password'] = $passwordHasher->hash(
+                $this->data['User']['password']
+            );
+        }
         if (array_key_exists('settings', $this->data['User'])
             && is_array($this->data['User']['settings'])) {
             $settings = $this->field('settings', array('id' => $this->id));

--- a/app/Test/Case/Controller/AppControllerTest.php
+++ b/app/Test/Case/Controller/AppControllerTest.php
@@ -31,6 +31,7 @@ class AppControllerTest extends ControllerTestCase {
 	}
 
 	function tearDown() {
+		$this->controller->Auth->Session->destroy();
 		unset($this->controller);
 	}
 
@@ -156,11 +157,19 @@ class AppControllerTest extends ControllerTestCase {
 	}
 
 	function testRememberMeAutomaticallyLogsInUser() {
-		$this->controller->RememberMe->remember('contributor', '123456');
+		$this->controller->RememberMe->remember('contributor', '0 $2a$10$Dn8/JT1xViULUEBCR5HiquLCXXB4/K3N2Nzc0PRZ.bfbmoApO55l6');
 		$this->assertFalse($this->controller->Auth->loggedIn());
 
 		$this->testAction('/eng/foo/bar', array('method' => 'GET'));
 
 		$this->assertTrue($this->controller->Auth->loggedIn());
+	}
+
+	function testRememberMeFailsIfIncorrectPassword() {
+		$this->controller->RememberMe->remember('contributor', '0 $2a$10$Dn8/JT1xViULUEBCR5HiquLCXXB4/K3N2Nzc0PRZ.bfbmoApO55l4');
+
+		$this->testAction('/eng/foo/bar', array('method' => 'GET'));
+
+		$this->assertFalse($this->controller->Auth->loggedIn());
 	}
 }

--- a/app/Test/Case/Controller/AppControllerTest.php
+++ b/app/Test/Case/Controller/AppControllerTest.php
@@ -5,6 +5,7 @@ App::import('Component', 'Cookie');
 class AppControllerTest extends ControllerTestCase {
 	public $fixtures = array(
 		'app.sentence',
+		'app.user',
 	);
 
 	private $interfaceLangCookie = false;
@@ -18,11 +19,13 @@ class AppControllerTest extends ControllerTestCase {
 			array('pt_BR', 'BR', 'Português (BR)'),
 		));
 		Configure::write('App.base', ''); // prevent using the filesystem path as base
+		$mockedComponents = array();
+		if (strpos($method, "testBeforeFilter_") !== false) {
+			$mockedComponents = array('Cookie' => array('read', 'write'));
+		}
 		$this->controller = $this->generate('App', array(
 			'methods' => array('redirect', 'bar'),
-			'components' => array(
-				'Cookie' => array('read', 'write')
-			)
+			'components' => $mockedComponents,
 		));
 		$this->controller->Auth->allowedActions = array('bar');
 	}
@@ -150,5 +153,14 @@ class AppControllerTest extends ControllerTestCase {
 			->method('redirect');
 
 		$this->testAction('/cmn/foo/bar', array('method' => 'GET'));
+	}
+
+	function testRememberMeAutomaticallyLogsInUser() {
+		$this->controller->RememberMe->remember('contributor', '123456');
+		$this->assertFalse($this->controller->Auth->loggedIn());
+
+		$this->testAction('/eng/foo/bar', array('method' => 'GET'));
+
+		$this->assertTrue($this->controller->Auth->loggedIn());
 	}
 }

--- a/app/Test/Case/Controller/UserControllerTest.php
+++ b/app/Test/Case/Controller/UserControllerTest.php
@@ -64,6 +64,11 @@ class UserControllerTest extends ControllerTestCase {
         $this->fail("Failed to assert that password of user '$username' $what");
     }
 
+    private function assertFlashMessage($message) {
+        $flash = $this->controller->Session->read('Message.flash');
+        $this->assertEquals($message, $flash['message'], "Flash message equals '$message'");
+    }
+
     public function testSavePassword_changesPassword() {
         $username = 'contributor';
         $oldPassword = '123456';
@@ -96,6 +101,7 @@ class UserControllerTest extends ControllerTestCase {
             )
         ));
         $this->assertPassword("didn't change", $username);
+        $this->assertFlashMessage('New password cannot be empty.');
     }
 
     public function testSavePassword_failsIfOldPasswordDoesntMatch() {
@@ -113,6 +119,7 @@ class UserControllerTest extends ControllerTestCase {
             )
         ));
         $this->assertPassword("didn't change", $username);
+        $this->assertFlashMessage('Password error. Please try again.');
     }
 
     public function testSavePassword_failsIfNewPasswordDoesntMatch() {
@@ -129,5 +136,6 @@ class UserControllerTest extends ControllerTestCase {
             )
         ));
         $this->assertPassword("didn't change", $username);
+        $this->assertFlashMessage('New passwords do not match.');
     }
 }

--- a/app/Test/Case/Controller/UserControllerTest.php
+++ b/app/Test/Case/Controller/UserControllerTest.php
@@ -1,0 +1,116 @@
+<?php
+App::uses('UserController', 'Controller');
+
+class UserControllerTest extends ControllerTestCase {
+
+    public $fixtures = array(
+        'app.user',
+    );
+
+    private $oldPasswords = array();
+
+    public function startTest($method) {
+        $this->controller = $this->generate('User', array(
+            'components' => array(
+                'Auth' => array('user')
+            )
+        ));
+
+        $users = $this->controller->User->find('all', array(
+            'fields' => array('username', 'password'),
+        ));
+        $this->oldPasswords = Set::combine($users, '{n}.User.username', '{n}.User.password');
+    }
+
+    public function tearDown() {
+        unset($this->controller);
+    }
+
+    private function logInAs($username) {
+        $user = $this->controller->User->find('first', array(
+            'conditions' => array('username' => $username),
+        ));
+        $this->controller->Auth
+            ->staticExpects($this->any())
+            ->method('user')
+            ->will($this->returnCallback(
+                function () use ($user) {
+                    $args = func_get_args();
+                    if (isset($args[0])) {
+                        return $user['User'][ $args[0] ];
+                    } else {
+                        return $user['User'];
+                    }
+                }
+            ));
+    }
+
+    private function assertPassword($what, $username) {
+        $user = $this->controller->User->findByUsername($username);
+        $currentPassword = $user['User']['password'];
+        $oldPassword = $this->oldPasswords[$username];
+        if ($oldPassword) {
+            $message = "Password of '$username' $what";
+            switch ($what) {
+            case "didn't change":
+                $this->assertEquals($oldPassword, $currentPassword, $message);
+                return;
+            case "changed":
+                $this->assertNotEquals($oldPassword, $currentPassword, $message);
+                return;
+            }
+        }
+        $this->fail("Failed to assert that password of user '$username' $what");
+    }
+
+    public function testSavePassword_changesPassword() {
+        $username = 'contributor';
+        $oldPassword = '123456';
+        $newPassword = '9{FA0E;pL#R(5JllB{wHWTO;6';
+        $this->logInAs($username);
+        $this->testAction('/eng/save_password', array(
+            'data' => array(
+                'User' => array(
+                    'old_password' => $oldPassword,
+                    'new_password' => $newPassword,
+                    'new_password2' => $newPassword,
+                )
+            )
+        ));
+        $this->assertPassword('changed', $username);
+    }
+
+    public function testSavePassword_failsIfOldPasswordDoesntMatch() {
+        $username = 'contributor';
+        $oldPassword = 'incorrect password';
+        $newPassword = '9{FA0E;pL#R(5JllB{wHWTO;6';
+        $this->logInAs($username);
+        $this->testAction('/eng/save_password', array(
+            'data' => array(
+                'User' => array(
+                    'old_password' => $oldPassword,
+                    'new_password' => $newPassword,
+                    'new_password2' => $newPassword,
+                )
+            )
+        ));
+        $this->assertPassword("didn't change", $username);
+    }
+
+    public function testSavePassword_failsIfNewPasswordDoesntMatch() {
+        $username = 'contributor';
+        $oldPassword = '123456';
+        $newPassword = '9{FA0E;pL#R(5JllB{wHWTO;6';
+        $this->logInAs($username);
+        $this->testAction('/eng/save_password', array(
+            'data' => array(
+                'User' => array(
+                    'old_password' => $oldPassword,
+                    'new_password' => 'something',
+                    'new_password2' => 'something different',
+                )
+            )
+        ));
+        $this->assertPassword("didn't change", $username);
+    }
+}

--- a/app/Test/Case/Controller/UserControllerTest.php
+++ b/app/Test/Case/Controller/UserControllerTest.php
@@ -100,7 +100,6 @@ class UserControllerTest extends ControllerTestCase {
     public function testSavePassword_failsIfNewPasswordDoesntMatch() {
         $username = 'contributor';
         $oldPassword = '123456';
-        $newPassword = '9{FA0E;pL#R(5JllB{wHWTO;6';
         $this->logInAs($username);
         $this->testAction('/eng/save_password', array(
             'data' => array(

--- a/app/Test/Case/Controller/UserControllerTest.php
+++ b/app/Test/Case/Controller/UserControllerTest.php
@@ -5,6 +5,7 @@ class UserControllerTest extends ControllerTestCase {
 
     public $fixtures = array(
         'app.user',
+        'app.sentence',
     );
 
     private $oldPasswords = array();
@@ -78,6 +79,23 @@ class UserControllerTest extends ControllerTestCase {
             )
         ));
         $this->assertPassword('changed', $username);
+    }
+
+    public function testSavePassword_failsIfNewPasswordIsEmpty() {
+        $username = 'contributor';
+        $oldPassword = '123456';
+        $newPassword = '';
+        $this->logInAs($username);
+        $this->testAction('/eng/save_password', array(
+            'data' => array(
+                'User' => array(
+                    'old_password' => $oldPassword,
+                    'new_password' => $newPassword,
+                    'new_password2' => $newPassword,
+                )
+            )
+        ));
+        $this->assertPassword("didn't change", $username);
     }
 
     public function testSavePassword_failsIfOldPasswordDoesntMatch() {

--- a/app/Test/Case/Controller/UsersControllerTest.php
+++ b/app/Test/Case/Controller/UsersControllerTest.php
@@ -109,4 +109,18 @@ class UsersControllerTest extends ControllerTestCase {
 		));
 		$this->assertFalse($this->controller->Auth->loggedIn());
 	}
+
+	function testCheckLogin_loginUpdatedPasswordVersion() {
+		$this->testAction('/users/check_login', array(
+			'data' => array('User' => array(
+				'username' => 'contributor',
+				'password' => '123456',
+				'rememberMe' => 0,
+			))
+		));
+
+		$user = $this->controller->User->findByUsername('contributor');
+		list($version, $hash) = explode(' ', $user['User']['password'], 2);
+		$this->assertEquals(1, $version);
+	}
 }

--- a/app/Test/Case/Controller/UsersControllerTest.php
+++ b/app/Test/Case/Controller/UsersControllerTest.php
@@ -16,7 +16,7 @@ class UsersControllerTest extends ControllerTestCase {
 		$this->controller->Auth->Session->destroy();
 	}
 
-	function testCheckLogin_correctLoginAndPassword() {
+	function testCheckLogin_correctLoginAndPasswordV0() {
 		$this->testAction('/users/check_login', array(
 			'data' => array('User' => array(
 				'username' => 'contributor',
@@ -27,7 +27,7 @@ class UsersControllerTest extends ControllerTestCase {
 		$this->assertTrue($this->controller->Auth->loggedIn());
 	}
 
-	function testCheckLogin_correctLoginAndincorrectPassword() {
+	function testCheckLogin_correctLoginAndincorrectPasswordV0() {
 		$this->testAction('/users/check_login', array(
 			'data' => array('User' => array(
 				'username' => 'contributor',
@@ -43,6 +43,39 @@ class UsersControllerTest extends ControllerTestCase {
 			'data' => array('User' => array(
 				'username' => 'this_user_does_not_exist',
 				'password' => 'this_is_incorrect',
+				'rememberMe' => 0,
+			))
+		));
+		$this->assertFalse($this->controller->Auth->loggedIn());
+	}
+
+	function testCheckLogin_correctLoginAndPassowrdV1() {
+		$this->testAction('/users/check_login', array(
+			'data' => array('User' => array(
+				'username' => 'kazuki',
+				'password' => 'myAwesomePassword',
+				'rememberMe' => 0,
+			))
+		));
+		$this->assertTrue($this->controller->Auth->loggedIn());
+	}
+
+	function testCheckLogin_correctLoginAndIncorrectPassowrdV1() {
+		$this->testAction('/users/check_login', array(
+			'data' => array('User' => array(
+				'username' => 'kazuki',
+				'password' => 'this_is_incorrect',
+				'rememberMe' => 0,
+			))
+		));
+		$this->assertFalse($this->controller->Auth->loggedIn());
+	}
+
+	function testCheckLogin_userWithOldStylePasswordCannotLogin() {
+		$this->testAction('/users/check_login', array(
+			'data' => array('User' => array(
+				'username' => 'mr_old_style_passwd',
+				'password' => '123456',
 				'rememberMe' => 0,
 			))
 		));

--- a/app/Test/Case/Controller/UsersControllerTest.php
+++ b/app/Test/Case/Controller/UsersControllerTest.php
@@ -82,6 +82,20 @@ class UsersControllerTest extends ControllerTestCase {
 		$this->assertFalse($this->controller->Auth->loggedIn());
 	}
 
+	function testCheckLogin_canRegister() {
+		$this->testAction('/users/register', array(
+			'data' => array('User' => array(
+				'username' => 'polochon',
+				'password' => 'very bad password',
+				'language' => 'none',
+				'acceptation_terms_of_use' => '1',
+				'email' => 'polochon@example.net',
+				'quiz' => 'poloc',
+			))
+		));
+		$this->assertTrue($this->controller->Auth->loggedIn());
+	}
+
 	function testCheckLogin_cannotRegisterWithEmptyPassword() {
 		$this->testAction('/users/register', array(
 			'data' => array('User' => array(

--- a/app/Test/Case/Controller/UsersControllerTest.php
+++ b/app/Test/Case/Controller/UsersControllerTest.php
@@ -81,4 +81,18 @@ class UsersControllerTest extends ControllerTestCase {
 		));
 		$this->assertFalse($this->controller->Auth->loggedIn());
 	}
+
+	function testCheckLogin_cannotRegisterWithEmptyPassword() {
+		$this->testAction('/users/register', array(
+			'data' => array('User' => array(
+				'username' => 'polochon',
+				'password' => '',
+				'language' => 'none',
+				'acceptation_terms_of_use' => '1',
+				'email' => 'polochon@example.net',
+				'quiz' => 'poloc',
+			))
+		));
+		$this->assertFalse($this->controller->Auth->loggedIn());
+	}
 }

--- a/app/Test/Fixture/UserFixture.php
+++ b/app/Test/Fixture/UserFixture.php
@@ -6,7 +6,7 @@ class UserFixture extends CakeTestFixture {
 	public $fields = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => NULL, 'key' => 'primary'),
 		'username' => array('type' => 'string', 'null' => false, 'default' => NULL, 'length' => 20, 'key' => 'unique', 'collate' => 'utf8_unicode_ci', 'charset' => 'utf8'),
-		'password' => array('type' => 'string', 'null' => false, 'length' => 50, 'collate' => 'utf8_unicode_ci', 'charset' => 'utf8'),
+		'password' => array('type' => 'string', 'null' => false, 'length' => 64, 'collate' => 'utf8_unicode_ci', 'charset' => 'utf8'),
 		'email' => array('type' => 'string', 'null' => false, 'length' => 100, 'key' => 'unique', 'collate' => 'utf8_unicode_ci', 'charset' => 'utf8'),
 		'lang' => array('type' => 'string', 'null' => true, 'default' => NULL, 'length' => 100, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 		'since' => array('type' => 'datetime', 'null' => false, 'default' => '0000-00-00 00:00:00'),
@@ -29,7 +29,7 @@ class UserFixture extends CakeTestFixture {
 		array(
 			'id' => '1',
 			'username' => 'admin',
-			'password' => 'dc59e60a5353bf329d0c961185055226',
+			'password' => '0 $2a$10$C9HUn1u98XMMV/J2DP9F.eSPrJY0UiX7Z1PsDiWoGakXsSzwpUQ/e', // blowfish(md5('ze@9422#5dS?!99xx' . '123456'))
 			'email' => 'admin@example.com',
 			'lang' => NULL,
 			'since' => '2013-04-07 12:15:16',
@@ -48,7 +48,7 @@ class UserFixture extends CakeTestFixture {
 		array(
 			'id' => '2',
 			'username' => 'corpus_maintainer',
-			'password' => 'dc59e60a5353bf329d0c961185055226',
+			'password' => '0 $2a$10$si98GpL3psq5k1EKh/koVup8GfGoB1.hjdRCbgKlzofvUbRkRBwjC', // blowfish(md5('ze@9422#5dS?!99xx' . '123456'))
 			'email' => 'corpus_maintainer@example.com',
 			'lang' => NULL,
 			'since' => '2013-04-07 12:15:50',
@@ -67,7 +67,7 @@ class UserFixture extends CakeTestFixture {
 		array(
 			'id' => '3',
 			'username' => 'advanced_contributor',
-			'password' => 'dc59e60a5353bf329d0c961185055226',
+			'password' => '0 $2a$10$YeMYysi2Wkiu1LPdm2SAEeD7tfYsXKoAKDGKutQvOPcKKcdpte.3K', // blowfish(md5('ze@9422#5dS?!99xx' . '123456'))
 			'email' => 'advanced_contributor@example.com',
 			'lang' => NULL,
 			'since' => '2013-04-07 12:16:37',
@@ -86,7 +86,7 @@ class UserFixture extends CakeTestFixture {
 		array(
 			'id' => '4',
 			'username' => 'contributor',
-			'password' => 'dc59e60a5353bf329d0c961185055226',
+			'password' => '0 $2a$10$Dn8/JT1xViULUEBCR5HiquLCXXB4/K3N2Nzc0PRZ.bfbmoApO55l6', // blowfish(md5('ze@9422#5dS?!99xx' . '123456'))
 			'email' => 'contributor@example.com',
 			'lang' => NULL,
 			'since' => '2013-04-07 12:17:02',
@@ -105,7 +105,7 @@ class UserFixture extends CakeTestFixture {
 		array(
 			'id' => '5',
 			'username' => 'inactive',
-			'password' => 'dc59e60a5353bf329d0c961185055226',
+			'password' => '0 $2a$10$k4WEM.b.68FriHgL3TbOpOrEWb35kMSwzkjvrLd5bzLExnFpVxAQa', // blowfish(md5('ze@9422#5dS?!99xx' . '123456'))
 			'email' => 'inactive@example.com',
 			'lang' => NULL,
 			'since' => '2013-04-07 12:17:29',
@@ -124,7 +124,7 @@ class UserFixture extends CakeTestFixture {
 		array(
 			'id' => '6',
 			'username' => 'spammer',
-			'password' => 'dc59e60a5353bf329d0c961185055226',
+			'password' => '0 $2a$10$p6lW5xX5OXliZixaywnbjOj8Ye0cTGvfw2peMcqLNrisnydCjQnL', // blowfish(md5('ze@9422#5dS?!99xx' . '123456'))
 			'email' => 'spammer@example.com',
 			'lang' => NULL,
 			'since' => '2013-04-07 12:17:54',
@@ -143,8 +143,27 @@ class UserFixture extends CakeTestFixture {
 		array(
 			'id' => '7',
 			'username' => 'kazuki',
-			'password' => 'dc59e60a5353bf329d0c961185055226',
+			'password' => '1 $2a$10$eSfvBiKsuMQsKq0B2sGyuukXNBNPwXXqSZJfzFUu/6b4vZYnehn/2', // blowfish('myAwesomePassword')
 			'email' => 'kazuki@example.net',
+			'lang' => NULL,
+			'since' => '2013-04-22 19:20:11',
+			'last_time_active' => '1397514924',
+			'level' => '1',
+			'group_id' => '4',
+			'send_notifications' => 1,
+			'name' => '',
+			'birthday' => NULL,
+			'description' => '',
+			'homepage' => '',
+			'image' => '',
+			'country_id' => NULL,
+			'is_public' => 0
+		),
+		array(
+			'id' => '8',
+			'username' => 'mr_old_style_passwd',
+			'password' => 'dc59e60a5353bf329d0c961185055226',
+			'email' => 'mr_old_style_passwd@example.net',
 			'lang' => NULL,
 			'since' => '2013-04-22 19:20:11',
 			'last_time_active' => '1397514924',

--- a/app/Test/Fixture/UserFixture.php
+++ b/app/Test/Fixture/UserFixture.php
@@ -6,7 +6,7 @@ class UserFixture extends CakeTestFixture {
 	public $fields = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => NULL, 'key' => 'primary'),
 		'username' => array('type' => 'string', 'null' => false, 'default' => NULL, 'length' => 20, 'key' => 'unique', 'collate' => 'utf8_unicode_ci', 'charset' => 'utf8'),
-		'password' => array('type' => 'string', 'null' => false, 'length' => 64, 'collate' => 'utf8_unicode_ci', 'charset' => 'utf8'),
+		'password' => array('type' => 'string', 'null' => false, 'length' => 62, 'collate' => 'utf8_unicode_ci', 'charset' => 'utf8'),
 		'email' => array('type' => 'string', 'null' => false, 'length' => 100, 'key' => 'unique', 'collate' => 'utf8_unicode_ci', 'charset' => 'utf8'),
 		'lang' => array('type' => 'string', 'null' => true, 'default' => NULL, 'length' => 100, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 		'since' => array('type' => 'datetime', 'null' => false, 'default' => '0000-00-00 00:00:00'),

--- a/docs/database/import/users.sql
+++ b/docs/database/import/users.sql
@@ -30,7 +30,7 @@ DROP TABLE IF EXISTS `users`;
 CREATE TABLE `users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `username` varchar(20) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `password` varchar(50) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `password` varchar(62) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `email` varchar(100) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `since` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `last_time_active` int(11) NOT NULL DEFAULT '0',
@@ -53,12 +53,13 @@ CREATE TABLE `users` (
 --
 
 INSERT INTO `users` (`id`, `username`, `password`, `email`, `since`, `last_time_active`, `level`, `group_id`, `send_notifications`, `name`, `birthday`, `description`, `settings`, `homepage`, `image`, `country_id`) VALUES
-(1, 'admin', 'dc59e60a5353bf329d0c961185055226', 'admin@fakemail.com', '2013-04-07 12:15:16', 0, 1, 1, 1, '', NULL, '', '', '', '', NULL),
-(2, 'corpus_maintainer', 'dc59e60a5353bf329d0c961185055226', 'corpus_maintainer@fakemail.com', '2013-04-07 12:15:50', 0, 1, 2, 1, '', NULL, '', '', '', '', NULL),
-(3, 'advanced_contributor', 'dc59e60a5353bf329d0c961185055226', 'advanced_contributor@fakemail.com', '2013-04-07 12:16:37', 0, 1, 3, 1, '', NULL, '', '', '', '', NULL),
-(4, 'contributor', 'dc59e60a5353bf329d0c961185055226', 'contributor@fakemail.com', '2013-04-07 12:17:02', 0, 1, 4, 1, '', NULL, '', '', '', '', NULL),
-(5, 'inactive', 'dc59e60a5353bf329d0c961185055226', 'inactive@fakemail.com', '2013-04-07 12:17:29', 0, 1, 5, 1, '', NULL, '', '', '', '', NULL),
-(6, 'spammer', 'dc59e60a5353bf329d0c961185055226', 'spammer@fakemail.com', '2013-04-07 12:17:54', 0, 1, 6, 1, '', NULL, '', '', '', '', NULL);
+
+(1, 'admin', '1 $2a$10$ze.r64Pv1E.CTHUNFpFkVuqxuYlbj00aqqeRDd.kumCTIVtkZ/Q8C', 'admin@fakemail.com', '2013-04-07 12:15:16', 0, 1, 1, 1, '', NULL, '', '', '', '', NULL),
+(2, 'corpus_maintainer', '1 $2a$10$HiIXBuvKbZkPOJ3NNegnyO0tEXzI8Q7/.elZyicSbx3b4Q9y3WsRS', 'corpus_maintainer@fakemail.com', '2013-04-07 12:15:50', 0, 1, 2, 1, '', NULL, '', '', '', '', NULL),
+(3, 'advanced_contributor', '1 $2a$10$3jg3N9/ig6LTRumZPGPBiexEXFQ/5egPjBh3X/tuuU5R5H2kRX5em', 'advanced_contributor@fakemail.com', '2013-04-07 12:16:37', 0, 1, 3, 1, '', NULL, '', '', '', '', NULL),
+(4, 'contributor', '1 $2a$10$lGq/QSz3nwHsDAHubtPC7ebT2dnpVTtcSWCV1LJ/vhOwNuJp3Jxay', 'contributor@fakemail.com', '2013-04-07 12:17:02', 0, 1, 4, 1, '', NULL, '', '', '', '', NULL),
+(5, 'inactive', '1 $2a$10$vCE03mwxDuuhISbs9mRnTekuwqPrnTfLjHLoH0zGBg53JE1Z3hl/q', 'inactive@fakemail.com', '2013-04-07 12:17:29', 0, 1, 5, 1, '', NULL, '', '', '', '', NULL),
+(6, 'spammer', '1 $2a$10$x68Xtpx56iQubb0LHZN/3ez8auzxe3EnOj8GfY7Xn2DIKjpJIBEry', 'spammer@fakemail.com', '2013-04-07 12:17:54', 0, 1, 6, 1, '', NULL, '', '', '', '', NULL);
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;

--- a/docs/database/tables/users.sql
+++ b/docs/database/tables/users.sql
@@ -32,7 +32,7 @@ DROP TABLE IF EXISTS `users`;
 CREATE TABLE `users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `username` varchar(20) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `password` varchar(50) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `password` varchar(62) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `email` varchar(100) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `since` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `last_time_active` int(11) NOT NULL DEFAULT '0',

--- a/docs/database/updates/2018-06-09.sql
+++ b/docs/database/updates/2018-06-09.sql
@@ -1,0 +1,4 @@
+-- Maybe backup login credentials if anything goes wrong
+-- CREATE TABLE users_bak LIKE users;
+-- INSERT users_bak SELECT * FROM users;
+ALTER TABLE users CHANGE password password VARCHAR(62);


### PR DESCRIPTION
Fixes #1396. Reviews welcome.

Installation instructions:
1. Switch to maintenance mode
2. `git pull`
3. Uncomment backuping instructions in `docs/database/updates/2018-06-09.sql` if you want
4. `mysql tatoeba < docs/database/updates/2018-06-09.sql`
5. `cake update_password_version` (it won’t break things even if you run this several times)
6. Remove maintenance mode
7. Remove backup table `users_bak` if you uncommented code in 3.