### PR TITLE
Minify JS and CSS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ tmp/cache
 tmp/cache/models
 tmp/cache/persistent
 tmp/cache/views
+webroot/cache_css/
+webroot/cache_js/
 
 # Composer / Vendor
 composer.phar

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
         "cakephp/plugin-installer": "^1.0",
         "dereuromark/cakephp-queue": "^3.11",
         "cakephp/acl": "^0.4.0",
-        "markstory/asset_compress": "^3.5"
+        "markstory/asset_compress": "^3.5",
+        "patchwork/jsqueeze": "^2.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "2.*",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "dereuromark/cakephp-queue": "^3.11",
         "cakephp/acl": "^0.4.0",
         "markstory/asset_compress": "^3.5",
-        "patchwork/jsqueeze": "^2.0"
+        "patchwork/jsqueeze": "^2.0",
+        "natxet/CssMin": "^3.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "2.*",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "tatoeba",
     "require": {
-        "cakephp/cakephp": "~3.6.13",
+        "cakephp/cakephp": "3.7.*",
         "cakephp/plugin-installer": "^1.0",
         "dereuromark/cakephp-queue": "^3.11",
         "cakephp/acl": "^0.4.0"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
         "cakephp/cakephp": "3.7.*",
         "cakephp/plugin-installer": "^1.0",
         "dereuromark/cakephp-queue": "^3.11",
-        "cakephp/acl": "^0.4.0"
+        "cakephp/acl": "^0.4.0",
+        "markstory/asset_compress": "^3.5"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "aa2eb1a4dab6740562c506d8293d3504",
-    "content-hash": "8094c46abe7e31e8477043a170bcce72",
+    "hash": "d4f0f3d4e7a8afc060c9b6a9d75aea43",
+    "content-hash": "631210f682de750aae976d01fe0c1719",
     "packages": [
         {
             "name": "aura/intl",
@@ -350,6 +350,189 @@
             "time": "2018-12-05 09:32:21"
         },
         {
+            "name": "league/climate",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/climate.git",
+                "reference": "d657a19837c1f79a891381fb128b755aa3386381"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/climate/zipball/d657a19837c1f79a891381fb128b755aa3386381",
+                "reference": "d657a19837c1f79a891381fb128b755aa3386381",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6|^7.0",
+                "psr/log": "^1.0",
+                "seld/cli-prompt": "^1.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "^1.4",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^5.7.16"
+            },
+            "suggest": {
+                "ext-mbstring": "If ext-mbstring is not available you MUST install symfony/polyfill-mbstring"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\CLImate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Craig Duncan",
+                    "email": "git@duncanc.co.uk",
+                    "homepage": "https://github.com/duncan3dc",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Joe Tannenbaum",
+                    "email": "hey@joe.codes",
+                    "homepage": "http://joe.codes/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP's best friend for the terminal. CLImate allows you to easily output colored text, special formats, and more.",
+            "keywords": [
+                "cli",
+                "colors",
+                "command",
+                "php",
+                "terminal"
+            ],
+            "time": "2018-04-29 16:43:54"
+        },
+        {
+            "name": "markstory/asset_compress",
+            "version": "3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/markstory/asset_compress.git",
+                "reference": "81851833233ad05a283d36c5564d1cc13d297af6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/markstory/asset_compress/zipball/81851833233ad05a283d36c5564d1cc13d297af6",
+                "reference": "81851833233ad05a283d36c5564d1cc13d297af6",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/cakephp": ">=3.7.0 <4.0.0",
+                "markstory/mini-asset": ">=1.4.0 <2.0.0"
+            },
+            "require-dev": {
+                "cakephp/cakephp-codesniffer": "~2.1",
+                "phpunit/phpunit": "5.*"
+            },
+            "suggest": {
+                "328/jsqueeze": "For using the JSqueeze filter.",
+                "leafo/lessphp": "For using the LessPHP filter.",
+                "leafo/scssphp": "For using the ScssPHP filter.",
+                "natxet/CssMin": "For using the CssMin filter.",
+                "patchwork/jshrink": "For using the JShrink filter."
+            },
+            "type": "cakephp-plugin",
+            "autoload": {
+                "psr-4": {
+                    "AssetCompress\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Story",
+                    "homepage": "http://mark-story.com",
+                    "role": "Author"
+                }
+            ],
+            "description": "An asset compression plugin for CakePHP. Provides file concatenation and a flexible filter system for preprocessing and minification.",
+            "homepage": "https://github.com/markstory/asset_compress",
+            "keywords": [
+                "assets",
+                "cakephp",
+                "coffee-script",
+                "less",
+                "minifier",
+                "sass"
+            ],
+            "time": "2018-12-20 02:09:19"
+        },
+        {
+            "name": "markstory/mini-asset",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/markstory/mini-asset.git",
+                "reference": "28c126712421a84bf03a12ebde460224c98d96bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/markstory/mini-asset/zipball/28c126712421a84bf03a12ebde460224c98d96bb",
+                "reference": "28c126712421a84bf03a12ebde460224c98d96bb",
+                "shasum": ""
+            },
+            "require": {
+                "league/climate": "~3.0",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 | ^6.0",
+                "squizlabs/php_codesniffer": "*",
+                "zendframework/zend-diactoros": "~1.0"
+            },
+            "suggest": {
+                "leafo/scssphp": "For using the ScssPHP filter.",
+                "natxet/CssMin": "For using the CssMin filter.",
+                "oyejorge/less.php": "For using the LessDotPHP filter, see https://github.com/oyejorge/less.php",
+                "tchwork/jsqueeze": "For using the JSqueeze filter.",
+                "tedivm/jshrink": "For using the JShrink filter.",
+                "zendframework/diactoros": "The middleware layer relies on zendframework/diactoros."
+            },
+            "bin": [
+                "bin/mini_asset"
+            ],
+            "type": "cakephp-plugin",
+            "autoload": {
+                "psr-4": {
+                    "MiniAsset\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Story",
+                    "homepage": "http://mark-story.com",
+                    "role": "Author"
+                }
+            ],
+            "description": "An asset compression library. Provides file concatenation and a flexible filter system for preprocessing and minification.",
+            "homepage": "https://github.com/markstory/mini-asset",
+            "keywords": [
+                "assets",
+                "cakephp",
+                "coffee-script",
+                "less",
+                "minifier",
+                "psr7",
+                "sass"
+            ],
+            "time": "2017-11-16 20:45:31"
+        },
+        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -493,6 +676,54 @@
                 "simple-cache"
             ],
             "time": "2017-10-23 01:57:42"
