### PR TITLE
Preview affected sentences on the CC0 switching page

### DIFF
--- a/src/Controller/LicensingController.php
+++ b/src/Controller/LicensingController.php
@@ -85,22 +85,20 @@ class LicensingController extends AppController {
 
         $licensing = new Licensing();
         $isRefreshing = $licensing->is_refreshing($currentUserId);
+        $isSwitching = $licensing->is_switching($currentUserId);
         if ($this->request->is('post')) {
-            if ($currentJob) {
+            if ($isRefreshing) {
+                $this->Flash->set(__(
+                    'Please wait until the list is updated.'
+                ));
+            } elseif($isSwitching) {
                 $this->Flash->set(__(
                     'A license switch is already in progress.'
                 ));
             } else {
-                $options = array(
-                    'userId' => $currentUserId,
-                    'dryRun' => false,
-                    'UIlang' => Configure::read('Config.language'),
-                    'sendReport' => true,
-                );
-                $currentJob = $this->QueuedJobs->createJob(
-                    'SwitchSentencesLicense',
-                    $options,
-                    ['group' => $currentUserId]
+                $licensing->start_switch(
+                    $currentUserId,
+                    Configure::read('Config.language')
                 );
             }
         }

--- a/src/Controller/LicensingController.php
+++ b/src/Controller/LicensingController.php
@@ -103,7 +103,7 @@ class LicensingController extends AppController {
             }
         }
 
-        $listId = CurrentUser::getSetting('license_switch_list_id');
+        $listId = $licensing->get_license_switch_list_id($currentUserId);
         $list = $this->paginateAffected($listId);
         $this->set(compact('isSwitching', 'isRefreshing', 'currentJob', 'list'));
     }
@@ -115,7 +115,7 @@ class LicensingController extends AppController {
         if ($isRefreshing) {
             return $this->response->withStatus(400, 'List not ready yet');
         } else {
-            $listId = CurrentUser::getSetting('license_switch_list_id');
+            $listId = $licensing->get_license_switch_list_id($currentUserId);
             $list = $this->paginateAffected($listId);
             $this->set(compact('list'));
         }

--- a/src/Controller/LicensingController.php
+++ b/src/Controller/LicensingController.php
@@ -96,7 +96,7 @@ class LicensingController extends AppController {
                     'A license switch is already in progress.'
                 ));
             } else {
-                $licensing->start_switch(
+                $isSwitching = $licensing->start_switch(
                     $currentUserId,
                     Configure::read('Config.language')
                 );
@@ -105,7 +105,7 @@ class LicensingController extends AppController {
 
         $listId = CurrentUser::getSetting('license_switch_list_id');
         $list = $this->paginateAffected($listId);
-        $this->set(compact('isRefreshing', 'currentJob', 'list'));
+        $this->set(compact('isSwitching', 'isRefreshing', 'currentJob', 'list'));
     }
 
     public function get_license_switch_list() {

--- a/src/Controller/LicensingController.php
+++ b/src/Controller/LicensingController.php
@@ -61,7 +61,7 @@ class LicensingController extends AppController {
         }
 
         $licensing = new Licensing();
-        $licensing->refresh_license_switch_list(CurrentUser::get('id'));
+        $licensing->refreshLicenseSwitchList(CurrentUser::get('id'));
         $this->autoRender = false;
     }
 
@@ -96,14 +96,14 @@ class LicensingController extends AppController {
                     'A license switch is already in progress.'
                 ));
             } else {
-                $isSwitching = $licensing->start_switch(
+                $isSwitching = $licensing->startLicenseSwitch(
                     $currentUserId,
                     Configure::read('Config.language')
                 );
             }
         }
 
-        $listId = $licensing->get_license_switch_list_id($currentUserId);
+        $listId = $licensing->getLicenseSwitchListId($currentUserId);
         $list = $this->paginateAffected($listId);
         $this->set(compact('isSwitching', 'isRefreshing', 'currentJob', 'list'));
     }
