### PR TITLE
Pagination only works reliable with distinct values

### DIFF
--- a/src/Controller/TagsController.php
+++ b/src/Controller/TagsController.php
@@ -104,7 +104,7 @@ class TagsController extends AppController
         $this->paginate = [
             'limit' => 50,
             'fields' => ['name', 'id', 'nbrOfSentences'],
-            'order' => ['id' => 'DESC'],
+            'order' => ['nbrOfSentences' => 'DESC', 'id' => 'ASC'],
             'conditions' => $conditions
         ];
 

--- a/src/Controller/TagsController.php
+++ b/src/Controller/TagsController.php
@@ -104,7 +104,7 @@ class TagsController extends AppController
         $this->paginate = [
             'limit' => 50,
             'fields' => ['name', 'id', 'nbrOfSentences'],
-            'order' => ['nbrOfSentences' => 'DESC'],
+            'order' => ['id' => 'DESC'],
             'conditions' => $conditions
         ];
 


### PR DESCRIPTION
This pull request addresses issue #1594.

Pagination depends on a stable result set because it queries the
database several times in order to split the result in pages. But
`view_all()` in the `Tags` controller uses `nbrOfSentences` as the
ordering which isn't stable because several tags could have the same
number of sentences linked to them and MySQL doesn't guarantee the
order when there is a tie.

Using `id` instead ensures that there will always be a tiebreaker
because its values are distinct.