### PR TITLE
Added the information about how often the files on the downloads page are updated

### DIFF
--- a/app/View/Pages/downloads.ctp
+++ b/app/View/Pages/downloads.ctp
@@ -56,7 +56,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Download sentences'
         <h2><?php echo __('General information about the files'); ?></h2>
         <p>
             <?php
-            __(
+            echo __(
                 'The files provided here are updated every <strong>Saturday at 9 a.m.</strong> '.
                 '(GMT).'
             );


### PR DESCRIPTION
This pull request addresses issue #1655 
Added the information about how often the files are updated on the downloads page
https://tatoeba.org/eng/downloads