@@ -115,7 +115,7 @@ class LicensingController extends AppController {
         if ($isRefreshing) {
             return $this->response->withStatus(400, 'List not ready yet');
         } else {
-            $listId = $licensing->get_license_switch_list_id($currentUserId);
+            $listId = $licensing->getLicenseSwitchListId($currentUserId);
             $list = $this->paginateAffected($listId);
             $this->set(compact('list'));
         }

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -29,6 +29,7 @@ class User extends Entity
         'default_license' => 'CC BY 2.0 FR',
         'can_switch_license' => false,
         'new_terms_of_use' => false,
+        'license_switch_list_id' => null,
     );
 
     private $settingsValidation = array(

--- a/src/Model/Licensing.php
+++ b/src/Model/Licensing.php
@@ -7,7 +7,7 @@ use Cake\Datasource\Exception\InvalidPrimaryKeyException;
 class Licensing {
     use \Cake\Datasource\ModelAwareTrait;
 
-    private function create_licence_switch_list_for($user) {
+    private function createLicenseSwitchList($user) {
         $list = $this->SentencesLists->createList(__('Sentences to switch to CC0'), $user->id);
         if ($list) {
             $user->settings = ['license_switch_list_id' => $list->id];
@@ -16,7 +16,7 @@ class Licensing {
         return $list;
     }
 
-    public function get_license_switch_list_id($userId) {
+    public function getLicenseSwitchListId($userId) {
         $this->loadModel('Users');
         $user = $this->Users->get($userId);
 
@@ -25,15 +25,15 @@ class Licensing {
             $listId = $user->settings['license_switch_list_id'];
             $list = $this->SentencesLists->get($listId);
         } catch (RecordNotFoundException $e) {
-            $list = $this->create_licence_switch_list_for($user);
+            $list = $this->createLicenseSwitchList($user);
         } catch (InvalidPrimaryKeyException $e) {
-            $list = $this->create_licence_switch_list_for($user);
+            $list = $this->createLicenseSwitchList($user);
         }
 
         return $list->id;
     }
 
-    private function start_refresh_list($listId, $userId) {
+    private function startListRefresh($listId, $userId) {
         $this->loadModel('Queue.QueuedJobs');
         if (!$this->is_refreshing($userId)) {
             $this->QueuedJobs->createJob(
@@ -44,13 +44,13 @@ class Licensing {
         }
     }
 
-    public function refresh_license_switch_list($currentUserId) {
-        $listId = $this->get_license_switch_list_id($currentUserId);
-        $this->start_refresh_list($listId, $currentUserId);
+    public function refreshLicenseSwitchList($currentUserId) {
+        $listId = $this->getLicenseSwitchListId($currentUserId);
+        $this->startListRefresh($listId, $currentUserId);
     }
 
-    public function start_switch($userId, $lang) {
-        $listId = $this->get_license_switch_list_id($userId);
+    public function startLicenseSwitch($userId, $lang) {
+        $listId = $this->getLicenseSwitchListId($userId);
         $options = array(
             'userId' => $userId,
             'UIlang' => $lang,

--- a/src/Model/Licensing.php
+++ b/src/Model/Licensing.php
@@ -49,11 +49,40 @@ class Licensing {
         $this->start_refresh_list($listId, $currentUserId);
     }
 
+    public function start_switch($userId, $lang) {
+        $listId = $this->get_license_switch_list_id($userId);
+        $options = array(
+            'userId' => $userId,
+            'dryRun' => false,
+            'UIlang' => $lang,
+            'listId' => $listId,
+            'sendReport' => true,
+        );
+        $this->QueuedJobs->createJob(
+            'SwitchSentencesLicense',
+            $options,
+            ['group' => $userId]
+        );
+    }
+
     public function is_refreshing($userId) {
         $this->loadModel('Queue.QueuedJobs');
         $job = $this->QueuedJobs->find()
             ->where([
                 'job_type' => 'RefreshLicenseSwitchList',
+                'job_group' => $userId,
+                'completed IS' => null,
+            ])
+            ->first();
+
+        return (bool)$job;
+    }
+
+    public function is_switching($userId) {
+        $this->loadModel('Queue.QueuedJobs');
+        $job = $this->QueuedJobs->find()
+            ->where([
+                'job_type' => 'SwitchSentencesLicense',
                 'job_group' => $userId,
                 'completed IS' => null,
             ])

--- a/src/Model/Licensing.php
+++ b/src/Model/Licensing.php
@@ -20,14 +20,7 @@ class Licensing {
 
     private function start_refresh_list($listId, $userId) {
         $this->loadModel('Queue.QueuedJobs');
-        $currentJob = $this->QueuedJobs->find()
-            ->where([
-                'job_type' => 'RefreshLicenseSwitchList',
-                'job_group' => $userId,
-            ])
-            ->first();
-
-        if (!$currentJob || $currentJob->completed) {
+        if (!$this->is_refreshing($userId)) {
             $this->QueuedJobs->createJob(
                 'RefreshLicenseSwitchList',
                 compact('listId', 'userId'),
@@ -39,5 +32,18 @@ class Licensing {
     public function refresh_license_switch_list($currentUserId) {
         $listId = $this->get_license_switch_list_id($currentUserId);
         $this->start_refresh_list($listId, $currentUserId);
+    }
+
+    public function is_refreshing($userId) {
+        $this->loadModel('Queue.QueuedJobs');
+        $job = $this->QueuedJobs->find()
+            ->where([
+                'job_type' => 'RefreshLicenseSwitchList',
+                'job_group' => $userId,
+                'completed IS' => null,
+            ])
+            ->first();
+
+        return (bool)$job;
     }
 }

--- a/src/Model/Licensing.php
+++ b/src/Model/Licensing.php
@@ -53,7 +53,6 @@ class Licensing {
         $listId = $this->get_license_switch_list_id($userId);
         $options = array(
             'userId' => $userId,
-            'dryRun' => false,
             'UIlang' => $lang,
             'listId' => $listId,
             'sendReport' => true,

--- a/src/Model/Licensing.php
+++ b/src/Model/Licensing.php
@@ -16,7 +16,7 @@ class Licensing {
         return $list;
     }
 
-    private function get_license_switch_list_id($userId) {
+    public function get_license_switch_list_id($userId) {
         $this->loadModel('Users');
         $user = $this->Users->get($userId);
 

--- a/src/Model/Licensing.php
+++ b/src/Model/Licensing.php
@@ -1,0 +1,43 @@
+<?php
+namespace App\Model;
+
+class Licensing {
+    use \Cake\Datasource\ModelAwareTrait;
+
+    private function get_license_switch_list_id($userId) {
+        $this->loadModel('Users');
+        $user = $this->Users->get($userId);
+        if (!$user->settings['license_switch_list_id']) {
+            $this->loadModel('SentencesLists');
+            $list = $this->SentencesLists->createList(__('Sentences to switch to CC0'), $userId);
+            if ($list) {
+                $user->settings = ['license_switch_list_id' => $list->id];
+                $this->Users->save($user);
+            }
+        }
+        return $user->settings['license_switch_list_id'];
+    }
+
+    private function start_refresh_list($listId, $userId) {
+        $this->loadModel('Queue.QueuedJobs');
+        $currentJob = $this->QueuedJobs->find()
+            ->where([
+                'job_type' => 'RefreshLicenseSwitchList',
+                'job_group' => $userId,
+            ])
+            ->first();
+
+        if (!$currentJob || $currentJob->completed) {
+            $this->QueuedJobs->createJob(
+                'RefreshLicenseSwitchList',
+                compact('listId', 'userId'),
+                ['group' => $userId]
+            );
+        }
+    }
+
+    public function refresh_license_switch_list($currentUserId) {
+        $listId = $this->get_license_switch_list_id($currentUserId);
+        $this->start_refresh_list($listId, $currentUserId);
+    }
+}

--- a/src/Model/Licensing.php
+++ b/src/Model/Licensing.php
@@ -58,7 +58,7 @@ class Licensing {
             'listId' => $listId,
             'sendReport' => true,
         );
-        $this->QueuedJobs->createJob(
+        return (bool)$this->QueuedJobs->createJob(
             'SwitchSentencesLicense',
             $options,
             ['group' => $userId]

--- a/src/Model/Table/SentencesListsTable.php
+++ b/src/Model/Table/SentencesListsTable.php
@@ -600,6 +600,19 @@ class SentencesListsTable extends Table
         return $this->save($data);
     }
 
+    public function emptyList($listId, $currentUserId)
+    {
+        $list = $this->get($listId);
+        if ($list->isEditableBy($currentUserId)) {
+            $this->SentencesSentencesLists->deleteAll([
+                'sentences_list_id' => $listId
+            ]);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     /**
      * Delete list.
      */

--- a/src/Model/Table/SentencesListsTable.php
+++ b/src/Model/Table/SentencesListsTable.php
@@ -418,6 +418,37 @@ class SentencesListsTable extends Table
 
 
     /**
+     * Add sentences to list.
+     *
+     * @param array $sentences     Array of sentence entities.
+     * @param int   $listId        Id of the list.
+     * @param int   $currentUserId Id of the user performing the action.
+     *
+     * @return array
+     */
+    public function addSentencesToList($sentences, $listId, $currentUserId)
+    {
+        try {
+            $list = $this->get($listId);
+        } catch (RecordNotFoundException $e) {
+            return false;
+        }
+
+        if (!$list->isEditableBy($currentUserId)) {
+            return false;
+        }
+
+        try {
+            $this->Sentences->link($list, $sentences);
+            $this->_incrementNumberOfSentencesToList($listId, count($sentences));
+            return true;
+        } catch (\PDOException $e) {
+            return false;
+        }
+    }
+
+
+    /**
      * get all the list of a given user
      *
      * @param int $username Username of the user
@@ -487,13 +518,14 @@ class SentencesListsTable extends Table
      * Increment number of sentence to list.
      *
      * @param int $listId Id of the list.
+     * @param int $inc    The number to increment.
      *
      * @return boolean
      */
-    private function _incrementNumberOfSentencesToList($listId)
+    private function _incrementNumberOfSentencesToList($listId, $inc = 1)
     {
         $list = $this->get($listId);
-        $list->numberOfSentences++;
+        $list->numberOfSentences += $inc;
         $this->save($list);
     }
 

--- a/src/Model/Table/SentencesListsTable.php
+++ b/src/Model/Table/SentencesListsTable.php
@@ -643,6 +643,8 @@ class SentencesListsTable extends Table
             $this->SentencesSentencesLists->deleteAll([
                 'sentences_list_id' => $listId
             ]);
+            $list->numberOfSentences = 0;
+            $this->save($list);
             return true;
         } else {
             return false;

--- a/src/Model/Table/SentencesListsTable.php
+++ b/src/Model/Table/SentencesListsTable.php
@@ -438,13 +438,17 @@ class SentencesListsTable extends Table
             return false;
         }
 
-        try {
-            $this->Sentences->link($list, $sentences);
-            $this->_incrementNumberOfSentencesToList($listId, count($sentences));
-            return true;
-        } catch (\PDOException $e) {
-            return false;
+        $count = 0;
+        foreach ($sentences as $sentence) {
+            try {
+                $this->Sentences->link($list, [$sentence]);
+                $count++;
+            } catch (\PDOException $e) {
+                // Likely trying to add a sentence already in that list
+            }
         }
+        $this->_incrementNumberOfSentencesToList($listId, $count);
+        return $count == count($sentences);
     }
 
 

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -48,7 +48,7 @@ class UsersTable extends Table
     {
         parent::initialize($config);
 
-        $this->belongsTo('Groups');
+        $this->belongsTo('Groups', ['bindingKey' => 'id']);
 
         $this->hasMany('Audios');
         $this->hasMany('Contributions');

--- a/src/Shell/BatchOperationTrait.php
+++ b/src/Shell/BatchOperationTrait.php
@@ -1,33 +1,7 @@
 <?php
-/**
- * AppShell file
- *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org CakePHP(tm) Project
- * @since         CakePHP(tm) v 2.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
- */
 namespace App\Shell;
 
-use Cake\Console\Shell;
-
-
-/**
- * Application Shell
- *
- * Add your application-wide methods in the class below, your shells
- * will inherit them.
- *
- * @package       app.Console.Command
- */
-class AppShell extends Shell {
+trait BatchOperationTrait {
     public $batchOperationSize = 1000;
 
     private function _orderCondition($nonUniqueField, $lastValue, $pKey, $lastId) {

--- a/src/Shell/SentenceDerivationShell.php
+++ b/src/Shell/SentenceDerivationShell.php
@@ -2,7 +2,7 @@
 
 namespace App\Shell;
 
-use App\Shell\AppShell;
+use Cake\Console\Shell;
 use Cake\Utility\Hash;
 use Cake\Datasource\Exception\RecordNotFoundException;
 
@@ -103,7 +103,9 @@ class Walker {
     }
 }
 
-class SentenceDerivationShell extends AppShell {
+class SentenceDerivationShell extends Shell {
+
+    use BatchOperationTrait;
 
     public $uses = array('Sentence', 'Contribution');
     public $batchSize = 1000;

--- a/src/Shell/Task/QueueRefreshLicenseSwitchListTask.php
+++ b/src/Shell/Task/QueueRefreshLicenseSwitchListTask.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Shell\Task;
+
+use App\Shell\BatchOperationTrait;
+use Queue\Shell\Task\QueueTask;
+
+class QueueRefreshLicenseSwitchListTask extends QueueTask {
+
+    use BatchOperationTrait;
+
+/**
+ * ZendStudio Codecomplete Hint
+ *
+ * @var QueuedTask
+ */
+    public $QueuedTask;
+
+/**
+ * Timeout for run, after which the Task is reassigned to a new worker.
+ *
+ * @var int
+ */
+    public $timeout = 10;
+
+/**
+ * Number of times a failed instance of this task should be restarted before giving up.
+ *
+ * @var int
+ */
+    public $retries = 1;
+
+/**
+ * Stores any failure messages triggered during run()
+ *
+ * @var string
+ */
+    public $failureMessage = '';
+
+    public function add() {
+        $username = isset($this->args[1]) ? $this->args[1] : '';
+        $this->loadModel('Users');
+        $user = $this->Users->findByUsername($username)->first();
+        if (!$user) {
+            if (!empty($username)) {
+                $this->out("Error: '$username' is not a valid username.");
+            }
+            $this->out('Usage: cake queue add RefreshLicenseSwitchList <username>');
+            return;
+        }
+
+        $userId = $user->id;
+        $options = compact('userId');
+        if ($this->QueuedJobs->createJob('RefreshLicenseSwitchList', $options)) {
+            $this->out('OK, job created, now run the worker');
+        } else {
+            $this->err('Could not create Job');
+        }
+    }
+
+    public function addToList($sentences, $modelName, $listId, $userId) {
+        $this->SentencesLists->addSentencesToList($sentences, $listId, $userId);
+        return count($sentences);
+    }
+
+    private function refreshList($options) {
+        extract($options); // $listId and $userId
+
+        $this->loadModel('Sentences');
+        $findOptions = array(
+            'fields' => array('Sentences.id'),
+            'conditions' => array(
+                'license' => 'CC BY 2.0 FR',
+                'Sentences.user_id' => $userId,
+                'based_on_id' => 0,
+            ),
+            'join' => array(array(
+                'table' => 'contributions',
+                'alias' => 'Contributions',
+                'type' => 'INNER',
+                'conditions' => array(
+                    'Contributions.sentence_id = Sentences.id',
+                    'Contributions.user_id = Sentences.user_id',
+                    'action' => 'insert',
+                    'type' => 'sentence',
+                ),
+            )),
+        );
+
+        $this->loadModel('SentencesLists');
+        $this->SentencesLists->emptyList($listId, $userId);
+
+        $proceeded = $this->batchOperation(
+            'Sentences',
+            'addToList',
+            $findOptions,
+            $listId,
+            $userId
+        );
+    }
+
+/**
+ * Example run function.
+ * This function is executed, when a worker is executing a task.
+ * The return parameter will determine, if the task will be marked completed, or be requeued.
+ *
+ * @param array $data The array passed to QueuedTask->createJob()
+ * @param int $id The id of the QueuedTask
+ * @return bool Success
+ */
+    public function run(array $options, $id = null) {
+        $this->refreshList($options);
+        return true;
+    }
+}

--- a/src/Shell/Task/QueueRefreshLicenseSwitchListTask.php
+++ b/src/Shell/Task/QueueRefreshLicenseSwitchListTask.php
@@ -37,27 +37,6 @@ class QueueRefreshLicenseSwitchListTask extends QueueTask {
  */
     public $failureMessage = '';
 
-    public function add() {
-        $username = isset($this->args[1]) ? $this->args[1] : '';
-        $this->loadModel('Users');
-        $user = $this->Users->findByUsername($username)->first();
-        if (!$user) {
-            if (!empty($username)) {
-                $this->out("Error: '$username' is not a valid username.");
-            }
-            $this->out('Usage: cake queue add RefreshLicenseSwitchList <username>');
-            return;
-        }
-
-        $userId = $user->id;
-        $options = compact('userId');
-        if ($this->QueuedJobs->createJob('RefreshLicenseSwitchList', $options)) {
-            $this->out('OK, job created, now run the worker');
-        } else {
-            $this->err('Could not create Job');
-        }
-    }
-
     public function addToList($sentences, $listId, $userId) {
         $this->SentencesLists->addSentencesToList($sentences, $listId, $userId);
         return count($sentences);

--- a/src/Shell/Task/QueueSwitchSentencesLicenseTask.php
+++ b/src/Shell/Task/QueueSwitchSentencesLicenseTask.php
@@ -138,13 +138,13 @@ class QueueSwitchSentencesLicenseTask extends QueueTask {
                 'Sentences.user_id' => $options['userId'],
                 'based_on_id' => 0,
             ),
-            'joins' => array(array(
+            'join' => array(array(
                 'table' => 'contributions',
                 'alias' => 'Contributions',
                 'type' => 'INNER',
                 'conditions' => array(
-                    'Contributions.sentence_id = Sentence.id',
-                    'Contributions.user_id = Sentence.user_id',
+                    'Contributions.sentence_id = Sentences.id',
+                    'Contributions.user_id = Sentences.user_id',
                     'action' => 'insert',
                     'type' => 'sentence',
                 ),

--- a/src/Shell/Task/QueueSwitchSentencesLicenseTask.php
+++ b/src/Shell/Task/QueueSwitchSentencesLicenseTask.php
@@ -79,12 +79,16 @@ class QueueSwitchSentencesLicenseTask extends QueueTask {
         }
     }
 
+    public function getReport() {
+        return $this->report;
+    }
+
     private function sendReport($recipientId) {
         $this->loadModel('PrivateMessages');
         $now = date("Y/m/d H:i:s", time());
         $data = [
             'title' => __('Result of license switch to CC0 1.0'),
-            'content' => $this->report,
+            'content' => $this->getReport(),
             'messageId' => '',
         ];
         $this->PrivateMessages->notify($recipientId, $now, $data);
@@ -114,7 +118,7 @@ class QueueSwitchSentencesLicenseTask extends QueueTask {
                     __("Unable to change the license of sentence {id} to “{newLicense}” because:"),
                     compact('id', 'newLicense')
                 );
-                $errors = $this->Sentence->validationErrors['license'];
+                $errors = $data->errors('license');
                 $this->out($message."\n - ".implode("\n - ", $errors));
             }
         }

--- a/src/Shell/Task/QueueSwitchSentencesLicenseTask.php
+++ b/src/Shell/Task/QueueSwitchSentencesLicenseTask.php
@@ -98,10 +98,6 @@ class QueueSwitchSentencesLicenseTask extends QueueTask {
 
     private function _switchLicense($entities, $dryRun) {
         $total = 0;
-        $saveParams = array(
-            'validate' => true,
-            'callbacks' => true,
-        );
         $newLicense = 'CC0 1.0';
         foreach ($entities as $ent) {
             $id = $ent->id;

--- a/src/Shell/Task/QueueSwitchSentencesLicenseTask.php
+++ b/src/Shell/Task/QueueSwitchSentencesLicenseTask.php
@@ -59,28 +59,6 @@ class QueueSwitchSentencesLicenseTask extends QueueTask {
         return parent::out($message, $newlines, $level);
     }
 
-    public function add() {
-        $username = isset($this->args[1]) ? $this->args[1] : '';
-        $dryRun = isset($this->args[2]) && $this->args[2] == 'dryrun';
-        $this->loadModel('Users');
-        $user = $this->Users->findByUsername($username)->first();
-        if (!$user) {
-            if (!empty($username)) {
-                $this->out("Error: '$username' is not a valid username.");
-            }
-            $this->out('Usage: cake queue add SwitchSentencesLicense <username> [dryrun]');
-            return;
-        }
-
-        $userId = $user->id;
-        $options = compact('userId', 'dryRun');
-        if ($this->QueuedJobs->createJob('SwitchSentencesLicense', $options)) {
-            $this->out('OK, job created, now run the worker');
-        } else {
-            $this->err('Could not create Job');
-        }
-    }
-
     public function getReport() {
         return $this->report;
     }

--- a/src/Shell/Task/QueueSwitchSentencesLicenseTask.php
+++ b/src/Shell/Task/QueueSwitchSentencesLicenseTask.php
@@ -74,19 +74,14 @@ class QueueSwitchSentencesLicenseTask extends QueueTask {
         $this->PrivateMessages->notify($recipientId, $now, $data);
     }
 
-    private function _switchLicense($entities, $dryRun) {
+    private function _switchLicense($entities) {
         $total = 0;
         $newLicense = 'CC0 1.0';
         foreach ($entities as $ent) {
             $id = $ent->id;
             $data = $this->Sentences->get($id);
-            if ($dryRun) {
-                $this->Sentences->patchEntity($data, ['license' => $newLicense]);
-                $ok = empty($data->getErrors());                
-            } else {
-                $this->Sentences->patchEntity($data, ['license' => $newLicense]);
-                $ok = $this->Sentences->save($data);
-            }
+            $this->Sentences->patchEntity($data, ['license' => $newLicense]);
+            $ok = $this->Sentences->save($data);
             if ($ok) {
                 $total++;
             } else {
@@ -121,7 +116,7 @@ class QueueSwitchSentencesLicenseTask extends QueueTask {
             __('License switch started on {date} at {time} UTC.'),
             $this->dateAndTime()
         ));
-        $proceeded = $this->batchOperationNewORM($query, [$this, '_switchLicense'], $options['dryRun']);
+        $proceeded = $this->batchOperationNewORM($query, [$this, '_switchLicense']);
         $this->out(format(
             __n('Successfully changed the license of {n} sentence.',
                 'Successfully changed the license of {n} sentences.',

--- a/src/Shell/Task/QueueSwitchSentencesLicenseTask.php
+++ b/src/Shell/Task/QueueSwitchSentencesLicenseTask.php
@@ -74,7 +74,7 @@ class QueueSwitchSentencesLicenseTask extends QueueTask {
         $this->PrivateMessages->notify($recipientId, $now, $data);
     }
 
-    private function _switchLicense($entities) {
+    private function _switchLicense($entities, $options) {
         $total = 0;
         $newLicense = 'CC0 1.0';
         foreach ($entities as $ent) {
@@ -84,6 +84,11 @@ class QueueSwitchSentencesLicenseTask extends QueueTask {
             $ok = $this->Sentences->save($data);
             if ($ok) {
                 $total++;
+                $this->Sentences->SentencesLists->removeSentenceFromList(
+                    $id,
+                    $options['listId'],
+                    $options['userId']
+                );
             } else {
                 $message = format(
                     __("Unable to change the license of sentence {id} to “{newLicense}” because:"),
@@ -116,7 +121,7 @@ class QueueSwitchSentencesLicenseTask extends QueueTask {
             __('License switch started on {date} at {time} UTC.'),
             $this->dateAndTime()
         ));
-        $proceeded = $this->batchOperationNewORM($query, [$this, '_switchLicense']);
+        $proceeded = $this->batchOperationNewORM($query, [$this, '_switchLicense'], $options);
         $this->out(format(
             __n('Successfully changed the license of {n} sentence.',
                 'Successfully changed the license of {n} sentences.',

--- a/src/Shell/TranscriptionsShell.php
+++ b/src/Shell/TranscriptionsShell.php
@@ -18,12 +18,15 @@
  */
 namespace App\Shell;
 
+use Cake\Console\Shell;
 use Cake\Utility\Hash;
 use App\Model\Sentence;
 use App\Model\Transcription;
 
 
-class TranscriptionsShell extends AppShell {
+class TranscriptionsShell extends Shell {
+
+    use BatchOperationTrait;
 
     public function initialize()
     {

--- a/src/Shell/UpdatePasswordVersionShell.php
+++ b/src/Shell/UpdatePasswordVersionShell.php
@@ -2,9 +2,12 @@
 
 namespace App\Shell;
 
+use Cake\Console\Shell;
 use App\Security\Utility;
 
-class UpdatePasswordVersionShell extends AppShell {
+class UpdatePasswordVersionShell extends Shell {
+
+    use BatchOperationTrait;
 
     public $uses = array('User');
 

--- a/src/Template/Element/licensing/list.ctp
+++ b/src/Template/Element/licensing/list.ctp
@@ -1,5 +1,11 @@
 <?php
 
+$title = $this->Paginator->counter(
+    __('List of affected sentences (total {{count}})')
+);
+
+echo $this->Html->tag('h3', $title);
+
 foreach ($list as $item) {
     $this->Sentences->displayGenericSentence(
         $item->sentence, 'mainSentence', false

--- a/src/Template/Element/licensing/list.ctp
+++ b/src/Template/Element/licensing/list.ctp
@@ -1,0 +1,9 @@
+<?php
+
+foreach ($list as $item) {
+    $this->Sentences->displayGenericSentence(
+        $item->sentence, 'mainSentence', false
+    );
+}
+
+$this->Pagination->display();

--- a/src/Template/Licensing/get_license_switch_list.ctp
+++ b/src/Template/Licensing/get_license_switch_list.ctp
@@ -1,0 +1,3 @@
+<?php
+
+echo $this->element('licensing/list', compact($list));

--- a/src/Template/Licensing/switch_my_sentences.ctp
+++ b/src/Template/Licensing/switch_my_sentences.ctp
@@ -70,6 +70,7 @@ if ($isSwitching) {
     echo $this->Html->tag('md-button', __('Switch license to CC0 1.0'), [
         'type' => 'submit',
         'class' => 'md-raised md-warn',
+        'ng-disabled' => 'isRefreshing || '.($isSwitching ? 'true' : 'false'),
     ]);
     echo $this->Form->end();
 ?>

--- a/src/Template/Licensing/switch_my_sentences.ctp
+++ b/src/Template/Licensing/switch_my_sentences.ctp
@@ -20,6 +20,8 @@
 $this->set('title_for_layout', __("Switch my sentences' license"));
 echo $this->Html->script('licensing/switch-license.ctrl.js', ['block' => 'scriptBottom']);
 
+echo $this->Html->tag('h2', __('Switch my sentences to CC0'));
+
 if ($currentJob) {
     if (isset($currentJob['completed'])) {
         $message = __('The license switch of your sentences is completed. A report has been sent to you by private message.');
@@ -43,14 +45,25 @@ if ($currentJob) {
     ));
 
 ?>
-<div ng-controller="switchLicenseCtrl">
+<div ng-controller="switchLicenseCtrl" ng-init="init(<?= ($isRefreshing ? 'true' : 'false') ?>)">
+<?
+    echo $this->Html->tag('h3', __('List of affected sentences'));
+?>
+    <md-progress-circular ng-show="isRefreshing" md-mode="indeterminate" class="block-loader">
+    </md-progress-circular>
+    <div id="switchList" ng-show="!isRefreshing">
+<?
+    if (!$list->isEmpty()) {
+        echo $this->element('licensing/list', compact($list));
+    }
+?>
+    </div>
 <?
     echo $this->Html->tag('md-button', __('Refresh list'), [
         'type' => 'submit',
         'class' => 'md-raised md-primary',
         'ng-click' => 'refreshList()',
         'ng-disabled' => 'isRefreshing',
-        'ng-init' => 'isRefreshing = '.($isRefreshing ? 'true' : 'false'),
     ]);
 ?>
 </div>

--- a/src/Template/Licensing/switch_my_sentences.ctp
+++ b/src/Template/Licensing/switch_my_sentences.ctp
@@ -25,17 +25,8 @@ echo $this->Html->script('licensing/switch-license.ctrl.js', ['block' => 'script
 <?
 echo $this->Html->tag('h2', __('Switch my sentences to CC0'));
 
-if ($currentJob) {
-    if (isset($currentJob['completed'])) {
-        $message = __('The license switch of your sentences is completed. A report has been sent to you by private message.');
-    } elseif (isset($currentJob['fetched'])) {
-        $message = __('The license switch of your sentences is in progress. You will receive a private message when it will be completed.');
-    } elseif (isset($currentJob['created'])) {
-        $message = __('The license switch of your sentences will be started soon. You will receive a private message when it will be completed.');
-    } else {
-        $message = __('A problem occured while switching the license of your sentences.');
-    }
-    echo $this->Html->tag('p', $message);
+if ($isSwitching) {
+    echo $this->Html->tag('p', __('The license switch of your sentences is in progress. You will receive a private message when it will be completed.'));
 } else {
     echo $this->Html->tag('p', format(
         __('This page allows you to massively switch the license of your sentences to {CC0-link}. Among all your sentences, only the ones that meet the following conditions will be affected.'),

--- a/src/Template/Licensing/switch_my_sentences.ctp
+++ b/src/Template/Licensing/switch_my_sentences.ctp
@@ -38,10 +38,7 @@ if ($isSwitching) {
         __('The sentence must be original and not derived from translation.'),
     ));
 
-    echo $this->Html->tag('h3', __('List of affected sentences'));
 ?>
-    <md-progress-circular ng-show="isRefreshing" md-mode="indeterminate" class="block-loader">
-    </md-progress-circular>
     <div id="switchList" ng-show="!isRefreshing">
 <?
     if (!$list->isEmpty()) {
@@ -49,8 +46,13 @@ if ($isSwitching) {
     }
 ?>
     </div>
+    <md-progress-circular ng-show="isRefreshing" md-mode="indeterminate" class="block-loader">
+    </md-progress-circular>
 <?
-    echo $this->Html->tag('md-button', __('Refresh list'), [
+    echo $this->Html->tag('p', __(
+        'Press the following button to start or restart an analysis of which of your sentences can be switched to CC0.'
+    ));
+    echo $this->Html->tag('md-button', __('Start analysis'), [
         'type' => 'submit',
         'class' => 'md-raised md-primary',
         'ng-click' => 'refreshList()',

--- a/src/Template/Licensing/switch_my_sentences.ctp
+++ b/src/Template/Licensing/switch_my_sentences.ctp
@@ -18,6 +18,7 @@
  */
 
 $this->set('title_for_layout', __("Switch my sentences' license"));
+echo $this->Html->script('licensing/switch-license.ctrl.js', ['block' => 'scriptBottom']);
 
 if ($currentJob) {
     if (isset($currentJob['completed'])) {
@@ -41,6 +42,19 @@ if ($currentJob) {
         __('The sentence must be original and not derived from translation.'),
     ));
 
+?>
+<div ng-controller="switchLicenseCtrl">
+<?
+    echo $this->Html->tag('md-button', __('Refresh list'), [
+        'type' => 'submit',
+        'class' => 'md-raised md-primary',
+        'ng-click' => 'refreshList()',
+        'ng-disabled' => 'isRefreshing',
+        'ng-init' => 'isRefreshing = '.($isRefreshing ? 'true' : 'false'),
+    ]);
+?>
+</div>
+<?
     echo $this->Html->tag('p', __(
         'Press the following button to initiate the license switch.'
     ));

--- a/src/Template/Licensing/switch_my_sentences.ctp
+++ b/src/Template/Licensing/switch_my_sentences.ctp
@@ -20,6 +20,9 @@
 $this->set('title_for_layout', __("Switch my sentences' license"));
 echo $this->Html->script('licensing/switch-license.ctrl.js', ['block' => 'scriptBottom']);
 
+?>
+<div ng-controller="switchLicenseCtrl" ng-init="init(<?= ($isRefreshing ? 'true' : 'false') ?>)">
+<?
 echo $this->Html->tag('h2', __('Switch my sentences to CC0'));
 
 if ($currentJob) {
@@ -44,9 +47,6 @@ if ($currentJob) {
         __('The sentence must be original and not derived from translation.'),
     ));
 
-?>
-<div ng-controller="switchLicenseCtrl" ng-init="init(<?= ($isRefreshing ? 'true' : 'false') ?>)">
-<?
     echo $this->Html->tag('h3', __('List of affected sentences'));
 ?>
     <md-progress-circular ng-show="isRefreshing" md-mode="indeterminate" class="block-loader">
@@ -65,11 +65,10 @@ if ($currentJob) {
         'ng-click' => 'refreshList()',
         'ng-disabled' => 'isRefreshing',
     ]);
-?>
-</div>
-<?
+
+    echo $this->Html->tag('h3', __('Switch license'));
     echo $this->Html->tag('p', __(
-        'Press the following button to initiate the license switch.'
+        'Press the following button to initiate the license switch of the above-listed sentences.'
     ));
     echo $this->Html->tag(
         'p',
@@ -77,7 +76,13 @@ if ($currentJob) {
         array('class' => 'warning')
     );
     echo $this->Form->create();
-    echo $this->Form->submit(__('Switch license to CC0 1.0'));
+    echo $this->Html->tag('md-button', __('Switch license to CC0 1.0'), [
+        'type' => 'submit',
+        'class' => 'md-raised md-warn',
+    ]);
     echo $this->Form->end();
+?>
+</div>
+<?
 }
 

--- a/src/Template/Licensing/switch_my_sentences.ctp
+++ b/src/Template/Licensing/switch_my_sentences.ctp
@@ -75,8 +75,6 @@ if ($isSwitching) {
         'ng-disabled' => 'isRefreshing || '.($isSwitching ? 'true' : 'false'),
     ]);
     echo $this->Form->end();
+}
 ?>
 </div>
-<?
-}
-

--- a/tests/Fixture/QueuedJobsFixture.php
+++ b/tests/Fixture/QueuedJobsFixture.php
@@ -1,0 +1,39 @@
+<?php
+namespace App\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class QueuedJobsFixture extends TestFixture
+{
+    public $fields = [
+        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
+        'job_type' => ['type' => 'string', 'length' => 45, 'null' => false, 'default' => null, 'collate' => 'utf8mb4_unicode_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'data' => ['type' => 'text', 'length' => 16777215, 'null' => true, 'default' => null, 'collate' => 'utf8mb4_unicode_ci', 'comment' => '', 'precision' => null],
+        'job_group' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'collate' => 'utf8mb4_unicode_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'reference' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'collate' => 'utf8mb4_unicode_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'notbefore' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'fetched' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'completed' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'progress' => ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => ''],
+        'failed' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => '0', 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        'failure_message' => ['type' => 'text', 'length' => 16777215, 'null' => true, 'default' => null, 'collate' => 'utf8mb4_unicode_ci', 'comment' => '', 'precision' => null],
+        'workerkey' => ['type' => 'string', 'length' => 45, 'null' => true, 'default' => null, 'collate' => 'utf8mb4_unicode_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'status' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'collate' => 'utf8mb4_unicode_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'priority' => ['type' => 'integer', 'length' => 3, 'unsigned' => false, 'null' => false, 'default' => '5', 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8_general_ci'
+        ],
+    ];
+
+    public function init()
+    {
+        $this->records = [
+        ];
+        parent::init();
+    }
+}

--- a/tests/Fixture/SentencesFixture.php
+++ b/tests/Fixture/SentencesFixture.php
@@ -666,7 +666,7 @@ class SentencesFixture extends TestFixture {
 			'lang' => 'eng',
 			'text' => 'An original sentence whose owner changed.',
 			'correctness' => '0',
-			'user_id' => '3',
+			'user_id' => '4',
 			'created' => '2017-04-10 01:24:00',
 			'modified' => '2017-04-10 01:25:00',
 			'script' => null,

--- a/tests/Fixture/SentencesListsFixture.php
+++ b/tests/Fixture/SentencesListsFixture.php
@@ -50,6 +50,16 @@ class SentencesListsFixture extends TestFixture {
 			'modified' => '2018-04-15 00:54:12',
 			'visibility' => 'private',
 			'editable_by' => 'creator'
-		)
+		),
+		array(
+			'id' => '4',
+			'name' => 'Sentences to switch to CC0',
+			'user_id' => 4,
+			'numberOfSentences' => 1,
+			'created' => '2018-10-10 10:10:01',
+			'modified' => '2018-10-10 10:10:09',
+			'visibility' => 'private',
+			'editable_by' => 'creator'
+		),
 	);
 }

--- a/tests/Fixture/SentencesSentencesListsFixture.php
+++ b/tests/Fixture/SentencesSentencesListsFixture.php
@@ -35,5 +35,17 @@ class SentencesSentencesListsFixture extends TestFixture {
 			'sentence_id' => '50',
 			'created' => '2018-04-08 02:08:51',
 		),
+		array(
+			'id' => '4',
+			'sentences_list_id' => '4',
+			'sentence_id' => '48',
+			'created' => '2018-10-10 10:10:09',
+		),
+		array(
+			'id' => '5',
+			'sentences_list_id' => '4',
+			'sentence_id' => '53',
+			'created' => '2018-10-10 10:10:09',
+		),
 	);
 }

--- a/tests/Fixture/SentencesSentencesListsFixture.php
+++ b/tests/Fixture/SentencesSentencesListsFixture.php
@@ -29,5 +29,11 @@ class SentencesSentencesListsFixture extends TestFixture {
 			'sentence_id' => '8',
 			'created' => '2018-03-14 12:15:18',
 		),
+		array(
+			'id' => '3',
+			'sentences_list_id' => '3',
+			'sentence_id' => '50',
+			'created' => '2018-04-08 02:08:51',
+		),
 	);
 }

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -104,7 +104,7 @@ class UsersFixture extends TestFixture {
 			'name' => '',
 			'birthday' => NULL,
 			'description' => '',
-			'settings' => '{"is_public":"0","lang":"fra,deu"}',
+			'settings' => '{"is_public":"0","lang":"fra,deu","license_switch_list_id":4}',
 			'homepage' => '',
 			'image' => '',
 			'country_id' => NULL,

--- a/tests/TestCase/Model/LicensingTest.php
+++ b/tests/TestCase/Model/LicensingTest.php
@@ -11,6 +11,7 @@ class LicensingTest extends TestCase
 {
     public $fixtures = array(
         'app.sentences_lists',
+        'app.sentences_sentences_lists',
         'app.users',
         'app.queued_jobs',
         'app.aros',
@@ -31,6 +32,13 @@ class LicensingTest extends TestCase
         unset($this->Licensing);
     }
 
+    private function assertIsSwitchListOf($list, $userId) {
+        $this->assertEquals('Sentences to switch to CC0', $list->name);
+        $this->assertEquals('unlisted', $list->visibility);
+        $this->assertEquals('creator', $list->editable_by);
+        $this->assertEquals($userId, $list->user_id);
+    }
+
     public function testRefresh_createsNewList() {
         $SentencesLists = TableRegistry::get('SentencesLists');
         $before = $SentencesLists->find()->all();
@@ -41,10 +49,18 @@ class LicensingTest extends TestCase
         $this->assertNotEquals($before, $after);
 
         $list = $SentencesLists->find()->last();
-        $this->assertEquals('Sentences to switch to CC0', $list->name);
-        $this->assertEquals('unlisted', $list->visibility);
-        $this->assertEquals('creator', $list->editable_by);
-        $this->assertEquals(7, $list->user_id);
+        $this->assertIsSwitchListOf($list, 7);
+    }
+
+    public function testRefresh_reCreatesNewList() {
+        $SentencesLists = TableRegistry::get('SentencesLists');
+        $oldList = $SentencesLists->get(4);
+        $SentencesLists->delete($oldList);
+
+        $this->Licensing->refresh_license_switch_list(4);
+
+        $list = $SentencesLists->find()->last();
+        $this->assertIsSwitchListOf($list, 4);
     }
 
     public function testRefresh_savesNewListId() {

--- a/tests/TestCase/Model/LicensingTest.php
+++ b/tests/TestCase/Model/LicensingTest.php
@@ -43,7 +43,7 @@ class LicensingTest extends TestCase
         $SentencesLists = TableRegistry::get('SentencesLists');
         $before = $SentencesLists->find()->all();
 
-        $this->Licensing->refresh_license_switch_list(7);
+        $this->Licensing->refreshLicenseSwitchList(7);
 
         $after = $SentencesLists->find()->all();
         $this->assertNotEquals($before, $after);
@@ -57,14 +57,14 @@ class LicensingTest extends TestCase
         $oldList = $SentencesLists->get(4);
         $SentencesLists->delete($oldList);
 
-        $this->Licensing->refresh_license_switch_list(4);
+        $this->Licensing->refreshLicenseSwitchList(4);
 
         $list = $SentencesLists->find()->last();
         $this->assertIsSwitchListOf($list, 4);
     }
 
     public function testRefresh_savesNewListId() {
-        $this->Licensing->refresh_license_switch_list(7);
+        $this->Licensing->refreshLicenseSwitchList(7);
 
         $listId = $this->Licensing->SentencesLists->find()->last()->id;
         $settings = $this->Licensing->Users->get(7)->settings;
@@ -72,7 +72,7 @@ class LicensingTest extends TestCase
     }
 
     public function testRefresh_createsJob() {
-        $this->Licensing->refresh_license_switch_list(4);
+        $this->Licensing->refreshLicenseSwitchList(4);
 
         $QueuedJobs = TableRegistry::get('QueuedJobs');
         $job = $QueuedJobs->find()->last();
@@ -84,7 +84,7 @@ class LicensingTest extends TestCase
         $SentencesLists = TableRegistry::get('SentencesLists');
         $before = $SentencesLists->find()->all();
 
-        $this->Licensing->refresh_license_switch_list(4);
+        $this->Licensing->refreshLicenseSwitchList(4);
 
         $after = $SentencesLists->find()->all();
         $this->assertEquals($before, $after);
@@ -95,20 +95,20 @@ class LicensingTest extends TestCase
     }
 
     public function testRefresh_doesNotCreatesDuplicateJob() {
-        $this->Licensing->refresh_license_switch_list(4);
-        $this->Licensing->refresh_license_switch_list(4);
+        $this->Licensing->refreshLicenseSwitchList(4);
+        $this->Licensing->refreshLicenseSwitchList(4);
 
         $QueuedJobs = TableRegistry::get('QueuedJobs');
         $this->assertEquals(1, $QueuedJobs->find()->count());
     }
 
     public function testRefresh_createsDuplicateJobIfCompleted() {
-        $this->Licensing->refresh_license_switch_list(4);
+        $this->Licensing->refreshLicenseSwitchList(4);
         $QueuedJobs = TableRegistry::get('QueuedJobs');
         $job = $QueuedJobs->find()->last();
         $job->completed = '2019-01-01 01:02:03';
         $QueuedJobs->save($job);
-        $this->Licensing->refresh_license_switch_list(4);
+        $this->Licensing->refreshLicenseSwitchList(4);
 
         $QueuedJobs = TableRegistry::get('QueuedJobs');
         $this->assertEquals(2, $QueuedJobs->find()->count());

--- a/tests/TestCase/Model/LicensingTest.php
+++ b/tests/TestCase/Model/LicensingTest.php
@@ -1,0 +1,100 @@
+<?php
+namespace App\Test\TestCase\Model;
+
+use App\Model\Licensing;
+use Cake\Core\Configure;
+use Cake\Core\Plugin;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class LicensingTest extends TestCase
+{
+    public $fixtures = array(
+        'app.sentences_lists',
+        'app.users',
+        'app.queued_jobs',
+        'app.aros',
+    );
+
+    public function setUp()
+    {
+        parent::setUp();
+        Configure::write('Acl.database', 'test');
+        Plugin::load('Queue');
+
+        $this->Licensing = new Licensing();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        unset($this->Licensing);
+    }
+
+    public function testRefresh_createsNewList() {
+        $SentencesLists = TableRegistry::get('SentencesLists');
+        $before = $SentencesLists->find()->all();
+
+        $this->Licensing->refresh_license_switch_list(7);
+
+        $after = $SentencesLists->find()->all();
+        $this->assertNotEquals($before, $after);
+
+        $list = $SentencesLists->find()->last();
+        $this->assertEquals('Sentences to switch to CC0', $list->name);
+        $this->assertEquals('unlisted', $list->visibility);
+        $this->assertEquals('creator', $list->editable_by);
+        $this->assertEquals(7, $list->user_id);
+    }
+
+    public function testRefresh_savesNewListId() {
+        $this->Licensing->refresh_license_switch_list(7);
+
+        $listId = $this->Licensing->SentencesLists->find()->last()->id;
+        $settings = $this->Licensing->Users->get(7)->settings;
+        $this->assertEquals($listId, $settings['license_switch_list_id']);
+    }
+
+    public function testRefresh_createsJob() {
+        $this->Licensing->refresh_license_switch_list(4);
+
+        $QueuedJobs = TableRegistry::get('QueuedJobs');
+        $job = $QueuedJobs->find()->last();
+        $this->assertEquals('RefreshLicenseSwitchList', $job->job_type);
+        $this->assertEquals(4, $job->job_group);
+    }
+
+    public function testRefresh_usesExistingList() {
+        $SentencesLists = TableRegistry::get('SentencesLists');
+        $before = $SentencesLists->find()->all();
+
+        $this->Licensing->refresh_license_switch_list(4);
+
+        $after = $SentencesLists->find()->all();
+        $this->assertEquals($before, $after);
+
+        $QueuedJobs = TableRegistry::get('QueuedJobs');
+        $job = $QueuedJobs->find()->last();
+        $this->assertEquals(4, unserialize($job->data)['listId']);
+    }
+
+    public function testRefresh_doesNotCreatesDuplicateJob() {
+        $this->Licensing->refresh_license_switch_list(4);
+        $this->Licensing->refresh_license_switch_list(4);
+
+        $QueuedJobs = TableRegistry::get('QueuedJobs');
+        $this->assertEquals(1, $QueuedJobs->find()->count());
+    }
+
+    public function testRefresh_createsDuplicateJobIfCompleted() {
+        $this->Licensing->refresh_license_switch_list(4);
+        $QueuedJobs = TableRegistry::get('QueuedJobs');
+        $job = $QueuedJobs->find()->last();
+        $job->completed = '2019-01-01 01:02:03';
+        $QueuedJobs->save($job);
+        $this->Licensing->refresh_license_switch_list(4);
+
+        $QueuedJobs = TableRegistry::get('QueuedJobs');
+        $this->assertEquals(2, $QueuedJobs->find()->count());
+    }
+}

--- a/tests/TestCase/Model/Table/SentencesListsTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesListsTableTest.php
@@ -193,13 +193,13 @@ class SentencesListsTableTest extends TestCase {
     function testAddSentenceToList_failsBecauseSentenceAlreadyInList() {
         $result = $this->SentencesList->addSentenceToList(4, 1, 7);
 
-        $this->assertEmpty($result);
+        $this->assertFalse($result);
     }
 
     function testAddSentenceToList_failsBecauseUnknownSentenceId() {
         $result = $this->SentencesList->addSentenceToList(10000, 1, 7);
 
-        $this->assertEmpty($result);
+        $this->assertFalse($result);
     }
 
 

--- a/tests/TestCase/Model/Table/SentencesListsTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesListsTableTest.php
@@ -103,6 +103,9 @@ class SentencesListsTableTest extends TestCase {
                       ->where(['sentences_list_id' => $listId])->all();
         $this->assertEmpty($after);
 
+        $count = $this->SentencesList->get($listId)->numberOfSentences;
+        $this->assertEquals(0, $count);
+
         $all = $this->SentencesList->find()->all();
         $this->assertNotEmpty($all);
     }

--- a/tests/TestCase/Model/Table/SentencesListsTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesListsTableTest.php
@@ -203,6 +203,44 @@ class SentencesListsTableTest extends TestCase {
     }
 
 
+    function testAddSentencesToList_succeeds() {
+        $listId = 1;
+        $sentences = $this->SentencesList->Sentences->find()
+                          ->where(['user_id' => 1])->toList();
+        $before = $this->SentencesList->SentencesSentencesLists->find()
+            ->where(['sentences_list_id' => $listId])
+            ->count();
+
+        $result = $this->SentencesList->addSentencesToList($sentences, $listId, 7);
+        $this->assertTrue($result);
+
+        $after = $this->SentencesList->SentencesSentencesLists->find()
+            ->where(['sentences_list_id' => $listId])
+            ->count();
+        $this->assertEquals(count($sentences), $after - $before);
+    }
+
+    function testAddSentencesToList_incrementsCount() {
+        $listId = 1;
+        $sentences = $this->SentencesList->Sentences->find()
+                          ->where(['user_id' => 1])->toList();
+        $before = $this->SentencesList->get($listId)->numberOfSentences;
+
+        $this->SentencesList->addSentencesToList($sentences, $listId, 7);
+
+        $after = $this->SentencesList->get($listId)->numberOfSentences;
+        $this->assertEquals(count($sentences), $after - $before);
+    }
+
+    function testAddSentencesToList_failsBecauseSentenceAlreadyInList() {
+        $sentences = $this->SentencesList->Sentences->find()
+                          ->where(['user_id' => 7])->toList();
+        $result = $this->SentencesList->addSentencesToList($sentences, 1, 7);
+
+        $this->assertFalse($result);
+    }
+
+
     function testAddNewSentenceToList_succeeds() {
         $listId = 1;
         $lang = 'eng';

--- a/tests/TestCase/Model/Table/SentencesListsTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesListsTableTest.php
@@ -93,6 +93,33 @@ class SentencesListsTableTest extends TestCase {
         $this->assertFalse($list);
     }
 
+    function testEmptyList_succeeds() {
+        $listId = 1;
+
+        $result = $this->SentencesList->emptyList($listId, 7);
+        $this->assertTrue($result);
+
+        $after = $this->SentencesList->SentencesSentencesLists->find()
+                      ->where(['sentences_list_id' => $listId])->all();
+        $this->assertEmpty($after);
+
+        $all = $this->SentencesList->find()->all();
+        $this->assertNotEmpty($all);
+    }
+
+    function testEmptyList_fails() {
+        $listId = 1;
+        $before = $this->SentencesList->SentencesSentencesLists->find()
+                       ->where(['sentences_list_id' => $listId])->all();
+
+        $result = $this->SentencesList->emptyList(1, 1);
+        $this->assertFalse($result);
+
+        $after = $this->SentencesList->SentencesSentencesLists->find()
+                      ->where(['sentences_list_id' => $listId])->all();
+        $this->assertEquals($before, $after);
+    }
+
     function testEditName_suceeds() {
         $listId = 1;
         $newName = 'Very interesting French sentences';    

--- a/tests/TestCase/Shell/Task/QueueRefreshLicenseSwitchListTaskTest.php
+++ b/tests/TestCase/Shell/Task/QueueRefreshLicenseSwitchListTaskTest.php
@@ -61,4 +61,21 @@ class QueueRefreshLicenseSwitchListTaskTest extends TestCase
         $this->task->batchOperationSize = 1;
         $this->testRefreshList();
     }
+
+    public function testRefreshList_doesNotFailOnDuplicateLogRows()
+    {
+        $Contributions = TableRegistry::getTableLocator()->get('Contributions');
+        $row = $Contributions->find()
+            ->where([
+                'sentence_id' => 48,
+                'type' => 'sentence',
+                'action' => 'insert',
+            ])
+            ->first();
+        $row->id = null;
+        $row->isNew(true);
+        $Contributions->save($row);
+
+        $this->testRefreshList();
+    }
 }

--- a/tests/TestCase/Shell/Task/QueueRefreshLicenseSwitchListTaskTest.php
+++ b/tests/TestCase/Shell/Task/QueueRefreshLicenseSwitchListTaskTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace App\Test\TestCase\Shell\Task;
+
+use App\Shell\Task\QueueRefreshLicenseSwitchListTask;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOutput;
+use Cake\TestSuite\TestCase;
+use Cake\ORM\TableRegistry;
+use Cake\Core\Plugin;
+use Cake\Utility\Hash;
+use Cake\Core\Configure;
+
+class QueueRefreshLicenseSwitchListTaskTest extends TestCase
+{
+    public $fixtures = array(
+        'app.sentences',
+        'app.contributions',
+        'app.sentences_lists',
+        'app.sentences_sentences_lists',
+    );
+
+    public function setUp()
+    {
+        parent::setUp();
+        Configure::write('Acl.database', 'test');
+        Plugin::load('Queue');
+
+        $io = $this->getMockBuilder(ConsoleIo::class)->getMock();
+        $this->task = $this->getMockBuilder(QueueRefreshLicenseSwitchListTask::class)
+            ->setMethods(['in', 'err', 'createFile', '_stop', 'clear'])
+            ->setConstructorArgs([$io])
+            ->getMock();
+
+        $this->SentencesLists = TableRegistry::getTableLocator()->get('SentencesLists');
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        unset($this->task);
+    }
+
+    public function testRefreshList()
+    {
+        $userId = 4;
+        $list = $this->SentencesLists->createList('list name', $userId);
+        $listId = $list->id;
+        $expected = array(48, 53);
+
+        $this->task->run(compact('userId', 'listId'));
+
+        $after = $this->SentencesLists->SentencesSentencesLists->find()
+            ->where(['sentences_list_id' => $listId])
+            ->toList();
+        $afterIds = Hash::extract($after, '{n}.sentence_id');
+
+        $this->assertEquals($expected, $afterIds);
+    }
+
+    public function testRefreshList_batchedOperation() {
+        $this->task->batchOperationSize = 1;
+        $this->testRefreshList();
+    }
+}

--- a/tests/TestCase/Shell/Task/QueueSwitchSentencesLicenseTaskTest.php
+++ b/tests/TestCase/Shell/Task/QueueSwitchSentencesLicenseTaskTest.php
@@ -114,4 +114,9 @@ class QueueSwitchSentencesLicenseTaskTest extends TestCase
 
         $this->assertContains($fakeError, $this->task->getReport());
     }
+
+    public function testSwitchLicense_batchedOperation() {
+        $this->task->batchOperationSize = 1;
+        $this->testSwitchLicense();
+    }
 }

--- a/tests/TestCase/Shell/Task/QueueSwitchSentencesLicenseTaskTest.php
+++ b/tests/TestCase/Shell/Task/QueueSwitchSentencesLicenseTaskTest.php
@@ -96,4 +96,22 @@ class QueueSwitchSentencesLicenseTaskTest extends TestCase
 
         $this->assertEquals(1, $numPmAfter - $numPmBefore);
     }
+
+    public function testSwitchLicense_reportsErrors() {
+        $fakeError = "AAAAAH I'M DYIIIING";
+        $rule = function() use ($fakeError) {
+            return $fakeError;
+        };
+        $validator = $this->Sentences->getValidator();
+        $validator->add('license', 'always-fail', compact('rule'));
+
+        $options = array(
+            'userId' => 4,
+            'dryRun' => true,
+            'sendReport' => true,
+        );
+        $this->task->run($options);
+
+        $this->assertContains($fakeError, $this->task->getReport());
+    }
 }

--- a/tests/TestCase/Shell/Task/QueueSwitchSentencesLicenseTaskTest.php
+++ b/tests/TestCase/Shell/Task/QueueSwitchSentencesLicenseTaskTest.php
@@ -108,4 +108,14 @@ class QueueSwitchSentencesLicenseTaskTest extends TestCase
         $this->task->batchOperationSize = 1;
         $this->testSwitchLicense_all();
     }
+
+    public function testSwitchLicense_removesSentencesFromList()
+    {
+        $options = ['userId' => 4, 'listId' => 4];
+
+        $this->task->run($options);
+
+        $count = $this->Sentences->SentencesLists->getNumberOfSentences(4);
+        $this->assertEquals(0, $count);
+    }
 }

--- a/tests/TestCase/Shell/Task/QueueSwitchSentencesLicenseTaskTest.php
+++ b/tests/TestCase/Shell/Task/QueueSwitchSentencesLicenseTaskTest.php
@@ -65,7 +65,7 @@ class QueueSwitchSentencesLicenseTaskTest extends TestCase
     public function testSwitchLicense_all()
     {
         $expected = [48, 53];
-        $options = ['dryRun' => false, 'userId' => 4, 'listId' => 4];
+        $options = ['userId' => 4, 'listId' => 4];
         $this->_testSwitchLicense($expected, $options);
     }
 
@@ -73,24 +73,13 @@ class QueueSwitchSentencesLicenseTaskTest extends TestCase
     {
         $this->Sentences->SentencesLists->removeSentenceFromList(48, 4, 4);
         $expected = [53];
-        $options = ['dryRun' => false, 'userId' => 4, 'listId' => 4];
+        $options = ['userId' => 4, 'listId' => 4];
         $this->_testSwitchLicense($expected, $options);
-    }
-
-    public function testSwitchLicense_withDryRun()
-    {
-        $before = $this->Sentences->findAllByLicense('CC0 1.0');
-        $options = ['dryRun' => false, 'userId' => 4, 'listId' => 4];
-
-        $this->task->run($options);
-
-        $after = $this->Sentences->findAllByLicense('CC0 1.0');
-        $this->assertEquals($before, $after);
     }
 
     public function testSwitchLicense_sendsResultByPM()
     {
-        $options = ['dryRun' => false, 'userId' => 4, 'listId' => 4, 'sendReport' => true];
+        $options = ['userId' => 4, 'listId' => 4, 'sendReport' => true];
         CurrentUser::store(['id' => 4]);
         $numPmBefore = $this->PrivateMessages->find('all')->count();
         $this->task->run($options);
@@ -108,7 +97,7 @@ class QueueSwitchSentencesLicenseTaskTest extends TestCase
         $validator = $this->Sentences->getValidator();
         $validator->add('license', 'always-fail', compact('rule'));
 
-        $options = ['dryRun' => false, 'userId' => 4, 'listId' => 4, 'sendReport' => true];
+        $options = ['userId' => 4, 'listId' => 4, 'sendReport' => true];
 
         $this->task->run($options);
 

--- a/webroot/js/licensing/switch-license.ctrl.js
+++ b/webroot/js/licensing/switch-license.ctrl.js
@@ -1,0 +1,12 @@
+(function(){
+    angular.module('app').controller('switchLicenseCtrl', ['$scope', '$http', function ($scope, $http) {
+
+        $scope.refreshList = function () {
+            var rootUrl = get_tatoeba_root_url();
+            $http.post(rootUrl + "/licensing/refresh_license_switch_list")
+                 .then(
+                    function() { $scope.isRefreshing = true; }
+                 );
+        };
+    }]);
+})();

--- a/webroot/js/licensing/switch-license.ctrl.js
+++ b/webroot/js/licensing/switch-license.ctrl.js
@@ -26,7 +26,8 @@
                 $http.get(rootUrl + "/licensing/get_license_switch_list")
                 .then(
                     function(response) {
-                        angular.element('switchList').replaceWith(response);
+                        var switchList = document.getElementById('switchList');
+                        angular.element(switchList).replaceWith(response.data);
                         $scope.isRefreshing = false;
                     },
                     function() { /* a callback to prevent console warning */ }

--- a/webroot/js/licensing/switch-license.ctrl.js
+++ b/webroot/js/licensing/switch-license.ctrl.js
@@ -1,12 +1,53 @@
 (function(){
-    angular.module('app').controller('switchLicenseCtrl', ['$scope', '$http', function ($scope, $http) {
+    angular.module('app').controller('switchLicenseCtrl', ['$scope', '$http', '$interval', function ($scope, $http, $interval) {
 
+        $scope.init = function (isRefreshing) {
+            $scope.isRefreshing = isRefreshing;
+            refreshingStateChanged(isRefreshing);
+        };
+
+        var rootUrl = get_tatoeba_root_url();
         $scope.refreshList = function () {
-            var rootUrl = get_tatoeba_root_url();
             $http.post(rootUrl + "/licensing/refresh_license_switch_list")
                  .then(
                     function() { $scope.isRefreshing = true; }
                  );
         };
+
+        var stop;
+        var stopCheckingForList = function() {
+            if (angular.isDefined(stop)) {
+                $interval.cancel(stop);
+                stop = undefined;
+            }
+        };
+        var startCheckingForList = function () {
+            stop = $interval(function() {
+                $http.get(rootUrl + "/licensing/get_license_switch_list")
+                .then(
+                    function(response) {
+                        angular.element('switchList').replaceWith(response);
+                        $scope.isRefreshing = false;
+                    },
+                    function() { /* a callback to prevent console warning */ }
+                );
+            }, 2000);
+        };
+
+        var refreshingStateChanged = function(newValue) {
+            if (newValue == true) {
+                startCheckingForList();
+            } else {
+                stopCheckingForList();
+            }
+        };
+        $scope.$watch('isRefreshing', function(newValue, oldValue) {
+            if (oldValue == !newValue) {
+               refreshingStateChanged(newValue);
+            }
+        });
+
+        // Make sure that the $interval callback is destroyed
+        $scope.$on('$destroy', stopCheckingForList);
     }]);
 })();

--- a/webroot/js/responsive/app.module.js
+++ b/webroot/js/responsive/app.module.js
@@ -18,5 +18,7 @@
                 'application/x-www-form-urlencoded; charset=UTF-8';
             $httpProvider.defaults.headers.common['X-Requested-With'] =
                 'XMLHttpRequest';
+            $httpProvider.defaults.xsrfHeaderName = 'X-CSRF-Token';
+            $httpProvider.defaults.xsrfCookieName = 'csrfToken';
         }]);
 })();


### PR DESCRIPTION
This PR is an implementation of #1823.

Both the creation of the list and the license switch are performed by background jobs, so make sure to run `bin/cake Queue.Queue runworker` while testing. Note that the list can be manually edited between the two steps, as a primitive way of filtering out sentences.

Caveats:
* The list of affected sentences is displayed as such outside of the switch_my_sentences page.
* The list id is stored as a hidden user setting, which is not what it is meant for.