### PR TITLE
Fix localization bug for audio icon tooltip

### DIFF
--- a/src/View/Helper/SentenceButtonsHelper.php
+++ b/src/View/Helper/SentenceButtonsHelper.php
@@ -187,10 +187,10 @@ class SentenceButtonsHelper extends AppHelper
             if (empty($author)) {
                 $title = __('Play audio');
             } else {
-                $title = __(format(
-                    'Play audio recorded by {author}',
+                $title = format(
+                    __('Play audio recorded by {author}', true),
                     array('author' => $author)
-                ), true);
+                );
             }
             $this->Html->script('sentences.play_audio.js', array('block' => 'scriptBottom'));
         } else {


### PR DESCRIPTION
The functions `__()` and `format()` are called in the wrong order. Thus the text of the tooltip for the audio icon when an audio file is available ("Play audio recorded by ...") cannot be translated.