### PR TITLE
Remove ng-cloak from <body>

### DIFF
--- a/src/Template/Element/language_dropdown.ctp
+++ b/src/Template/Element/language_dropdown.ctp
@@ -11,6 +11,7 @@ $this->Form->unlockField($name);
      title="{{vm.selectedItem.name}}">
      <?= $this->Form->hidden($name, array('value' => '{{vm.selectedItem.code}}')); ?>
     <md-autocomplete
+        ng-cloak
 <? if (isset($id)): ?>
         md-input-id="<?= $id ?>"
 <? endif; ?>

--- a/src/Template/Element/logs/log_entry.ctp
+++ b/src/Template/Element/logs/log_entry.ctp
@@ -54,8 +54,6 @@ $langDir = LanguagesLib::getLanguageDirection($langCode);
         $langCode,
         array(
             'ng-cloak' => true,
-            'width' => 30,
-            'height' => 20,
             'class' => 'md-secondary lang'
         )
     );

--- a/src/Template/Element/logs/log_entry.ctp
+++ b/src/Template/Element/logs/log_entry.ctp
@@ -53,6 +53,7 @@ $langDir = LanguagesLib::getLanguageDirection($langCode);
     echo $this->Languages->icon(
         $langCode,
         array(
+            'ng-cloak' => true,
             'width' => 30,
             'height' => 20,
             'class' => 'md-secondary lang'
@@ -73,7 +74,7 @@ $langDir = LanguagesLib::getLanguageDirection($langCode);
         </div>
         <p><?= $infoLabel ?></p>
     </div>
-    <md-button class="md-secondary md-icon-button" href="<?= $sentenceUrl ?>">
+    <md-button ng-cloak class="md-secondary md-icon-button" href="<?= $sentenceUrl ?>">
         <md-icon>info</md-icon>
     </md-button>
 </md-list-item>

--- a/src/Template/Element/messages/comment.ctp
+++ b/src/Template/Element/messages/comment.ctp
@@ -147,7 +147,8 @@ if ($sentenceOwnerLink) {
                 $confirmation = 'onclick="return confirm(\''.$msg.'\');"';
             }
             ?>
-            <md-button class="md-icon-button" <?= $confirmation ?>
+            <md-button ng-cloak
+                       class="md-icon-button" <?= $confirmation ?>
                        href="<?= $this->Url->build($menuItem['url']) ?>"
                        aria-label="<?= $itemLabel ?>">
                 <md-icon><?= $menuItem['icon'] ?></md-icon>

--- a/src/Template/Element/messages/comment.ctp
+++ b/src/Template/Element/messages/comment.ctp
@@ -90,7 +90,7 @@ if ($sentenceOwnerLink) {
 ?>
 
 <? if (!isset($hideSentence) || !$hideSentence) { ?>
-<div class="comment sentence" md-whiteframe="2">
+<div class="comment sentence md-whiteframe-1dp">
     <div class="info">
         <?= format(
             $sentenceInfoLabel,

--- a/src/Template/Element/messages/comment.ctp
+++ b/src/Template/Element/messages/comment.ctp
@@ -108,13 +108,14 @@ if ($sentenceOwnerLink) {
         echo $this->Languages->icon(
             $sentenceLang,
             array(
+                'ng-cloak' => true,
                 'width' => 30,
                 'height' => 20,
                 'class' => 'lang'
             )
         );
         ?>
-        <md-button class="md-icon-button" href="<?= $sentenceUrl ?>">
+        <md-button ng-cloak class="md-icon-button" href="<?= $sentenceUrl ?>">
             <md-icon>info</md-icon>
         </md-button>
     </div>

--- a/src/Template/Element/messages/comment.ctp
+++ b/src/Template/Element/messages/comment.ctp
@@ -109,8 +109,6 @@ if ($sentenceOwnerLink) {
             $sentenceLang,
             array(
                 'ng-cloak' => true,
-                'width' => 30,
-                'height' => 20,
                 'class' => 'lang'
             )
         );

--- a/src/Template/Element/search_bar.ctp
+++ b/src/Template/Element/search_bar.ctp
@@ -50,7 +50,8 @@ echo $this->Form->create(
     )
 );
 ?>
-<div layout-gt-sm="row" layout-align-gt-sm="center end" layout-margin
+<div ng-cloak
+     layout-gt-sm="row" layout-align-gt-sm="center end" layout-margin
      layout="column" layout-align="center center">
     <div layout="column" flex>
         <div layout="row" layout-align="end center" class="search-bar-extra">

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -67,13 +67,7 @@ if (isset($sentence->highlight)) {
              layout="row" layout-align="start center">
             <div class="lang">
                 <?
-                echo $this->Languages->icon(
-                    $sentence->lang,
-                    array(
-                        'width' => 30,
-                        'height' => 20
-                    )
-                );
+                echo $this->Languages->icon($sentence->lang);
                 ?>
             </div>
             <div class="text" flex

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -30,7 +30,10 @@ if (isset($sentence->highlight)) {
 }
 
 ?>
-<div sentence-and-translations class="sentence-and-translations" md-whiteframe="1">
+<div ng-cloak
+     sentence-and-translations
+     class="sentence-and-translations"
+     md-whiteframe="1">
     <div layout="column">
         <md-subheader>
             <?

--- a/src/Template/Element/short_description.ctp
+++ b/src/Template/Element/short_description.ctp
@@ -116,7 +116,7 @@ $this->Html->script(JS_PATH . 'elements/search-bar.ctrl.js', array('block' => 's
 
             <fieldset class="submit">
                 <md-button type="submit" class="search-submit-button md-raised md-primary">
-                    <md-icon>search</md-icon>
+                    <md-icon ng-cloak>search</md-icon>
                 </md-button>
             </fieldset>
 

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -62,7 +62,7 @@ use Cake\Core\Configure;
     <link rel="search" type="application/opensearchdescription+xml"
           href="/opensearch.xml" title="Tatoeba" />
 </head>
-<body ng-app="app" ng-cloak>
+<body ng-app="app">
     <div id="audioPlayer"></div>
 
     <!--  TOP  -->

--- a/src/Template/Sentences/add.ctp
+++ b/src/Template/Sentences/add.ctp
@@ -93,7 +93,8 @@ $vocabularyUrl = $this->Url->build(array(
             echo $this->Form->create('Sentence', [
                 'id' => 'sentence-form',
                 'url' => '/sentences/add_an_other_sentence',
-                'onsubmit' => 'return false'
+                'onsubmit' => 'return false',
+                'ng-cloak' => true,
             ]);
             ?>
 
@@ -175,7 +176,7 @@ $vocabularyUrl = $this->Url->build(array(
         </div>
     </div>
 
-    <div class="section" md-whiteframe="1">
+    <div ng-cloak class="section" md-whiteframe="1">
         <div layout="column" layout-align="center center">
             <? echo __('Check out the vocabulary for which we need sentences'); ?>
             <md-button class="md-primary" href="<?= $vocabularyUrl ?>">

--- a/src/Template/Stats/native_speakers.ctp
+++ b/src/Template/Stats/native_speakers.ctp
@@ -90,9 +90,7 @@ $membersIcons = array(
                 $numContributors = $language->group_4;
                 $total = $language->total;
 
-                $languageIcon = $this->Languages->icon(
-                    $langCode, array('width' => 30, 'height' => 20)
-                );
+                $languageIcon = $this->Languages->icon($langCode);
 
                 $languageName = $this->Languages->codeToNameAlone($langCode);
                 if (empty($langCode)) {

--- a/src/Template/Stats/sentences_by_language.ctp
+++ b/src/Template/Stats/sentences_by_language.ctp
@@ -71,9 +71,7 @@ $max = $stats[0]['sentences'];
         $numSentencesDiv  = '<div class="bar" style="width:'.$percent.'%"></div>';
         $numSentencesDiv .= $numSentences;
 
-        $languageIcon = $this->Languages->icon(
-            $langCode, array('width' => 30, 'height' => 20)
-        );
+        $languageIcon = $this->Languages->icon($langCode);
 
         $langName = $this->Languages->codeToNameAlone($langCode);
         if (empty($langCode)) {

--- a/src/Template/Stats/users_languages.ctp
+++ b/src/Template/Stats/users_languages.ctp
@@ -80,7 +80,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Languages of member
                 );
 
                 echo '<tr>';
-                echo $this->Html->tag('td', $this->Languages->icon($langCode, array()));
+                echo $this->Html->tag('td', $this->Languages->icon($langCode));
                 echo $this->Html->tag('td', $langName);
                 echo $this->Html->tag('td', $language->level_5);
                 echo $this->Html->tag('td', $language->level_4);

--- a/src/Template/User/language.ctp
+++ b/src/Template/User/language.ctp
@@ -50,6 +50,7 @@ $this->set('title_for_layout', h($this->Pages->formatTitle($title)));
         echo $this->Html->tag('h2', $title);
 
         echo $this->Form->create($userLanguage, [
+            'ng-cloak' => true,
             'url' => ['controller' => 'users_languages', 'action' => 'save']
         ]);
         echo $this->Form->hidden('id');

--- a/src/Template/User/profile.ctp
+++ b/src/Template/User/profile.ctp
@@ -359,8 +359,6 @@ $this->set('title_for_layout', h($this->Pages->formatTitle($title)));
                         echo $this->Languages->icon(
                             $langCode,
                             array(
-                                'width' => 30,
-                                'height' => 20,
                                 'class' => 'language-icon'
                             )
                         );

--- a/src/Template/User/profile.ctp
+++ b/src/Template/User/profile.ctp
@@ -151,7 +151,7 @@ $this->set('title_for_layout', h($this->Pages->formatTitle($title)));
                     'action' => 'settings'
                 ));
                 ?>
-                <div layout="row" layout-align="end center">
+                <div ng-cloak layout="row" layout-align="end center">
                     <md-button class="md-primary md-raised"
                                aria-label="<?= __('Edit') ?>"
                                href="<?= $editSettingsUrl ?>">
@@ -168,7 +168,7 @@ $this->set('title_for_layout', h($this->Pages->formatTitle($title)));
 </div>
 
 <div id="main_content">
-    <div id="profile" class="section with-title-button" layout="column" md-whiteframe="1">
+    <div ng-cloak id="profile" class="section with-title-button" layout="column" md-whiteframe="1">
 
         <div layout="row" class="header">
             <div>
@@ -303,7 +303,7 @@ $this->set('title_for_layout', h($this->Pages->formatTitle($title)));
         ?>
     </div>
 
-    <div class="section with-title-button" md-whiteframe="1">
+    <div ng-cloak class="section with-title-button" md-whiteframe="1">
         <div layout="row" layout-align="start center">
             <h2 flex><? echo __('Languages'); ?></h2>
             <?php

--- a/src/Template/User/settings.ctp
+++ b/src/Template/User/settings.ctp
@@ -39,10 +39,11 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
 
 <div id="main_content">
     <div md-whiteframe="1" class="options settings-form">
+        <h2><?php echo __('Options'); ?></h2>
         <?php echo $this->Form->create($userSettings, [
+            'ng-cloak' => true,
             'url' => ['controller' => 'user', 'action' => 'save_settings']
         ]); ?>
-        <h2><?php echo __('Options'); ?></h2>
         <md-list flex role="list" class="flex" >
             <md-subheader><?php echo __('Main options'); ?></md-subheader>
             <md-list-item>
@@ -342,7 +343,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
 
         <?php echo $this->Form->end(); ?>
     </div>
-    <div md-whiteframe="1" class="settings-form">
+    <div ng-cloak md-whiteframe="1" class="settings-form">
         <?php
         echo $this->Form->create($userSettings, [
             'url' => ['controller' => 'user', 'action' => 'save_basic']
@@ -366,7 +367,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
         ?>
     </div>
 
-    <div md-whiteframe="1" class="settings-form">
+    <div ng-cloak md-whiteframe="1" class="settings-form">
         <?php
         echo $this->Form->create($userSettings, [
             'url' => ['controller' => 'user', 'action' => 'save_password']

--- a/src/Template/Users/login.ctp
+++ b/src/Template/Users/login.ctp
@@ -71,7 +71,8 @@ echo $this->Form->create(
 
 ?>
 <div md-whiteframe="1" id="login-form">
-    <h2><? echo __('Log in'); ?></h2>
+  <h2><? echo __('Log in'); ?></h2>
+  <div ng-cloak>
     <md-input-container class="md-block">
         <?php
         echo $this->Form->input(
@@ -123,6 +124,7 @@ echo $this->Form->create(
             <?php echo __('Register'); ?>
         </md-button>
     </div>
+  </div>
 </div>
 <?php
 echo $this->Form->end();

--- a/src/Template/Users/new_password.ctp
+++ b/src/Template/Users/new_password.ctp
@@ -38,14 +38,17 @@
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Send new password')));
 
 $this->Security->enableCSRFProtection();
-echo $this->Form->create('User', array(
-    "url" => array("action" => "new_password")
-));
 ?>
 
 <div md-whiteframe="1" id="reset-form">
     <h2><? echo __('Send new password'); ?></h2>
-        <md-input-container class="md-block">
+    <?
+        echo $this->Form->create('User', array(
+            "ng-cloak" => true,
+            "url" => array("action" => "new_password")
+        ));
+    ?>
+    <md-input-container class="md-block">
         <?php
         echo $this->Form->input(
             'email', array(
@@ -60,9 +63,9 @@ echo $this->Form->create('User', array(
             <?php echo __('Send'); ?>
         </md-button>
     </div>
+    <? echo $this->Form->end(); ?>
 </div>
 
 <?php
-echo $this->Form->end();
 $this->Security->disableCSRFProtection();
 ?>

--- a/src/Template/Users/register.ctp
+++ b/src/Template/Users/register.ctp
@@ -49,15 +49,6 @@ echo $this->Form->create('User', array(
     'ng-controller' => 'UsersRegisterController as ctrl'
 ));
 
-
-echo $this->Form->checkbox(
-    'mask_password',
-    array(
-        'class' => 'ng-hide',
-        'value' => '{{registration.maskPassword}}'
-    )
-);
-
 $lang = Configure::read('Config.language');
 $label = format(
     __('I accept the <a href="{}">terms of use</a>'),

--- a/src/Template/Users/register.ctp
+++ b/src/Template/Users/register.ctp
@@ -58,6 +58,15 @@ echo $this->Form->checkbox(
     )
 );
 
+echo $this->Form->checkbox(
+    'acceptation_terms_of_use',
+    array(
+        'class' => 'ng-hide',
+        'checked' => '{{registration.termsOfUse}}',
+        'value' => '{{registration.termsOfUse ? 1 : 0 }}'
+    )
+);
+
 $lang = Configure::read('Config.language');
 $label = format(
     __('I accept the <a href="{}">terms of use</a>'),
@@ -66,7 +75,6 @@ $label = format(
 ?>
 <h2><? echo __('Register'); ?></h2>
 
-<div ng-cloak>
 <div layout="row" layout-align="center center">
     <md-input-container class="md-icon-float md-icon-left md-block" flex>
         <label for="registrationUsername"><?php echo __('Username'); ?></label>
@@ -251,15 +259,6 @@ $label = format(
     <md-checkbox ng-model="registration.termsOfUse" class="md-primary">
         <?= $label ?>
     </md-checkbox>
-    <? echo $this->Form->checkbox(
-        'acceptation_terms_of_use',
-        array(
-            'class' => 'ng-hide',
-            'class' => 'ng-hide',
-            'checked' => '{{registration.termsOfUse}}',
-            'value' => '{{registration.termsOfUse ? 1 : 0 }}'
-        )
-    ); ?>
 </md-input-container>
 
 <div layout="column">
@@ -267,7 +266,7 @@ $label = format(
         <?php echo __('Register'); ?>
     </md-button>
 </div>
-</div>
+
 
 <?php
 echo $this->Form->end();

--- a/src/Template/Users/register.ctp
+++ b/src/Template/Users/register.ctp
@@ -58,15 +58,6 @@ echo $this->Form->checkbox(
     )
 );
 
-echo $this->Form->checkbox(
-    'acceptation_terms_of_use',
-    array(
-        'class' => 'ng-hide',
-        'checked' => '{{registration.termsOfUse}}',
-        'value' => '{{registration.termsOfUse ? 1 : 0 }}'
-    )
-);
-
 $lang = Configure::read('Config.language');
 $label = format(
     __('I accept the <a href="{}">terms of use</a>'),
@@ -75,6 +66,7 @@ $label = format(
 ?>
 <h2><? echo __('Register'); ?></h2>
 
+<div ng-cloak>
 <div layout="row" layout-align="center center">
     <md-input-container class="md-icon-float md-icon-left md-block" flex>
         <label for="registrationUsername"><?php echo __('Username'); ?></label>
@@ -259,6 +251,15 @@ $label = format(
     <md-checkbox ng-model="registration.termsOfUse" class="md-primary">
         <?= $label ?>
     </md-checkbox>
+    <? echo $this->Form->checkbox(
+        'acceptation_terms_of_use',
+        array(
+            'class' => 'ng-hide',
+            'class' => 'ng-hide',
+            'checked' => '{{registration.termsOfUse}}',
+            'value' => '{{registration.termsOfUse ? 1 : 0 }}'
+        )
+    ); ?>
 </md-input-container>
 
 <div layout="column">
@@ -266,7 +267,7 @@ $label = format(
         <?php echo __('Register'); ?>
     </md-button>
 </div>
-
+</div>
 
 <?php
 echo $this->Form->end();

--- a/src/Template/Vocabulary/add.ctp
+++ b/src/Template/Vocabulary/add.ctp
@@ -33,7 +33,7 @@ $title = __('Add vocabulary items');
 $this->set('title_for_layout', $this->Pages->formatTitle($title));
 ?>
 
-<div id="annexe_content">
+<div ng-cloak id="annexe_content">
     <?php echo $this->element('vocabulary/menu'); ?>
 
     <div class="section" layout="column" md-whiteframe="1">
@@ -52,6 +52,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
     <div class="section" layout="column" md-whiteframe="1">
         <h2><?= $title ?></h2>
         <?= $this->Form->create('Vocabulary', [
+            'ng-cloak' => true,
             'id' => 'add-vocabulary-form',
             'ng-submit' => 'ctrl.add()',
             'url' => ['action' => 'save'],
@@ -100,7 +101,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
 
     </div>
 
-    <div class="section" md-whiteframe="1">
+    <div ng-cloak class="section" md-whiteframe="1">
         <div layout="row">
             <h2 flex><? echo __('Vocabulary items added'); ?></h2>
             <md-progress-circular md-mode="indeterminate"

--- a/src/Template/Vocabulary/add_sentences.ctp
+++ b/src/Template/Vocabulary/add_sentences.ctp
@@ -33,7 +33,7 @@ $title = __('Vocabulary that needs sentences');
 $this->set('title_for_layout', $this->Pages->formatTitle($title));
 ?>
 
-<div id="annexe_content">
+<div ng-cloak id="annexe_content">
     <?php echo $this->element('vocabulary/menu'); ?>
 
     <?php $this->CommonModules->createFilterByLangMod(); ?>

--- a/src/Template/Vocabulary/of.ctp
+++ b/src/Template/Vocabulary/of.ctp
@@ -37,7 +37,7 @@ $title = format(
 $this->set('title_for_layout', $this->Pages->formatTitle($title));
 ?>
 
-<div id="annexe_content">
+<div ng-cloak id="annexe_content">
     <?php echo $this->element('vocabulary/menu'); ?>
 
     <?php $this->CommonModules->createFilterByLangMod(2); ?>

--- a/src/View/Helper/CommentsHelper.php
+++ b/src/View/Helper/CommentsHelper.php
@@ -89,7 +89,7 @@ class CommentsHelper extends AppHelper
             ?>
             </div>
 
-            <div layout="row" layout-align="end center" layout-padding>
+            <div ng-cloak layout="row" layout-align="end center" layout-padding>
                 <md-button type="submit" class="md-raised md-primary">
                     <?php echo __('Submit comment'); ?>
                 </md-button>

--- a/src/View/Helper/LanguagesHelper.php
+++ b/src/View/Helper/LanguagesHelper.php
@@ -381,13 +381,7 @@ class LanguagesHelper extends AppHelper
      */
     function stat($langCode, $numberOfSentences, $link)
     {
-        $flagImage = $this->icon(
-            $langCode,
-            array(
-                'width' => 30,
-                'height' => 20
-            )
-        );
+        $flagImage = $this->icon($langCode);
         $numberOfSentencesHtml = '<span class="total">'.$numberOfSentences.'</span>';
 
         if (empty($langCode)) {
@@ -417,7 +411,7 @@ class LanguagesHelper extends AppHelper
      *
      * @return string
      */
-    public function icon($lang, $options)
+    public function icon($lang, $options = array())
     {
         if (empty($lang)) {
             $lang = 'unknown';
@@ -425,6 +419,8 @@ class LanguagesHelper extends AppHelper
 
         $options["title"] = $this->codeToNameAlone($lang);
         $options["alt"] = $lang;
+        $options["width"] = 30;
+        $options["height"] = 20;
 
         return $this->Html->image(
             IMG_PATH . 'flags/'.$lang.'.png',

--- a/src/View/Helper/MembersHelper.php
+++ b/src/View/Helper/MembersHelper.php
@@ -175,7 +175,7 @@ class MembersHelper extends AppHelper
 
     public function displayLanguageLevel($level)
     {
-        $result = '<div class="languageLevel">';
+        $result = '<div ng-cloak class="languageLevel">';
         $maxLanguageLevel = 5;
         if (isset($level)) {
             for ($i = 0; $i < $maxLanguageLevel; $i++) {

--- a/src/View/Helper/MessagesHelper.php
+++ b/src/View/Helper/MessagesHelper.php
@@ -509,7 +509,6 @@ class MessagesHelper extends AppHelper
                 $sentenceLang,
                 array(
                     "class" => "langIcon",
-                    "width" => 20
                 )
             );
 

--- a/src/View/Helper/PaginationHelper.php
+++ b/src/View/Helper/PaginationHelper.php
@@ -112,6 +112,7 @@ class PaginationHelper extends AppHelper
         <ul class="paging">
             <?php
             $prevIcon = $this->Html->tag('md-icon', 'keyboard_arrow_left', [
+                'ng-cloak' => true,
                 // @translators Appears on “previous page” links
                 // mouseover. Keyboard shortcut is between brackets.
                 'title' => __('Previous page [Ctrl+←]'),
@@ -121,6 +122,7 @@ class PaginationHelper extends AppHelper
             echo $this->Paginator->numbers($numbersOptions);
 
             $nextIcon = $this->Html->tag('md-icon', 'keyboard_arrow_right', [
+                'ng-cloak' => true,
                 // @translators Appears on “next page” links
                 // mouseover. Keyboard shortcut is between brackets.
                 'title' => __('Next page [Ctrl+→]'),

--- a/src/View/Helper/PrivateMessagesHelper.php
+++ b/src/View/Helper/PrivateMessagesHelper.php
@@ -117,7 +117,7 @@ class PrivateMessagesHelper extends AppHelper
             ]);
             ?>
             </div>
-            <div layout="row" layout-align="end center" layout-padding>
+            <div ng-cloak layout="row" layout-align="end center" layout-padding>
                 <md-button type="submit" name="submitType" value="saveDraft" class="md-raised">
                     <?php echo __('Save as draft'); ?>
                 </md-button>

--- a/src/View/Helper/PrivateMessagesHelper.php
+++ b/src/View/Helper/PrivateMessagesHelper.php
@@ -79,14 +79,12 @@ class PrivateMessagesHelper extends AppHelper
 
         <div class="body">
             <div class="pmFields">
-            <div ng-hide="true">
             <?php
             if (!$isReply) {
-                echo $this->Form->input('messageId', array('value' => $pm->id));
+                echo $this->Form->hidden('messageId', array('value' => $pm->id));
             }
-            echo $this->Form->input('submitType', array('value' => ''));
+            echo $this->Form->hidden('submitType', array('value' => ''));
             ?>
-            </div>
             <?php
             echo $this->Form->control('recipients', [
                 'label' => __x('message', 'To'),

--- a/src/View/Helper/PrivateMessagesHelper.php
+++ b/src/View/Helper/PrivateMessagesHelper.php
@@ -84,6 +84,7 @@ class PrivateMessagesHelper extends AppHelper
                 echo $this->Form->hidden('messageId', array('value' => $pm->id));
             }
             echo $this->Form->hidden('submitType', array('value' => ''));
+            $this->Form->unlockField('submitType');
             ?>
             <?php
             echo $this->Form->control('recipients', [

--- a/src/View/Helper/SentenceButtonsHelper.php
+++ b/src/View/Helper/SentenceButtonsHelper.php
@@ -266,8 +266,6 @@ class SentenceButtonsHelper extends AppHelper
             array(
                 "id" => "flag_".$id,
                 "class" => "languageFlag ".$class,
-                "width" => 30,
-                "height" => 20,
                 "data-sentence-id" => $id
             )
         );

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -385,8 +385,6 @@ class SentencesHelper extends AppHelper
             $preSelectedLang,
             array(
                 'class' => 'flag translationLang_flag',
-                'width' => '30',
-                'height' => '20',
                 'style' => $display
             )
         );

--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -747,6 +747,11 @@ md-button {
     vertical-align: middle;
 }
 
+md-icon {
+    overflow: hidden;
+    white-space: nowrap;
+}
+
 .md-button {
     padding: 0 10px;
     font-size: 16px;

--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -347,6 +347,7 @@ rt {
 
 .search_bar {
     min-height: 92px;
+    background-color: #4caf50; /* Material's green */
 }
 
 .search_bar a {

--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -739,6 +739,13 @@ md-toolbar {
     transition: none;
 }
 
+md-button {
+    display: inline-block;
+    margin: 6px 8px;
+    min-height: 36px;
+    min-width: 88px;
+}
+
 .md-button {
     padding: 0 10px;
     font-size: 16px;

--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -744,6 +744,7 @@ md-button {
     margin: 6px 8px;
     min-height: 36px;
     min-width: 88px;
+    vertical-align: middle;
 }
 
 .md-button {

--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -345,6 +345,10 @@ rt {
  * search bar
  */
 
+.search_bar {
+    height: 92px;
+}
+
 .search_bar a {
     color: white;
 }

--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -346,7 +346,7 @@ rt {
  */
 
 .search_bar {
-    height: 92px;
+    min-height: 92px;
 }
 
 .search_bar a {

--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -540,6 +540,7 @@ rt {
     margin: 5px 0;
 }
 #footer .license {
+    display: flex;
     font-size: 15px;
     margin-top: 20px;
 }

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -643,6 +643,7 @@ html[dir="rtl"] .comment.sentence .text {
 .paging {
     margin: 20px 0;
     text-align: center;
+    min-height: 26px;
 }
 
 .paging li {
@@ -652,6 +653,7 @@ html[dir="rtl"] .comment.sentence .text {
 .paging li a {
     padding: 5px 8px;
     margin: 3px;
+    line-height: 24px;
     background: #EEEEEE;
     color: #757575;
 }

--- a/webroot/css/pages/index.css
+++ b/webroot/css/pages/index.css
@@ -58,6 +58,11 @@
     font-size: 24px;
 }
 
+.topContent > md-toolbar {
+    background-color: #4caf50; /* Material's green */
+    color: white;
+}
+
 
 /*
  * Search

--- a/webroot/css/sentences/add.css
+++ b/webroot/css/sentences/add.css
@@ -30,6 +30,10 @@
     min-width: 200px;
 }
 
+#main_content > :first-child {
+    height: 220px;
+}
+
 /*
  * Sentences added
  */


### PR DESCRIPTION
We currently put `ng-cloak` on the `<body>` tag in order to hide unstyled elements during page load. As a result, pages appear as blank while they are loading. This gives a feeling of general slowness of the website.

This PR is an attempt to make pages load faster by:
* removing `ng-cloak` from `<body>`
* dispatching it on specific parts of the pages that really needs to be hidden during load
* providing the hidden parts with basic CSS positioning styles like min-height so that the content is not jumping around when parts hidden with `ng-cloak` get displayed

On most of the pages that have been converted to AngularJS (like /register), everything after the title is hidden during load. On the main page (/), the welcome message is displayed during loading. On pages that are not converted to AngularJS yet (like /sentences/show/<n>), the content is displayed as soon as the page is downloaded.

Another indirect benefit is that CakePHP errors are not hidden by ng-cloak any more.