### PR TITLE
Avoid submitting an empty tag name

### DIFF
--- a/webroot/js/tags.add.js
+++ b/webroot/js/tags.add.js
@@ -31,31 +31,33 @@ $(document).ready(function() {
     });
 
     function addTag() {
-        var sentenceId = $("#tag-form [name='sentence_id']").val();
         var tagName = $("#tag-form [name='tag_name']").val();
-        var rootUrl = get_tatoeba_root_url();
-        var data = { "sentence_id": sentenceId, "tag_name": tagName };
+		if (tagName) {
+			var sentenceId = $("#tag-form [name='sentence_id']").val();
+			var rootUrl = get_tatoeba_root_url();
+			var data = { "sentence_id": sentenceId, "tag_name": tagName };
 
-        var csrfHeader = $('#tag-form [name="_csrfToken"]').val();
-        $('#tag-form input[name^="_Token"]').each(function() {
-            data[$(this).attr('name')] = $(this).val();
-        });
+			var csrfHeader = $('#tag-form [name="_csrfToken"]').val();
+			$('#tag-form input[name^="_Token"]').each(function() {
+				data[$(this).attr('name')] = $(this).val();
+			});
 
-        $("#TagTagName").val('');
-        $(".tagsListOnSentence").append(
-            "<div class='tags-loader loader'></div>"
-        );
-        $.ajax({
-            method: 'POST',
-            url: rootUrl + '/tags/add_tag_post',
-            headers: {
-                'X-CSRF-Token': csrfHeader
-            },
-            data: data,
-            success: function(data){
-                $(".tags-loader").first().replaceWith(data);
-            }
-        });
+			$("#TagTagName").val('');
+			$(".tagsListOnSentence").append(
+				"<div class='tags-loader loader'></div>"
+			);
+			$.ajax({
+				method: 'POST',
+				url: rootUrl + '/tags/add_tag_post',
+				headers: {
+					'X-CSRF-Token': csrfHeader
+				},
+				data: data,
+				success: function(data){
+					$(".tags-loader").first().replaceWith(data);
+				}
+			});
+		}
     }
 });
 


### PR DESCRIPTION
This PR addresses #1605.

Instead of displaying an error message, this proposed fix simply ignores submitting an empty tag name.