+        },
+        {
+            "name": "seld/cli-prompt",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/cli-prompt.git",
+                "reference": "a19a7376a4689d4d94cab66ab4f3c816019ba8dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/cli-prompt/zipball/a19a7376a4689d4d94cab66ab4f3c816019ba8dd",
+                "reference": "a19a7376a4689d4d94cab66ab4f3c816019ba8dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Seld\\CliPrompt\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Allows you to prompt for user input on the command line, and optionally hide the characters they type",
+            "keywords": [
+                "cli",
+                "console",
+                "hidden",
+                "input",
+                "prompt"
+            ],
+            "time": "2017-03-18 11:32:45"
         },
         {
             "name": "zendframework/zend-diactoros",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d4f0f3d4e7a8afc060c9b6a9d75aea43",
-    "content-hash": "631210f682de750aae976d01fe0c1719",
+    "hash": "1ee36b35b392bae9d301e414754076b2",
+    "content-hash": "2a74040ced173d6eab9fdabdbc2a517a",
     "packages": [
         {
             "name": "aura/intl",
@@ -531,6 +531,53 @@
                 "sass"
             ],
             "time": "2017-11-16 20:45:31"
+        },
+        {
+            "name": "patchwork/jsqueeze",
+            "version": "v2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tchwork/jsqueeze.git",
+                "reference": "693d64850eab2ce6a7c8f7cf547e1ab46e69d542"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tchwork/jsqueeze/zipball/693d64850eab2ce6a7c8f7cf547e1ab46e69d542",
+                "reference": "693d64850eab2ce6a7c8f7cf547e1ab46e69d542",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Patchwork\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "(Apache-2.0 or GPL-2.0)"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                }
+            ],
+            "description": "Efficient JavaScript minification in PHP",
+            "homepage": "https://github.com/tchwork/jsqueeze",
+            "keywords": [
+                "compression",
+                "javascript",
+                "minification"
+            ],
+            "time": "2016-04-19 09:28:22"
         },
         {
             "name": "psr/http-message",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e38ca77ea6ea467687c2a352ce9a329",
+    "hash": "aa2eb1a4dab6740562c506d8293d3504",
+    "content-hash": "8094c46abe7e31e8477043a170bcce72",
     "packages": [
         {
             "name": "aura/intl",
@@ -50,7 +51,7 @@
                 "l10n",
                 "localization"
             ],
-            "time": "2017-01-20T05:00:11+00:00"
+            "time": "2017-01-20 05:00:11"
         },
         {
             "name": "cakephp/acl",
@@ -96,20 +97,20 @@
                 "acl",
                 "cakephp"
             ],
-            "time": "2018-08-15T08:51:49+00:00"
+            "time": "2018-08-15 08:51:49"
         },
         {
             "name": "cakephp/cakephp",
-            "version": "3.6.14",
+            "version": "3.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/cakephp.git",
-                "reference": "4ce123c1255e8ada474d02703abede3f8dced3bf"
+                "reference": "5c78a61c0ed7fbd56ce9d7cee3c6d6f9b27af46b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/4ce123c1255e8ada474d02703abede3f8dced3bf",
-                "reference": "4ce123c1255e8ada474d02703abede3f8dced3bf",
+                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/5c78a61c0ed7fbd56ce9d7cee3c6d6f9b27af46b",
+                "reference": "5c78a61c0ed7fbd56ce9d7cee3c6d6f9b27af46b",
                 "shasum": ""
             },
             "require": {
@@ -119,6 +120,7 @@
                 "ext-mbstring": "*",
                 "php": ">=5.6.0",
                 "psr/log": "^1.0.0",
+                "psr/simple-cache": "^1.0.0",
                 "zendframework/zend-diactoros": "^1.4.0"
             },
             "conflict": {
@@ -141,9 +143,11 @@
             },
             "require-dev": {
                 "cakephp/cakephp-codesniffer": "^3.0",
+                "cakephp/chronos": "^1.2.1",
                 "phpunit/phpunit": "^5.7.14|^6.0"
             },
             "suggest": {
+                "ext-curl": "To enable more efficient network calls in Http\\Client.",
                 "ext-openssl": "To use Security::encrypt() or have secure CSRF token generation.",
                 "lib-ICU": "The intl PHP library, to use Text::transliterate() or Text::slug()"
             },
@@ -182,20 +186,20 @@
                 "rapid-development",
                 "validation"
             ],
-            "time": "2018-12-07T03:21:25+00:00"
+            "time": "2019-02-09 20:30:00"
         },
         {
             "name": "cakephp/chronos",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/chronos.git",
-                "reference": "395110125ff577f080fa064dca5c5608a4e77ee1"
+                "reference": "ebda7326d4a65e53bc5bb915ebbbeee98f1926b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/chronos/zipball/395110125ff577f080fa064dca5c5608a4e77ee1",
-                "reference": "395110125ff577f080fa064dca5c5608a4e77ee1",
+                "url": "https://api.github.com/repos/cakephp/chronos/zipball/ebda7326d4a65e53bc5bb915ebbbeee98f1926b0",
+                "reference": "ebda7326d4a65e53bc5bb915ebbbeee98f1926b0",
                 "shasum": ""
             },
             "require": {
@@ -239,7 +243,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2018-10-18T22:02:21+00:00"
+            "time": "2019-02-11 02:08:31"
         },
         {
             "name": "cakephp/plugin-installer",
@@ -280,7 +284,7 @@
                 }
             ],
             "description": "A composer installer for CakePHP 3.0+ plugins.",
-            "time": "2017-12-24T21:09:29+00:00"
+            "time": "2017-12-24 21:09:29"
         },
         {
             "name": "dereuromark/cakephp-queue",
@@ -343,7 +347,7 @@
                 "deferred tasks",
                 "queue"
             ],
-            "time": "2018-12-05T09:32:21+00:00"
+            "time": "2018-12-05 09:32:21"
         },
         {
             "name": "psr/http-message",
@@ -393,7 +397,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2016-08-06 14:39:51"
         },
         {
             "name": "psr/log",
@@ -440,7 +444,55 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2018-11-20T15:27:04+00:00"
+            "time": "2018-11-20 15:27:04"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23 01:57:42"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -504,7 +556,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2018-09-05T19:29:37+00:00"
+            "time": "2018-09-05 19:29:37"
         }
     ],
     "packages-dev": [
@@ -566,7 +618,7 @@
                 "breakpoint",
                 "twig"
             ],
-            "time": "2018-12-10T08:22:36+00:00"
+            "time": "2018-12-10 08:22:36"
         },
         {
             "name": "aptoma/twig-markdown",
@@ -623,7 +675,7 @@
                 "markdown",
                 "twig"
             ],
-            "time": "2015-10-23T20:27:08+00:00"
+            "time": "2015-10-23 20:27:08"
         },
         {
             "name": "asm89/twig-cache-extension",
@@ -677,7 +729,7 @@
                 "extension",
                 "twig"
             ],
-            "time": "2017-01-10T22:04:15+00:00"
+            "time": "2017-01-10 22:04:15"
         },
         {
             "name": "cakephp/bake",
@@ -725,7 +777,7 @@
                 "bake",
                 "cakephp"
             ],
