### PR TITLE
Add original sentences filter on a user's sentences page

### DIFF
--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -875,12 +875,14 @@ class SentencesController extends AppController
         // if there's no such user no need to do more computation
         $this->set("userName", $userName);
         if (empty($userId)) {
-
             $this->set("userExists", false);
             return;
         }
 
         $this->set("userExists", true);
+
+        $onlyOriginal = array_key_exists('only_original', $this->request->getQueryParams());
+        $this->set('onlyOriginal', $onlyOriginal);
 
         $this->paginate = array(
             'Sentences' => array(
@@ -904,11 +906,14 @@ class SentencesController extends AppController
             )
         );
 
-
         $conditions = $this->Sentences->find()->where(['user_id' => $userId]);
         // if the lang is specified then we also filter on the language
         if (!empty($lang)) {
             $conditions = $conditions->where(['lang' => $lang]);
+        }
+
+        if ($onlyOriginal) {
+            $conditions = $conditions->where('based_on_id = 0');
         }
 
         try {

--- a/src/Template/Sentences/of_user.ctp
+++ b/src/Template/Sentences/of_user.ctp
@@ -56,9 +56,19 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
     );
 
     $this->CommonModules->createFilterByLangMod(2);
-    ?>
-</div>
 
+    echo $this->Html->script('sentences/only_original.ctrl.js', ['block' => 'scriptBottom']);
+    ?>
+    <div ng-controller="OriginalSentencesController" class="section md-whiteframe-1dp" layout="column">
+        <md-checkbox
+            class="md-primary"
+            ng-model="original"
+            ng-checked="<?= $onlyOriginal ?>"
+            ng-click="toggle()">
+            <?= __('Only show original sentences') ?>
+        </md-checkbox>
+    </div>
+</div>
 
 <div id="main_content">
     <div class="section md-whiteframe-1dp">
@@ -96,6 +106,12 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
         <div class="sortBy">
             <strong><?php echo __("Sort by:") ?> </strong>
             <?php
+            if ($onlyOriginal) {
+                $urlOptions = $this->Paginator->generateUrlParams(
+                    array('?' => array('only_original' => ''))
+                );
+                $this->Paginator->options(array('url' => $urlOptions));
+            }
             echo $this->Paginator->sort('modified', __('date modified'));
             echo " | ";
             echo $this->Paginator->sort('created', __('date created'));

--- a/src/Template/Sentences/of_user.ctp
+++ b/src/Template/Sentences/of_user.ctp
@@ -57,17 +57,20 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
 
     $this->CommonModules->createFilterByLangMod(2);
 
-    echo $this->Html->script('sentences/only_original.ctrl.js', ['block' => 'scriptBottom']);
-    ?>
-    <div ng-controller="OriginalSentencesController" class="section md-whiteframe-1dp" layout="column">
-        <md-checkbox
-            class="md-primary"
-            ng-model="original"
-            ng-checked="<?= $onlyOriginal ?>"
-            ng-click="toggle()">
-            <?= __('Only show original sentences') ?>
-        </md-checkbox>
-    </div>
+    if (isset($onlyOriginal)) {
+        echo $this->Html->script('sentences/only_original.ctrl.js', ['block' => 'scriptBottom']);
+        ?>
+        <div ng-controller="OriginalSentencesController" class="section md-whiteframe-1dp" layout="column">
+            <md-checkbox
+                class="md-primary"
+                ng-model="original"
+                ng-checked="<?= $onlyOriginal ?>"
+                ng-click="toggle()">
+                <?= __('Only show original sentences') ?>
+            </md-checkbox>
+        </div>
+        <?php
+     } ?>
 </div>
 
 <div id="main_content">

--- a/src/View/Helper/CommonModulesHelper.php
+++ b/src/View/Helper/CommonModulesHelper.php
@@ -50,11 +50,11 @@ class CommonModulesHelper extends AppHelper
     );
 
     /**
-     * create a module where one can filter the page by lang
+     * Create a module for filtering a page by language
      *
-     * @param int $maxNumberOfParams The numbers of params use in the controller
-     *                               to generate the view where you include this
-     *                               NOTE: the lang must be the last params
+     * @param int $maxNumberOfParams The number of parameters used in the controller
+     *                               for the view which uses this module
+     *                               NOTE: the language must be the last parameter
      *
      * @return void
      */
