### PR TITLE
Add missing scripts to ngram_chars

### DIFF
--- a/src/Shell/SphinxConfShell.php
+++ b/src/Shell/SphinxConfShell.php
@@ -207,6 +207,8 @@ class SphinxConfShell extends Shell {
         'U+1780..U+17D2', 'U+17E0..U+17E9', 'U+17F0..U+17F9', 'U+19E0..U+19FF',
         # Thai (tha)
         'U+0E01..U+0E2E', 'U+0E30..U+0E3A', 'U+0E40..U+0E4E', 'U+0E50..U+0E59',
+        # Yi syllables, used by Nuosu (iii)
+        'U+A000..U+A48C',
     );
 
     public $regexpFilter = array(

--- a/src/Shell/SphinxConfShell.php
+++ b/src/Shell/SphinxConfShell.php
@@ -199,7 +199,7 @@ class SphinxConfShell extends Shell {
         # Lao (lao)
         'U+0E81', 'U+0E82', 'U+0E84', 'U+0E87', 'U+0E88', 'U+0E8A', 'U+0E8D', 'U+0E94..U+0E97', 'U+0E99..U+0E9F',
         'U+0EA1..U+0EA3', 'U+0EA5', 'U+0EA7', 'U+0EAA', 'U+0EAB', 'U+0EAD', 'U+0EAE', 'U+0EB0..U+0EB9', 'U+0EBB',
-        'U+0EC0..U+0EC4', 'U+0EC8..U+0ECD', 'U+0ED0..U+0ED9', 'U+0EDC..U+0EDF',
+        'U+0EBC', 'U+0EBD', 'U+0EC0..U+0EC4', 'U+EC6', 'U+0EC8..U+0ECD', 'U+0ED0..U+0ED9', 'U+0EDC..U+0EDF',
         # Tibetan (bod) (not sure about marks and signs)
         'U+0F00', 'U+0F20..U+0F33', 'U+0F40..U+0F47', 'U+0F49..U+0F6C', 'U+0F71..U+0F87', 'U+0F90..U+0F97',
         'U+0F99..U+0FBC', 'U+0FD0..U+0FD2',

--- a/src/Shell/SphinxConfShell.php
+++ b/src/Shell/SphinxConfShell.php
@@ -211,6 +211,8 @@ class SphinxConfShell extends Shell {
         'U+A000..U+A48C',
         # Javanese (jav)
         'U+A980..U+A9C0', 'U+A9CF..U+A9D9',
+        # Cuneiform, used by Sumerian (sux):
+        'U+12000..U+12399', 'U+12400..U+1246E', 'U+12480..U+12543',
     );
 
     public $regexpFilter = array(

--- a/src/Shell/SphinxConfShell.php
+++ b/src/Shell/SphinxConfShell.php
@@ -194,6 +194,8 @@ class SphinxConfShell extends Shell {
         'U+FF8D->U+30D8', 'U+FF8E->U+30DB', 'U+FF8F..U+FF93->U+30DE..U+30E2', 'U+FF94->U+30E4',
         'U+FF95->U+30E6', 'U+FF96->U+30E8', 'U+FF97->U+30E9', 'U+FF98->U+30EA', 'U+FF99->U+30EB',
         'U+FF9A->U+30EC', 'U+FF9B->U+30ED', 'U+FF9C->U+30EF', 'U+FF9D->U+30F3',
+        # Katakana Phonetic Extensions
+        'U+31F0..U+31FF',
         # Lao (lao)
         'U+0E81', 'U+0E82', 'U+0E84', 'U+0E87', 'U+0E88', 'U+0E8A', 'U+0E8D', 'U+0E94..U+0E97', 'U+0E99..U+0E9F',
         'U+0EA1..U+0EA3', 'U+0EA5', 'U+0EA7', 'U+0EAA', 'U+0EAB', 'U+0EAD', 'U+0EAE', 'U+0EB0..U+0EB9', 'U+0EBB',

--- a/src/Shell/SphinxConfShell.php
+++ b/src/Shell/SphinxConfShell.php
@@ -209,6 +209,8 @@ class SphinxConfShell extends Shell {
         'U+0E01..U+0E2E', 'U+0E30..U+0E3A', 'U+0E40..U+0E4E', 'U+0E50..U+0E59',
         # Yi syllables, used by Nuosu (iii)
         'U+A000..U+A48C',
+        # Javanese (jav)
+        'U+A980..U+A9C0', 'U+A9CF..U+A9D9',
     );
 
     public $regexpFilter = array(


### PR DESCRIPTION
This PR adds or improves for support for a number of scripts. See issue #1970, section "Other Unsearchable Characters".

# Katakana Phonetic Extensions
The characters from U+31F0 ㇰ to U+31FF ㇿ are used to write Ainu.
Unicode Block: https://www.unicode.org/charts/PDF/U31F0.pdf

# Yi
The characters from U+A000 ꀀ to U+A48C ꒌ are used to write Yi
languages like Nuosu (iii). No Yi language has been added to Tatoeba
yet, and the person who added the sentences using Yi syllables has not
responded to [my attempt at making
contact](https://tatoeba.org/eng/sentences/show/8191359#comment-1126914) so far.
Adding the script anyway probably won't hurt.

Unicode Block: http://unicode.org/charts/PDF/UA000.pdf

# Javanese
Although most Javanese (jav) sentences on Tatoeba use Latin, some use the historical Javanese script.
There are a few punctuation marks, which I have excluded.

Unicode Block: https://www.unicode.org/charts/PDF/UA980.pdf

# Lao
A handful of characters seem to have been missed when the Lao script was
added.

Unicode Block: https://www.unicode.org/charts/PDF/U0E80.pdf

# Cuneiform
Cuneiform is used to write Sumerian (sux).
There are three Unicode blocks:
  - Cuneiform: https://www.unicode.org/charts/PDF/U12000.pdf
  - Cuneiform Numbers and Punctuation: https://www.unicode.org/charts/PDF/U12400.pdf
  - Early Dynastic Cuneiform: https://www.unicode.org/charts/PDF/U12480.pdf

I omitted the punctuation.