-            "time": "2018-12-04T04:23:24+00:00"
+            "time": "2018-12-04 04:23:24"
         },
         {
             "name": "doctrine/instantiator",
@@ -779,7 +831,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2015-06-14 21:17:01"
         },
         {
             "name": "jasny/twig-extensions",
@@ -839,7 +891,7 @@
                 "text",
                 "time"
             ],
-            "time": "2017-09-13T07:38:01+00:00"
+            "time": "2017-09-13 07:38:01"
         },
         {
             "name": "myclabs/deep-copy",
@@ -884,7 +936,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2017-10-19 19:58:43"
         },
         {
             "name": "phar-io/manifest",
@@ -939,7 +991,7 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2017-03-05 18:14:27"
         },
         {
             "name": "phar-io/version",
@@ -986,7 +1038,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2017-03-05 17:38:23"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1040,7 +1092,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2017-09-11 18:02:19"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -1091,7 +1143,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
+            "time": "2017-11-30 07:14:17"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1138,7 +1190,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14T14:27:02+00:00"
+            "time": "2017-07-14 14:27:02"
         },
         {
             "name": "phpspec/prophecy",
@@ -1201,7 +1253,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2018-08-05 17:53:17"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1264,7 +1316,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-06T15:36:58+00:00"
+            "time": "2018-04-06 15:36:58"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1311,7 +1363,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2017-11-27 13:52:08"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1352,7 +1404,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
@@ -1401,7 +1453,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2017-02-26 11:10:40"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -1450,7 +1502,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27T05:48:46+00:00"
+            "time": "2017-11-27 05:48:46"
         },
         {
             "name": "phpunit/phpunit",
@@ -1534,7 +1586,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-09-08T15:10:43+00:00"
+            "time": "2018-09-08 15:10:43"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1593,7 +1645,8 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-08-09T05:50:03+00:00"
+            "abandoned": true,
+            "time": "2018-08-09 05:50:03"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1638,7 +1691,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "time": "2017-03-04 06:30:41"
         },
         {
             "name": "sebastian/comparator",
@@ -1702,7 +1755,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01T13:46:46+00:00"
+            "time": "2018-02-01 13:46:46"
         },
         {
             "name": "sebastian/diff",
@@ -1754,7 +1807,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "time": "2017-08-03 08:09:46"
         },
         {
             "name": "sebastian/environment",
@@ -1804,7 +1857,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2017-07-01 08:51:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1871,7 +1924,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03T13:19:02+00:00"
+            "time": "2017-04-03 13:19:02"
         },
         {
             "name": "sebastian/global-state",
@@ -1922,7 +1975,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "time": "2017-04-27 15:39:26"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1969,7 +2022,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
+            "time": "2017-08-03 12:35:26"
         },
         {
             "name": "sebastian/object-reflector",
@@ -2014,7 +2067,7 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
+            "time": "2017-03-29 09:07:27"
         },
         {
             "name": "sebastian/recursion-context",
@@ -2067,7 +2120,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
+            "time": "2017-03-03 06:23:57"
         },
         {
             "name": "sebastian/resource-operations",
@@ -2109,7 +2162,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2015-07-28 20:34:47"
         },
         {
             "name": "sebastian/version",
@@ -2152,7 +2205,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "time": "2016-10-03 07:35:21"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -2230,7 +2283,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2018-11-07 22:31:41"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2288,7 +2341,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2018-08-06 14:22:27"
         },
         {
             "name": "theseer/tokenizer",
@@ -2328,7 +2381,7 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07T12:08:54+00:00"
+            "time": "2017-04-07 12:08:54"
         },
         {
             "name": "twig/twig",
@@ -2394,7 +2447,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2018-12-16T10:34:11+00:00"
+            "time": "2018-12-16 10:34:11"
         },
         {
             "name": "umpirsky/twig-php-function",
@@ -2435,7 +2488,7 @@
                 }
             ],
             "description": "Call (almost) any PHP function from your Twig templates.",
-            "time": "2016-03-12T16:36:32+00:00"
+            "time": "2016-03-12 16:36:32"
         },
         {
             "name": "webmozart/assert",
@@ -2485,7 +2538,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2018-01-29 19:49:41"
         },
         {
             "name": "wyrihaximus/twig-view",
@@ -2543,7 +2596,7 @@
                 "twig",
                 "view"
             ],