@@ -64,8 +64,8 @@ class CommonModulesHelper extends AppHelper
         <div class="section md-whiteframe-1dp" layout="column">
             <h2><?php echo __('Filter by language'); ?></h2>
             <?php
-            /*to stay on the same page except language filter option*/
-            // we reconstruct the path
+            // In order to stay on the same page we reconstruct the path
+            // without the language parameter
             $path ='/';
             // language of the interface
             $path .= $this->request->params['lang'] .'/';
@@ -73,15 +73,14 @@ class CommonModulesHelper extends AppHelper
             $path .= $this->request->params['action'].'/';
 
             $params = $this->request->params['pass'];
-
             $numberOfParams = count($params);
 
-            $paramsWitoutLang = $numberOfParams;
+            $paramsWithoutLang = $numberOfParams;
             if ($numberOfParams === $maxNumberOfParams) {
-                $paramsWitoutLang--;
+                $paramsWithoutLang--;
             }
 
-            for ($i = 0; $i < $paramsWitoutLang; $i++) {
+            for ($i = 0; $i < $paramsWithoutLang; $i++) {
                 $path .= $params[$i] .'/';
             }
 
@@ -92,6 +91,12 @@ class CommonModulesHelper extends AppHelper
 
             $langs = $this->Languages->languagesArrayAlone();
 
+            // Avoid loosing the query parameters
+            $query = parse_url($this->request->getRequestTarget(), PHP_URL_QUERY);
+            if (!empty($query)) {
+                $query = '?' . $query;
+            }
+
             echo $this->Form->select(
                 'filterLanguageSelect',
                 $langs,
@@ -99,9 +104,9 @@ class CommonModulesHelper extends AppHelper
                     "value" => $lang,
                     "onchange" => "
                         if (this.value == 'und') {
-                            $(location).attr('href','$path');
+                            $(location).attr('href','$path' + '$query');
                         } else {
-                            $(location).attr('href','$path' + this.value);
+                            $(location).attr('href','$path' + this.value + '$query');
                         }",
                     // the if is to avoid a duplicate page (with and without "und")
                     "class" => "language-selector",

--- a/webroot/js/sentences/only_original.ctrl.js
+++ b/webroot/js/sentences/only_original.ctrl.js
@@ -1,0 +1,43 @@
+/*
+    Tatoeba Project, free collaborative creation of multilingual corpuses project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+(function() {
+    'use strict';
+
+    angular
+        .module('app')
+        .controller('OriginalSentencesController', [
+            '$scope', '$window', OriginalSentencesController
+        ]);
+
+    function OriginalSentencesController($scope, $window) {
+        $scope.toggle = function() {
+            var oldQuery = $window.location.search;
+            if ($scope.original) {
+                    var newQuery = oldQuery.replace(/only_original=&?/, '');
+            } else {
+                if (oldQuery.indexOf('?') > -1) {
+                    var newQuery = oldQuery.replace('?', '?only_original=&');
+                } else {
+                    var newQuery = oldQuery + '?only_original=';
+                }
+            }
+            $window.location.search = newQuery;
+        }
+    }
+
+})();

--- a/webroot/js/sentences/only_original.ctrl.js
+++ b/webroot/js/sentences/only_original.ctrl.js
@@ -26,17 +26,13 @@
 
     function OriginalSentencesController($scope, $window) {
         $scope.toggle = function() {
-            var oldQuery = $window.location.search;
+            var searchParams = new URLSearchParams($window.location.search);
             if ($scope.original) {
-                    var newQuery = oldQuery.replace(/only_original=&?/, '');
+                searchParams.delete('only_original');
             } else {
-                if (oldQuery.indexOf('?') > -1) {
-                    var newQuery = oldQuery.replace('?', '?only_original=&');
-                } else {
-                    var newQuery = oldQuery + '?only_original=';
-                }
+                searchParams.set('only_original', '');
             }
-            $window.location.search = newQuery;
+            $window.location.search = searchParams.toString();
         }
     }
 


### PR DESCRIPTION
This PR addresses #1698.

The first commit adds a checkbox on a user's sentences page to filter original sentences.

The second commit changes the behavior of the language filter so that an existing query string isn't lost when the language is changed. I personally find that more useful but I will remove it if it is not wanted.