### PR TITLE
Add missing numbers in sidebar table

### DIFF
--- a/src/Template/Users/for_language.ctp
+++ b/src/Template/Users/for_language.ctp
@@ -69,7 +69,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
                     $langCode
                 )
             );
-            $total = $language[0]['total'];
+            $total = $language->total;
             $selected = '';
             if ($lang == $langCode) {
                 $selected = 'selected';
@@ -78,7 +78,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
             echo '<tr class="'.$selected.'">';
             echo $this->Html->tag('td', $this->Languages->icon($langCode, array()));
             echo $this->Html->tag('td', $langName);
-            echo $this->Html->tag('td', $total);
+            echo $this->Html->tag('td', $this->Number->format($total));
             echo '</tr>';
         }
         ?>


### PR DESCRIPTION
Currently the sidebar on [Users for language xxx](https://tatoeba.org/eng/users/for_language) looks like 
![original](https://user-images.githubusercontent.com/6566321/66577633-07bee800-eb7a-11e9-84f5-f5e6a7483d83.png)
but reading the code it should look like 
![intention](https://user-images.githubusercontent.com/6566321/66577686-1c02e500-eb7a-11e9-8e90-af826956a823.png)

The reason is a wrong expression [on line 72](https://github.com/Tatoeba/tatoeba2/blob/935cd51557130cecffb92fe0089f3e512f16a987/src/Template/Users/for_language.ctp#L72) which assigns `NULL` to `$total`.