-            "time": "2018-12-17T21:08:25+00:00"
+            "time": "2018-12-17 21:08:25"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1ee36b35b392bae9d301e414754076b2",
-    "content-hash": "2a74040ced173d6eab9fdabdbc2a517a",
+    "hash": "10bb32b2c3a6c36146e6aaf893302e3f",
+    "content-hash": "60e89956628ef5a642a4210a29cf7baf",
     "packages": [
         {
             "name": "aura/intl",
@@ -531,6 +531,53 @@
                 "sass"
             ],
             "time": "2017-11-16 20:45:31"
+        },
+        {
+            "name": "natxet/CssMin",
+            "version": "v3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/natxet/CssMin.git",
+                "reference": "d5d9f4c3e5cedb1ae96a95a21731f8790e38f1dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/natxet/CssMin/zipball/d5d9f4c3e5cedb1ae96a95a21731f8790e38f1dd",
+                "reference": "d5d9f4c3e5cedb1ae96a95a21731f8790e38f1dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joe Scylla",
+                    "email": "joe.scylla@gmail.com",
+                    "homepage": "https://profiles.google.com/joe.scylla"
+                }
+            ],
+            "description": "Minifying CSS",
+            "homepage": "http://code.google.com/p/cssmin/",
+            "keywords": [
+                "css",
+                "minify"
+            ],
+            "time": "2018-01-09 11:15:01"
         },
         {
             "name": "patchwork/jsqueeze",

--- a/config/app_local.php.template
+++ b/config/app_local.php.template
@@ -1,7 +1,6 @@
 <?php
 
 define("TATOEBA_DOMAIN", "localhost");
-define("CSS_PATH", "");
 define("JS_PATH", "");
 define("IMG_PATH", "");
 

--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -1,0 +1,22 @@
+
+[General]
+; * cacheConfig - set to true to cache the parsed configuration data
+;   so it doesn't get parsed on each request.
+cacheConfig = false
+; * alwaysEnableController - Set to true to always enable the
+;   AssetsController. Generally you will want to disable the controller
+;   in production, as it could allow an attacker to request expensive
+;   resources repeatedly. However, if you need the controller available
+;   in production. You can enable this flag.
+alwaysEnableController = false
+
+[js]
+cachePath = WEBROOT/cache_js/
+
+[css]
+cachePath = WEBROOT/cache_css/
+
+[layout.css]
+files[] = angular-material.min.css
+files[] = layouts/default.css
+files[] = layouts/elements.css

--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -16,6 +16,7 @@ filters[] = JSqueezeFilter
 
 [css]
 cachePath = WEBROOT/cache_css/
+filters[] = CssMinFilter
 
 [layout.css]
 files[] = angular-material.min.css

--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -34,3 +34,5 @@ files[] = generic_functions.js
 ; Source: https://github.com/jonathantneal/svg4everybody
 ; This is needed to make "fill: currentColor" work on every browser.
 files[] = svg4everybody.min.js
+files[] = elements/search-bar.ctrl.js
+files[] = directives/language-dropdown.dir.js

--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -36,3 +36,14 @@ files[] = generic_functions.js
 files[] = svg4everybody.min.js
 files[] = elements/search-bar.ctrl.js
 files[] = directives/language-dropdown.dir.js
+
+[sentences-block-for-members.js]
+files[] = sentences.add_translation.js
+files[] = favorites.add.js
+files[] = sentences_lists.menu.js
+files[] = sentences.adopt.js
+files[] = sentences.edit_in_place.js
+files[] = sentences.change_language.js
+files[] = sentences.link.js
+files[] = links.add_and_delete.js
+files[] = collections.add_remove.js

--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -20,3 +20,17 @@ cachePath = WEBROOT/cache_css/
 files[] = angular-material.min.css
 files[] = layouts/default.css
 files[] = layouts/elements.css
+
+[layout.js]
+files[] = jquery-1.11.3.min.js
+files[] = angular/angular.min.js
+files[] = angular/angular-animate.min.js
+files[] = angular/angular-aria.min.js
+files[] = angular/angular-material.min.js
+files[] = angular/angular-messages.min.js
+files[] = watch.js
+files[] = responsive/app.module.js
+files[] = generic_functions.js
+; Source: https://github.com/jonathantneal/svg4everybody
+; This is needed to make "fill: currentColor" work on every browser.
+files[] = svg4everybody.min.js

--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -12,6 +12,7 @@ alwaysEnableController = false
 
 [js]
 cachePath = WEBROOT/cache_js/
+filters[] = JSqueezeFilter
 
 [css]
 cachePath = WEBROOT/cache_css/

--- a/docs/database/tables/private_messages.sql
+++ b/docs/database/tables/private_messages.sql
@@ -15,7 +15,7 @@ CREATE TABLE `private_messages` (
   `folder` enum('Inbox','Sent','Trash','Drafts') CHARACTER SET utf8 NOT NULL DEFAULT 'Inbox',
   `title` varchar(255) CHARACTER SET utf8 NOT NULL,
   `content` text CHARACTER SET utf8 NOT NULL,
-  `isnonread` tinyint(4) NOT NULL DEFAULT '1',
+  `isnonread` BOOLEAN NOT NULL DEFAULT '1',
   `draft_recpts` VARCHAR(255) CHARACTER SET utf8 NOT NULL,
   `sent` tinyint(4) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),

--- a/docs/database/updates/2019-03-02.sql
+++ b/docs/database/updates/2019-03-02.sql
@@ -1,0 +1,1 @@
+ALTER TABLE private_messages CHANGE COLUMN isnonread isnonread BOOLEAN NOT NULL DEFAULT '1';

--- a/src/Application.php
+++ b/src/Application.php
@@ -43,6 +43,7 @@ class Application extends BaseApplication
 
         $this->addPlugin('Acl');
         $this->addPlugin('Queue', ['bootstrap' => true]);
+        $this->addPlugin('AssetCompress');
     }
 
     /**

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -69,6 +69,7 @@ class AppController extends Controller
     );
 
     public $helpers = array(
+        'AssetCompress.AssetCompress',
         'Sentences',
         'Comments',
         'Date',

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -1239,7 +1239,7 @@ class SentencesTable extends Table
             $dirtyArray = explode("_", $sentenceId);
 
             return [
-                'id' => $dirtyArray[1],
+                'id' => (int)$dirtyArray[1],
                 'lang' => $dirtyArray[0]
             ];
         }

--- a/src/Template/Element/language_dropdown.ctp
+++ b/src/Template/Element/language_dropdown.ctp
@@ -1,5 +1,4 @@
 <?
-$this->Html->script(JS_PATH . 'directives/language-dropdown.dir.js', array('block' => 'scriptBottom'));
 $languagesJSON = htmlspecialchars(json_encode($languages), ENT_QUOTES, 'UTF-8');
 $selectedLanguage = isset($selectedLanguage) ? $selectedLanguage : '';
 $placeholder = isset($placeholder) ? $placeholder : __('Select a language');

--- a/src/Template/Element/search_bar.ctp
+++ b/src/Template/Element/search_bar.ctp
@@ -27,8 +27,6 @@
 
 use Cake\Core\Configure;
 
-$this->Html->script(JS_PATH . 'elements/search-bar.ctrl.js', array('block' => 'scriptBottom'));
-
 $searchQuery = h($searchQuery);
 ?>
 

--- a/src/Template/Element/short_description.ctp
+++ b/src/Template/Element/short_description.ctp
@@ -24,8 +24,6 @@
 * @license  Affero General Public License
 * @link     http://tatoeba.org
 */
-
-$this->Html->script(JS_PATH . 'elements/search-bar.ctrl.js', array('block' => 'scriptBottom'));
 ?>
 
 <div class="topContent">

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -53,7 +53,10 @@ use Cake\Core\Configure;
         $controller = $this->request->getParam("controller");
         $controller = Cake\Utility\Inflector::delimit($controller);
         $action = $this->request->getParam("action");
-        echo $this->Html->css(CSS_PATH . $controller."/".$action .".css");
+        $specificCSS = CSS_PATH . "$controller/$action.css";
+        if (file_exists(Configure::read('App.cssBaseUrl') . $specificCSS)) {
+            echo $this->Html->css($specificCSS);
+        }
 
         echo $this->element('seo_international_targeting');
     ?>

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -122,19 +122,8 @@ use Cake\Core\Configure;
     echo $this->element('foot');
     echo $this->element('sql_dump');
 
-    echo $this->Html->script(JS_PATH . 'jquery-1.11.3.min.js');
-    echo $this->Html->script(JS_PATH . 'angular/angular.min.js');
-    echo $this->Html->script(JS_PATH . 'angular/angular-animate.min.js');
-    echo $this->Html->script(JS_PATH . 'angular/angular-aria.min.js');
-    echo $this->Html->script(JS_PATH . 'angular/angular-material.min.js');
-    echo $this->Html->script(JS_PATH . 'angular/angular-messages.min.js');
-    echo $this->Html->script(JS_PATH . 'watch.js');
-    echo $this->Html->script(JS_PATH . 'responsive/app.module.js');
-
-    echo $this->Html->script(JS_PATH . 'generic_functions.js');
-    // Source: https://github.com/jonathantneal/svg4everybody
-    // This is needed to make "fill: currentColor" work on every browser.
-    echo $this->Html->script(JS_PATH . 'svg4everybody.min.js');
+    // layout.js is defined in config/asset_compress.ini
+    echo $this->AssetCompress->script('layout.js');
 
     echo $this->fetch('scriptBottom');
 

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -53,7 +53,7 @@ use Cake\Core\Configure;
         $controller = $this->request->getParam("controller");
         $controller = Cake\Utility\Inflector::delimit($controller);
         $action = $this->request->getParam("action");
