### PR TITLE
Fix typos which broke audio filter for searches

### DIFF
--- a/src/Template/Element/advanced_search_form.ctp
+++ b/src/Template/Element/advanced_search_form.ctp
@@ -114,9 +114,9 @@ echo $this->Form->create('AdvancedSearch', [
             </div>
             
             <div class="param" layout="row" layout-align="center">
-                <label for="has_audio" flex><?= __('Has audio:') ?></label>
+                <label for="has-audio" flex><?= __('Has audio:') ?></label>
                 <?php
-                echo $this->Form->input('has-audio', array(
+                echo $this->Form->input('has_audio', array(
                     'label' => '',
                     'options' => array(
                         '' => __x('audio', 'Any'),


### PR DESCRIPTION
5f5c4fd1bcf5edfa2f614de1005fe673b34b31b4 introduced some typos which broke the filter for audio.