### PR TITLE
replace "moins libre" with "plus restrictive"

### DIFF
--- a/src/Locale/fr/terms-of-use.html
+++ b/src/Locale/fr/terms-of-use.html
@@ -148,7 +148,7 @@ La mention BY est également la condition de base pour les phrases audio, qui pe
 
 <p>Si nous souhaitons rendre possible la modification de licence d’une phrase, il ne faut pas négliger le fait que cette phrase aura déjà pu être réutilisée sous l’ancienne licence. Les implications de ce changement ne seront donc pas forcément rétroactives.</p>
 
-<p>Il est autorisé de rajouter des conditions à une licence <em>Creative Commons</em>, mais il est interdit d’en retirer. Cela signifie concrètement qu’il est possible de modifier une telle licence uniquement vers une licence moins libre.</p>
+<p>Il est autorisé de rajouter des conditions à une licence <em>Creative Commons</em>, mais il est interdit d’en retirer. Cela signifie concrètement qu’il est possible de modifier une telle licence uniquement vers une licence plus restrictive.</p>
 
 <p>Exemples :
 <ul>


### PR DESCRIPTION
Licence libre renvoie à la définition de la Free Software Foundation.
Dire qu'une licence copyleft est moins libre qu'une licence qui ne l'est pas est donc… discutable.
On peut par contre dire qu'elle est moins permissive ou plus restrictive.