-        $specificCSS = CSS_PATH . "$controller/$action.css";
+        $specificCSS = "$controller/$action.css";
         if (file_exists(Configure::read('App.cssBaseUrl') . $specificCSS)) {
             echo $this->Html->css($specificCSS);
         }

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -46,9 +46,8 @@ use Cake\Core\Configure;
         // the name of the controller.
 
         // Generic
-        echo $this->Html->css(CSS_PATH . 'angular-material.min.css');
-        echo $this->Html->css(CSS_PATH . 'layouts/default.css');
-        echo $this->Html->css(CSS_PATH . 'layouts/elements.css');
+        // layout.css is defined in config/asset_compress.ini
+        echo $this->AssetCompress->css('layout.css');
 
         // Specific
         $controller = $this->request->getParam("controller");

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -131,24 +131,22 @@ use Cake\Core\Configure;
     echo $this->Html->script(JS_PATH . 'watch.js');
     echo $this->Html->script(JS_PATH . 'responsive/app.module.js');
 
-    $scriptOptions = array('block' => 'scriptBottom');
-
-    $this->Html->script(JS_PATH . 'generic_functions.js', $scriptOptions);
+    echo $this->Html->script(JS_PATH . 'generic_functions.js');
     // Source: https://github.com/jonathantneal/svg4everybody
     // This is needed to make "fill: currentColor" work on every browser.
-    $this->Html->script(JS_PATH . 'svg4everybody.min.js', $scriptOptions);
+    echo $this->Html->script(JS_PATH . 'svg4everybody.min.js');
+
+    echo $this->fetch('scriptBottom');
 
     if (CurrentUser::getSetting('copy_button')) {
-        $this->Html->script(JS_PATH . 'clipboard.min.js', $scriptOptions);
-        $this->Html->script(JS_PATH . 'sentences.copy.js', $scriptOptions);
+        echo $this->Html->script(JS_PATH . 'clipboard.min.js');
+        echo $this->Html->script(JS_PATH . 'sentences.copy.js');
     }
 
     if (Configure::read('Announcement.enabled') || Configure::read('Tatoeba.devStylesheet')) {
-        $this->Html->script(JS_PATH . 'jquery.cookie.js', $scriptOptions);
-        $this->Html->script(JS_PATH . 'announcement.js', $scriptOptions);
+        echo $this->Html->script(JS_PATH . 'jquery.cookie.js');
+        echo $this->Html->script(JS_PATH . 'announcement.js');
     }
