### PR TITLE
Fix search link for vocabulary item

### DIFF
--- a/src/View/Helper/VocabularyHelper.php
+++ b/src/View/Helper/VocabularyHelper.php
@@ -52,7 +52,9 @@ class VocabularyHelper extends AppHelper
                 'action' => 'search',
                 '?' => array(
                     'query' => Search::exactSearchQuery($text),
-                    'from' => $lang
+                    'from' => $lang,
+                    'orphans' => '',
+                    'unapproved' => ''
                 )
             ));
         }

--- a/webroot/js/vocabulary/add.ctrl.js
+++ b/webroot/js/vocabulary/add.ctrl.js
@@ -57,7 +57,8 @@
                         var query = encodeURIComponent(data.query);
                         data.url = '/sentences/search?' +
                             'query=' + query + '&' +
-                            'from=' + data.lang;
+                            'from=' + data.lang +
+                            '&orphans=&unapproved=';
                     }
                     vm.vocabularyAdded.unshift(data);
                     vm.data.text = '';


### PR DESCRIPTION
This PR addresses the second part of #1886.

Include orphan and unapproved sentences in the search for a vocabulary item. This fixes a mismatch between the count on the result page and the count on the vocabulary page.