-
-    echo $this->fetch('scriptBottom');
 
     if (Configure::read('GoogleAnalytics.enabled')) {
         echo $this->element('google_analytics', array('cache' => true));

--- a/src/Template/Sentences/add.ctp
+++ b/src/Template/Sentences/add.ctp
@@ -28,7 +28,7 @@ use App\Model\CurrentUser;
 
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Add sentences')));
 
-$this->Sentences->javascriptForAJAXSentencesGroup(false);
+$this->Sentences->javascriptForAJAXSentencesGroup();
 $this->Html->script(JS_PATH . 'sentences.contribute.js', ['block' => 'scriptBottom']);
 
 $vocabularyUrl = $this->Url->build(array(

--- a/src/Template/Sentences/random.ctp
+++ b/src/Template/Sentences/random.ctp
@@ -25,8 +25,6 @@
  * @link     http://tatoeba.org
  */
 
-
-$this->Sentences->javascriptForAJAXSentencesGroup();
 if (is_null($random)) {
    echo $this->Html->tag('p', format(__('An error occurred while fetching the random sentence. '.
                                   'If this persists, please <a href="{}">let us know</a>.', true),

--- a/src/Template/Sentences/show.ctp
+++ b/src/Template/Sentences/show.ctp
@@ -26,7 +26,6 @@
  */
 use App\Model\CurrentUser;
 
-$this->Sentences->javascriptForAJAXSentencesGroup(false);
 $this->Html->script('jquery.scrollTo.min.js', ['block' => 'scriptBottom']);
 
 if (!isset($searchProblem)) {

--- a/src/Template/Sentences/translations_group.ctp
+++ b/src/Template/Sentences/translations_group.ctp
@@ -17,8 +17,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-$this->Sentences->javascriptForAJAXTranslationsGroup();
-
 if (!$saved) {
 ?>
 <div id="_<?php echo $sentenceId ?>_message" class="error"><?php echo htmlentities($message) ?></div>

--- a/src/Template/SentencesLists/show.ctp
+++ b/src/Template/SentencesLists/show.ctp
@@ -27,7 +27,7 @@
 use App\Model\CurrentUser;
 use App\Model\Entity\SentencesList;
 
-$this->Sentences->javascriptForAJAXSentencesGroup(false);
+$this->Sentences->javascriptForAJAXSentencesGroup();
 $this->Html->script(
     JS_PATH . 'sentences_lists.remove_sentence_from_list.js', array('block' => 'scriptBottom')
 );

--- a/src/Template/SentencesLists/show.ctp
+++ b/src/Template/SentencesLists/show.ctp
@@ -28,6 +28,9 @@ use App\Model\CurrentUser;
 use App\Model\Entity\SentencesList;
 
 $this->Sentences->javascriptForAJAXSentencesGroup(false);
+$this->Html->script(
+    JS_PATH . 'sentences_lists.remove_sentence_from_list.js', array('block' => 'scriptBottom')
+);
 
 $listCount = $this->Paginator->param('count');
 $listId = $list['id'];

--- a/src/View/Helper/ListsHelper.php
+++ b/src/View/Helper/ListsHelper.php
@@ -448,7 +448,6 @@ class ListsHelper extends AppHelper
 
 
     private function _displayRemoveButton($sentenceId) {
-        $this->Sentences->javascriptForAJAXSentencesGroup(false);
         $this->Html->script(
             JS_PATH . 'sentences_lists.remove_sentence_from_list.js', array('block' => 'scriptBottom')
         );

--- a/src/View/Helper/ListsHelper.php
+++ b/src/View/Helper/ListsHelper.php
@@ -448,9 +448,6 @@ class ListsHelper extends AppHelper
 
 
     private function _displayRemoveButton($sentenceId) {
-        $this->Html->script(
-            JS_PATH . 'sentences_lists.remove_sentence_from_list.js', array('block' => 'scriptBottom')
-        );
         ?>
         <span class="removeFromList">
 

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -95,9 +95,7 @@ class MenuHelper extends AppHelper
             echo '</a>';
 
         } else if ($isLogged) {
-            $this->Html->script('sentences.add_translation.js', array('block' => 'scriptBottom'));
             $this->Html->script('jquery.jeditable.js', array('block' => 'scriptBottom'));
-            $this->Html->script('sentences.edit_in_place.js', array('block' => 'scriptBottom'));
             ?>
             <a><?php echo $translateButton;?></a>
            <?php
@@ -170,7 +168,6 @@ class MenuHelper extends AppHelper
             $svgIconOptions['class'] .= ' adopt-item uneditable';
             $contents = $this->Images->svgIcon($image, $svgIconOptions);
         } else {
-            $this->Html->script('sentences.adopt.js', array('block' => 'scriptBottom'));
             $contents = $this->Images->svgIcon($image, $svgIconOptions);
             $contents = '<a class="adopt-item adopt-button">'.$contents.'</a>';
         }
@@ -235,7 +232,6 @@ class MenuHelper extends AppHelper
         ));
 
         if ($isLogged) {
-            $this->Html->script('favorites.add.js', array('block' => 'scriptBottom'));
             ?>
             <a><?php echo $favoriteImage;?></a>
             <?php
@@ -299,7 +295,6 @@ class MenuHelper extends AppHelper
         ?>
         </li>
         <?php
-        $this->Html->script('sentences.link.js', array('block' => 'scriptBottom'));
     }
 
     /**
@@ -356,8 +351,6 @@ class MenuHelper extends AppHelper
         if (!$isLogged) {
             return;
         }
-
-        $this->Html->script('sentences_lists.menu.js', array('block' => 'scriptBottom'));
 
         $SentencesLists = TableRegistry::getTableLocator()->get('SentencesLists');
         $lists = $SentencesLists->getUserChoices(
@@ -539,8 +532,6 @@ class MenuHelper extends AppHelper
 
     public function correctnessButton($sentenceId)
     {
-        $this->Html->script('collections.add_remove.js', array('block' => 'scriptBottom'));
-
         $userCorrectness = CurrentUser::correctnessForSentence($sentenceId);
 
         $icons = array(

--- a/src/View/Helper/SentenceButtonsHelper.php
+++ b/src/View/Helper/SentenceButtonsHelper.php
@@ -90,8 +90,6 @@ class SentenceButtonsHelper extends AppHelper
      */
     public function unlinkButton($sentenceId, $translationId, $langFilter = 'und')
     {
-        $this->Html->script('links.add_and_delete.js', array('block' => 'scriptBottom'));
-
         $elementId = 'link_'.$sentenceId.'_'.$translationId;
 
         $image = $this->Images->svgIcon(
@@ -133,8 +131,6 @@ class SentenceButtonsHelper extends AppHelper
      */
     public function linkButton($sentenceId, $translationId, $langFilter = 'und')
     {
-        $this->Html->script('links.add_and_delete.js', array('block' => 'scriptBottom'));
-
         $elementId = 'link_'.$sentenceId.'_'.$translationId;
 
         $image = $this->Images->svgIcon(
@@ -229,7 +225,6 @@ class SentenceButtonsHelper extends AppHelper
     {
         $class = '';
         if ($editable) {
-            $this->Html->script('sentences.change_language.js', array('block' => 'scriptBottom'));
             $class = 'editableFlag';
 
             // language select

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -746,15 +746,7 @@ class SentencesHelper extends AppHelper
             $this->Html->script('clipboard.min.js', $options);
             $this->Html->script('sentences.copy.js', $options);
         }
-        $this->javascriptForAJAXTranslationsGroup($inline);
-    }
 
-    public function javascriptForAJAXTranslationsGroup($inline = true) {
-        if($inline) {
-            $options = [];
-        } else {
-            $options = array('block' => 'scriptBottom');
-        }
         $this->Html->script('sentences.play_audio.js', $options);
         $this->Html->script('links.add_and_delete.js', $options);
         $this->Html->script('sentences.logs.js', $options);

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -57,6 +57,7 @@ use Cake\Utility\Hash;
 class SentencesHelper extends AppHelper
 {
     public $helpers = array(
+        'AssetCompress.AssetCompress',
         'Html',
         'Form',
         'SentenceButtons',
@@ -90,6 +91,11 @@ class SentencesHelper extends AppHelper
         $options = array(),
         $duplicate = false
     ) {
+        if (CurrentUser::isMember()) {
+            // defined in config/asset_compress.ini
+            $this->AssetCompress->script('sentences-block-for-members.js', ['block' => 'scriptBottom']);
+        }
+
         $options = array_merge(
             array(
                 'withAudio' => true,
@@ -731,24 +737,17 @@ class SentencesHelper extends AppHelper
         } else {
             $options = array('block' => 'scriptBottom');
         }
-        $this->Html->script('sentences.add_translation.js', $options);
-        $this->Html->script('favorites.add.js', $options);
-        $this->Html->script('sentences_lists.menu.js', $options);
-        $this->Html->script('sentences.adopt.js', $options);
+        // defined in config/asset_compress.ini
+        $this->AssetCompress->script('sentences-block-for-members.js', $options);
         $this->Html->script('jquery.jeditable.js', $options);
-        $this->Html->script('sentences.edit_in_place.js', $options);
         $this->Html->script('transcriptions.js', $options);
-        $this->Html->script('sentences.change_language.js', $options);
-        $this->Html->script('sentences.link.js', $options);
         $this->Html->script('sentences.collapse.js', $options);
-        $this->Html->script('collections.add_remove.js', $options);
         if (CurrentUser::getSetting('copy_button')) {
             $this->Html->script('clipboard.min.js', $options);
             $this->Html->script('sentences.copy.js', $options);
         }
 
         $this->Html->script('sentences.play_audio.js', $options);
-        $this->Html->script('links.add_and_delete.js', $options);
         $this->Html->script('sentences.logs.js', $options);
         $this->Html->script('transcriptions.js', $options);
     }

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -727,16 +727,13 @@ class SentencesHelper extends AppHelper
     }
 
     /**
-     * Inline Javascript for AJAX loaded sentences group.
+     * Javascript for AJAX loaded sentences group.
      *
      * @return void
      */
-    public function javascriptForAJAXSentencesGroup($inline = true) {
-        if($inline) {
-            $options = [];
-        } else {
-            $options = array('block' => 'scriptBottom');
-        }
+    public function javascriptForAJAXSentencesGroup() {
+        $options = ['block' => 'scriptBottom'];
+
         // defined in config/asset_compress.ini
         $this->AssetCompress->script('sentences-block-for-members.js', $options);
         $this->Html->script('jquery.jeditable.js', $options);

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -749,7 +749,6 @@ class SentencesHelper extends AppHelper
 
         $this->Html->script('sentences.play_audio.js', $options);
         $this->Html->script('sentences.logs.js', $options);
-        $this->Html->script('transcriptions.js', $options);
     }
 
 

--- a/src/View/Helper/TagsHelper.php
+++ b/src/View/Helper/TagsHelper.php
@@ -59,7 +59,6 @@ class TagsHelper extends AppHelper
      */
     public function displayTagsModule($tagsArray, $sentenceId = null, $sentenceLang = null)
     {
-        $this->Html->script('autocompletion.js', ['block' => 'scriptBottom']);
         ?>
 
         <div class="module">
@@ -186,6 +185,7 @@ class TagsHelper extends AppHelper
     public function displayAddTagForm($sentenceId = null)
     {
         $this->Html->script('tags.add.js', ['block' => 'scriptBottom']);
+        $this->Html->script('autocompletion.js', ['block' => 'scriptBottom']);
 
         echo $this->Form->create('Tag', [
             'id' => 'tag-form',

--- a/src/View/Helper/TranscriptionsHelper.php
+++ b/src/View/Helper/TranscriptionsHelper.php
@@ -104,7 +104,6 @@ class TranscriptionsHelper extends AppHelper
         $lang,
         $sentenceOwnerId
     ) {
-        $this->Html->script('jquery.jeditable.js', ['block' => 'scriptBottom']);
         $this->Html->script('transcriptions.js', ['block' => 'scriptBottom']);
 
         $canEdit = CurrentUser::canEditTranscription(
@@ -226,6 +225,7 @@ class TranscriptionsHelper extends AppHelper
             return $this->Html->tag('li', '', array('class' => 'option'));
         }
 
+        $this->Html->script('jquery.jeditable.js', ['block' => 'scriptBottom']);
         $editImage = $this->Images->svgIcon('edit', array(
             'width'  => 16,
             'height' => 16,

--- a/tests/Fixture/PrivateMessagesFixture.php
+++ b/tests/Fixture/PrivateMessagesFixture.php
@@ -22,7 +22,7 @@ class PrivateMessagesFixture extends TestFixture {
 		'folder' => ['type' => 'string', 'null' => false, 'default' => 'Inbox', 'collate' => 'utf8_general_ci', 'charset' => 'utf8'],
 		'title' => ['type' => 'string', 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'],
 		'content' => ['type' => 'text', 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'],
-		'isnonread' => ['type' => 'integer', 'null' => false, 'default' => '1', 'length' => 4, 'unsigned' => false],
+		'isnonread' => ['type' => 'boolean', 'null' => false, 'default' => '1', 'length' => 4, 'unsigned' => false],
 		'draft_recpts' => ['type' => 'string', 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'],
 		'sent' => ['type' => 'integer', 'null' => false, 'default' => '1', 'length' => 4, 'unsigned' => false],
 		'_indexes' => [

--- a/tests/TestCase/Controller/UserControllerTest.php
+++ b/tests/TestCase/Controller/UserControllerTest.php
@@ -58,10 +58,6 @@ class UserControllerTest extends IntegrationTestCase
         $this->fail("Failed to assert that password of user '$username' $what");
     }
 
-    private function assertFlashMessage($message) {
-        $this->assertSession($message, 'Flash.flash.0.message');
-    }
-
     public function testSavePassword_changesPassword() {
         $username = 'contributor';
         $oldPassword = '123456';

--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -20,12 +20,12 @@
     font-family: 'Material Icons';
     font-style: normal;
     font-weight: 400;
-    src: url(../fonts/MaterialIcons-Regular.eot); /* For IE6-8 */
+    src: url(/css/fonts/MaterialIcons-Regular.eot); /* For IE6-8 */
     src: local('Material Icons'),
     local('MaterialIcons-Regular'),
-    url(../fonts/MaterialIcons-Regular.woff2) format('woff2'),
-    url(../fonts/MaterialIcons-Regular.woff) format('woff'),
-    url(../fonts/MaterialIcons-Regular.ttf) format('truetype');
+    url(/css/fonts/MaterialIcons-Regular.woff2) format('woff2'),
+    url(/css/fonts/MaterialIcons-Regular.woff) format('woff'),
+    url(/css/fonts/MaterialIcons-Regular.ttf) format('truetype');
 }
 
 .material-icons {

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -28,103 +28,101 @@
     function languageDropdown() {
         return {
             scope: true,
-            controller: LanguageDropdownController,
-            controllerAs: 'vm'
-        };
-    }
+            controllerAs: 'vm',
+            controller: ['$scope', function($scope) {
+                var vm = this;
+                var languages = [];
+                var name = '';
 
-    function LanguageDropdownController($scope) {
-        var vm = this;
-        var languages = [];
-        var name = '';
-
-        vm.previousSelectedItem = languages[0];
-        vm.selectedItem = null;
-        vm.searchText = '';
-
-        vm.init = init;
-        vm.querySearch = querySearch;
-        vm.onSelectedItemChange = onSelectedItemChange;
-        vm.onSearchTextChange = onSearchTextChange;
-        vm.onBlur = onBlur;
-        vm.onFocus = onFocus;
-
-        /////////////////////////////////////////////////////////////////////////
-
-        $scope.$on('setLang', function(event, data){
-            if (data.name && data.name === name) {
-                setLang(data.lang);
-            }
-        });
-
-        /////////////////////////////////////////////////////////////////////////
-
-        function init(data, selectedLang, dropdownName) {
-            var isPriority;
-            name = dropdownName;
-            
-            Object.keys(data).forEach(function (key1) {
-                if (typeof data[key1] === 'object'){
-                    var items = data[key1];
-                    isPriority = !isPriority && key1 !== '0';
-                    Object.keys(items).forEach(function (key2) {
-                        languages.push({code: key2, name: items[key2], isPriority: isPriority});
-                    });
-                } else {
-                    languages.push({code: key1, name: data[key1]});
-                }
-            });
-
-            if (selectedLang) {
-                setLang(selectedLang);
-            }
-        }
-
-        function querySearch(value) {
-            if (value) {
-                var search = value.toLowerCase();
-                return languages.filter(function (item) {
-                    var language = item.name.toLowerCase();
-                    return language.indexOf(search) > -1;
-                }).sort(function(itemA, itemB) {
-                    var nameA = itemA.name.toLowerCase();
-                    var nameB = itemB.name.toLowerCase();
-                    return nameA.indexOf(search) > nameB.indexOf(search);
-                });
-            } else {
-                return languages;
-            }
-        }
-
-        function onSelectedItemChange(item) {
-            if (vm.selectedItem) {
-                $scope.$parent.$broadcast('languageChange', {name: name, lang: vm.selectedItem.code});
-            }            
-        }
-
-        function setLang(lang) {
-            vm.selectedItem = languages.find(function (item) {
-                return item.code === lang;
-            });
-            $scope.$parent.$broadcast('languageChange', {name: name, lang: lang});
-        }
-
-        function onSearchTextChange() {
-            vm.searchText = vm.searchText.replace(/\t/, ' ');
-        }
-
-        function onBlur() {
-            if (!vm.selectedItem) {
-                vm.selectedItem = vm.previousSelectedItem;
-            }
-        }
-
-        function onFocus() {
-            if (vm.selectedItem) {
-                vm.previousSelectedItem = vm.selectedItem;
+                vm.previousSelectedItem = languages[0];
+                vm.selectedItem = null;
                 vm.searchText = '';
-            }
-        }
+
+                vm.init = init;
+                vm.querySearch = querySearch;
+                vm.onSelectedItemChange = onSelectedItemChange;
+                vm.onSearchTextChange = onSearchTextChange;
+                vm.onBlur = onBlur;
+                vm.onFocus = onFocus;
+
+                /////////////////////////////////////////////////////////////////////////
+
+                $scope.$on('setLang', function(event, data){
+                    if (data.name && data.name === name) {
+                        setLang(data.lang);
+                    }
+                });
+
+                /////////////////////////////////////////////////////////////////////////
+
+                function init(data, selectedLang, dropdownName) {
+                    var isPriority;
+                    name = dropdownName;
+                    
+                    Object.keys(data).forEach(function (key1) {
+                        if (typeof data[key1] === 'object'){
+                            var items = data[key1];
+                            isPriority = !isPriority && key1 !== '0';
+                            Object.keys(items).forEach(function (key2) {
+                                languages.push({code: key2, name: items[key2], isPriority: isPriority});
+                            });
+                        } else {
+                            languages.push({code: key1, name: data[key1]});
+                        }
+                    });
+
+                    if (selectedLang) {
+                        setLang(selectedLang);
+                    }
+                }
+
+                function querySearch(value) {
+                    if (value) {
+                        var search = value.toLowerCase();
+                        return languages.filter(function (item) {
+                            var language = item.name.toLowerCase();
+                            return language.indexOf(search) > -1;
+                        }).sort(function(itemA, itemB) {
+                            var nameA = itemA.name.toLowerCase();
+                            var nameB = itemB.name.toLowerCase();
+                            return nameA.indexOf(search) > nameB.indexOf(search);
+                        });
+                    } else {
+                        return languages;
+                    }
+                }
+
+                function onSelectedItemChange(item) {
+                    if (vm.selectedItem) {
+                        $scope.$parent.$broadcast('languageChange', {name: name, lang: vm.selectedItem.code});
+                    }            
+                }
+
+                function setLang(lang) {
+                    vm.selectedItem = languages.find(function (item) {
+                        return item.code === lang;
+                    });
+                    $scope.$parent.$broadcast('languageChange', {name: name, lang: lang});
+                }
+
+                function onSearchTextChange() {
+                    vm.searchText = vm.searchText.replace(/\t/, ' ');
+                }
+
+                function onBlur() {
+                    if (!vm.selectedItem) {
+                        vm.selectedItem = vm.previousSelectedItem;
+                    }
+                }
+
+                function onFocus() {
+                    if (vm.selectedItem) {
+                        vm.previousSelectedItem = vm.selectedItem;
+                        vm.searchText = '';
+                    }
+                }
+            }]
+        };
     }
 
 })();

--- a/webroot/js/elements/search-bar.ctrl.js
+++ b/webroot/js/elements/search-bar.ctrl.js
@@ -19,45 +19,43 @@
 
     angular
         .module('app')
-        .controller('SearchBarController', SearchBarController);
+        .controller('SearchBarController', ['$scope', function($scope) {
+            var vm = this;
 
-    function SearchBarController($scope) {
-        var vm = this;
+            vm.searchQuery = angular.element('#SentenceQuery').data('query');
+            vm.langFrom = '';
+            vm.langTo = '';
+            
+            vm.clearSearch = clearSearch;
+            vm.swapLanguages = swapLanguages;
 
-        vm.searchQuery = angular.element('#SentenceQuery').data('query');
-        vm.langFrom = '';
-        vm.langTo = '';
-        
-        vm.clearSearch = clearSearch;
-        vm.swapLanguages = swapLanguages;
+            ///////////////////////////////////////////////////////////////////////////
 
-        ///////////////////////////////////////////////////////////////////////////
+            $scope.$on('languageChange', function(event, data){
+                if (data.name === 'from') {
+                    vm.langFrom = data.lang;
+                }
+                if (data.name === 'to') {
+                    vm.langTo = data.lang;
+                }
+            });
 
-        $scope.$on('languageChange', function(event, data){
-            if (data.name === 'from') {
-                vm.langFrom = data.lang;
+            $scope.$on('langToChange', function(event, data){
+                vm.langTo = data;
+            });
+
+            ///////////////////////////////////////////////////////////////////////////
+
+            function clearSearch() {
+                vm.searchQuery = '';
+                angular.element('#SentenceQuery').focus();
             }
-            if (data.name === 'to') {
-                vm.langTo = data.lang;
+
+            function swapLanguages() {
+                var newLangFrom = vm.langTo;
+                var newLangTo = vm.langFrom;
+                $scope.$broadcast('setLang', { name: 'from', lang: newLangFrom});
+                $scope.$broadcast('setLang', { name: 'to', lang: newLangTo});
             }
-        });
-
-        $scope.$on('langToChange', function(event, data){
-            vm.langTo = data;
-        });
-
-        ///////////////////////////////////////////////////////////////////////////
-
-        function clearSearch() {
-            vm.searchQuery = '';
-            angular.element('#SentenceQuery').focus();
-        }
-
-        function swapLanguages() {
-            var newLangFrom = vm.langTo;
-            var newLangTo = vm.langFrom;
-            $scope.$broadcast('setLang', { name: 'from', lang: newLangFrom});
-            $scope.$broadcast('setLang', { name: 'to', lang: newLangTo});
-        }
-    }
+        }]);
 })();

--- a/webroot/js/responsive/app.module.js
+++ b/webroot/js/responsive/app.module.js
@@ -3,7 +3,7 @@
 
     angular
         .module('app', ['ngMaterial', 'ngMessages'])
-        .config(function($mdThemingProvider, $mdIconProvider, $httpProvider) {
+        .config(['$mdThemingProvider', '$mdIconProvider', '$httpProvider', function($mdThemingProvider, $mdIconProvider, $httpProvider) {
             $mdThemingProvider.theme('default')
                 .primaryPalette('green')
                 .accentPalette('grey')
@@ -18,5 +18,5 @@
                 'application/x-www-form-urlencoded; charset=UTF-8';
             $httpProvider.defaults.headers.common['X-Requested-With'] =
                 'XMLHttpRequest';
-        });
+        }]);
 })();


### PR DESCRIPTION
This PR is an attempt to minify JS and CSS files (#248), and to reduce the number of requests needed to load pages. So far, only some of the JS and CSS files are minified (see the file `config/asset_compress.ini`).

Note that this PR updates CakePHP to 3.7 because it was a required dependency of the minifying plugin I used.

Steps needed when putting this on production:
* Add a line `cake asset_compress build` in `create-new-prod-folder.sh` before running it
* Run `docs/database/updates/2019-03-02.sql`