### PR TITLE
Internationalize dates

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -268,3 +268,4 @@ if (!function_exists('__format_decompose_list')) {
 
 Cake\I18n\I18n::setDefaultFormatter('sprintf');
 Cake\I18n\Time::setToStringFormat('yyyy-MM-dd HH:mm:ss');
+Cake\I18n\Time::$niceFormat = [\IntlDateFormatter::LONG, \IntlDateFormatter::SHORT];

--- a/src/Template/Collections/of.ctp
+++ b/src/Template/Collections/of.ctp
@@ -151,7 +151,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
                 echo $this->Html->div(
                     'correctness',
                     $this->Images->correctnessIcon($correctness),
-                    array('title' => $item->modified)
+                    array('title' => $this->Time->nice($item->modified))
                 );
 
                 echo '</div>';

--- a/src/Template/Contributions/activity_timeline.ctp
+++ b/src/Template/Contributions/activity_timeline.ctp
@@ -87,8 +87,9 @@ foreach ($stats as $stat) {
             array('style' => 'width:'.$width.'%')
         );
 
+        $formattedDate = $this->Time->i18nFormat($date, [IntlDateFormatter::SHORT, IntlDateFormatter::NONE]);
         echo '<tr>';
-        echo $this->Html->tag('td', $date, array('class' => 'date'));
+        echo $this->Html->tag('td', $formattedDate, array('class' => 'date'));
         echo $this->Html->tag('td', $this->Number->format($numSentences), array('class' => 'number'));
         echo $this->Html->tag('td', $bar, array('class' => 'bar'));
         echo '</tr>';

--- a/src/Template/Element/sentence_comments/comment.ctp
+++ b/src/Template/Element/sentence_comments/comment.ctp
@@ -56,17 +56,9 @@ $sentenceUrl = $this->Url->build(array(
     'action' => 'show',
     $sentenceId
 ));
-if (empty($modifiedDate) || $createdDate == $modifiedDate) {
-    $dateLabel = $this->Date->ago($createdDate);
-} else {
-    $dateLabel = format(
-        __x('sentence comment', '{createdDate}, edited {modifiedDate}'),
-        array(
-            'createdDate' => $this->Date->ago($createdDate),
-            'modifiedDate' => $this->Date->ago($modifiedDate, false)
-        )
-    );
-}
+$labelText = __x('sentence comment', '{createdDate}, edited {modifiedDate}');
+$dateLabel = $this->Date->getDateLabel($labelText, $createdDate, $modifiedDate);
+$dateTooltip = $this->Date->getDateLabel($labelText, $createdDate, $modifiedDate, true);
 $canViewContent = CurrentUser::isAdmin() || CurrentUser::get('id') == $authorId;
 $userProfileUrl = $this->Url->build(array(
     'controller' => 'user',
@@ -123,7 +115,7 @@ if ($sentenceOwnerLink) {
             </span>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>
-                <md-tooltip ng-cloak><?= $dateLabel ?></md-tooltip>
+                <md-tooltip ng-cloak><?= $dateTooltip ?></md-tooltip>
             </span>
         </md-card-header-text>
 

--- a/src/Template/Element/sentence_comments/comment.ctp
+++ b/src/Template/Element/sentence_comments/comment.ctp
@@ -58,20 +58,12 @@ $sentenceUrl = $this->Url->build(array(
 ));
 if (empty($modifiedDate) || $createdDate == $modifiedDate) {
     $dateLabel = $this->Date->ago($createdDate);
-    $fullDateLabel = $createdDate;
 } else {
     $dateLabel = format(
-        __('{createdDate}, edited {modifiedDate}'),
+        __x('sentence comment', '{createdDate}, edited {modifiedDate}'),
         array(
             'createdDate' => $this->Date->ago($createdDate),
-            'modifiedDate' => $this->Date->ago($modifiedDate)
-        )
-    );
-    $fullDateLabel = format(
-        __('{createdDate}, edited {modifiedDate}'),
-        array(
-            'createdDate' => $createdDate,
-            'modifiedDate' => $modifiedDate
+            'modifiedDate' => $this->Date->ago($modifiedDate, false)
         )
     );
 }
@@ -131,7 +123,7 @@ if ($sentenceOwnerLink) {
             </span>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>
-                <md-tooltip ng-cloak><?= $fullDateLabel ?></md-tooltip>
+                <md-tooltip ng-cloak><?= $dateLabel ?></md-tooltip>
             </span>
         </md-card-header-text>
 

--- a/src/Template/Element/sentence_comments/edit_form.ctp
+++ b/src/Template/Element/sentence_comments/edit_form.ctp
@@ -11,20 +11,12 @@ $modifiedDate = $comment->modified;
 
 if (empty($modifiedDate) || $createdDate == $modifiedDate) {
     $dateLabel = $this->Date->ago($createdDate);
-    $fullDateLabel = $createdDate;
 } else {
     $dateLabel = format(
-        __('{createdDate}, edited {modifiedDate}'),
+        __x('sentence comment', '{createdDate}, edited {modifiedDate}'),
         array(
             'createdDate' => $this->Date->ago($createdDate),
-            'modifiedDate' => $this->Date->ago($modifiedDate)
-        )
-    );
-    $fullDateLabel = format(
-        __('{createdDate}, edited {modifiedDate}'),
-        array(
-            'createdDate' => $createdDate,
-            'modifiedDate' => $modifiedDate
+            'modifiedDate' => $this->Date->ago($modifiedDate, false)
         )
     );
 }
@@ -49,7 +41,7 @@ $cancelUrl = $this->Url->build([
             </span>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>
-                <md-tooltip ng-cloak><?= $fullDateLabel ?></md-tooltip>
+                <md-tooltip ng-cloak><?= $dateLabel ?></md-tooltip>
             </span>
         </md-card-header-text>
     </md-card-header>

--- a/src/Template/Element/sentence_comments/edit_form.ctp
+++ b/src/Template/Element/sentence_comments/edit_form.ctp
@@ -9,17 +9,9 @@ $text = $comment->text;
 $createdDate = $comment->created;
 $modifiedDate = $comment->modified;
 
-if (empty($modifiedDate) || $createdDate == $modifiedDate) {
-    $dateLabel = $this->Date->ago($createdDate);
-} else {
-    $dateLabel = format(
-        __x('sentence comment', '{createdDate}, edited {modifiedDate}'),
-        array(
-            'createdDate' => $this->Date->ago($createdDate),
-            'modifiedDate' => $this->Date->ago($modifiedDate, false)
-        )
-    );
-}
+$labelText = __x('sentence comment', '{createdDate}, edited {modifiedDate}');
+$dateLabel = $this->Date->getDateLabel($labelText, $createdDate, $modifiedDate);
+$dateTooltip = $this->Date->getDateLabel($labelText, $createdDate, $modifiedDate, true); 
 
 $cancelUrl = $this->Url->build([
     "controller" => "sentences",
@@ -41,7 +33,7 @@ $cancelUrl = $this->Url->build([
             </span>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>
-                <md-tooltip ng-cloak><?= $dateLabel ?></md-tooltip>
+                <md-tooltip ng-cloak><?= $dateTooltip ?></md-tooltip>
             </span>
         </md-card-header-text>
     </md-card-header>

--- a/src/Template/Element/wall/edit_form.ctp
+++ b/src/Template/Element/wall/edit_form.ctp
@@ -7,20 +7,12 @@ $modifiedDate = $message->modified;
 
 if (empty($modifiedDate) || $createdDate == $modifiedDate) {
     $dateLabel = $this->Date->ago($createdDate);
-    $fullDateLabel = $createdDate;
 } else {
     $dateLabel = format(
-        __('{createdDate}, edited {modifiedDate}'),
+        __x('wall message', '{createdDate}, edited {modifiedDate}'),
         array(
             'createdDate' => $this->Date->ago($createdDate),
-            'modifiedDate' => $this->Date->ago($modifiedDate)
-        )
-    );
-    $fullDateLabel = format(
-        __('{createdDate}, edited {modifiedDate}'),
-        array(
-            'createdDate' => $createdDate,
-            'modifiedDate' => $modifiedDate
+            'modifiedDate' => $this->Date->ago($modifiedDate, false)
         )
     );
 }
@@ -44,7 +36,7 @@ $cancelUrl = $this->Url->build([
             </span>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>
-                <md-tooltip ng-cloak><?= $fullDateLabel ?></md-tooltip>
+                <md-tooltip ng-cloak><?= $dateLabel ?></md-tooltip>
             </span>
         </md-card-header-text>
     </md-card-header>

--- a/src/Template/Element/wall/edit_form.ctp
+++ b/src/Template/Element/wall/edit_form.ctp
@@ -5,17 +5,9 @@ $avatar = $user['image'];
 $createdDate = $message->date;
 $modifiedDate = $message->modified;
 
-if (empty($modifiedDate) || $createdDate == $modifiedDate) {
-    $dateLabel = $this->Date->ago($createdDate);
-} else {
-    $dateLabel = format(
-        __x('wall message', '{createdDate}, edited {modifiedDate}'),
-        array(
-            'createdDate' => $this->Date->ago($createdDate),
-            'modifiedDate' => $this->Date->ago($modifiedDate, false)
-        )
-    );
-}
+$labelText = __x('wall message', '{createdDate}, edited {modifiedDate}');
+$dateLabel = $this->Date->getDateLabel($labelText, $createdDate, $modifiedDate);
+$dateTooltip = $this->Date->getDateLabel($labelText, $createdDate, $modifiedDate, true);
 
 $cancelUrl = $this->Url->build([
     'action' => 'show_message',
@@ -36,7 +28,7 @@ $cancelUrl = $this->Url->build([
             </span>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>
-                <md-tooltip ng-cloak><?= $dateLabel ?></md-tooltip>
+                <md-tooltip ng-cloak><?= $dateTooltip ?></md-tooltip>
             </span>
         </md-card-header-text>
     </md-card-header>

--- a/src/Template/Element/wall/message.ctp
+++ b/src/Template/Element/wall/message.ctp
@@ -23,13 +23,9 @@ if (empty($modifiedDate) || $createdDate == $modifiedDate) {
     $dateLabel = $this->Date->ago($createdDate);
 } else {
     $dateLabel = format(
-        /* @translators: If you need to conjugate the verb "edited" you can indicate
-           the correct form here. The word itself and all its derived forms should be
-           translated at another place in this file. */
-        __x('wall message', '{createdDate}, {edited} {modifiedDate}'),
+        __x('wall message', '{createdDate}, edited {modifiedDate}'),
         array(
             'createdDate' => $this->Date->ago($createdDate),
-            'edited' => __('edited'),
             'modifiedDate' => $this->Date->ago($modifiedDate, false)
         )
     );

--- a/src/Template/Element/wall/message.ctp
+++ b/src/Template/Element/wall/message.ctp
@@ -19,17 +19,9 @@ $editUrl = $this->Url->build(array(
     $messageId
 ));
 
-if (empty($modifiedDate) || $createdDate == $modifiedDate) {
-    $dateLabel = $this->Date->ago($createdDate);
-} else {
-    $dateLabel = format(
-        __x('wall message', '{createdDate}, edited {modifiedDate}'),
-        array(
-            'createdDate' => $this->Date->ago($createdDate),
-            'modifiedDate' => $this->Date->ago($modifiedDate, false)
-        )
-    );
-}
+$labelText = __x('wall message', '{createdDate}, edited {modifiedDate}');
+$dateLabel = $this->Date->getDateLabel($labelText, $createdDate, $modifiedDate);
+$dateTooltip = $this->Date->getDateLabel($labelText, $createdDate, $modifiedDate, true);
 $canViewContent = CurrentUser::isAdmin() || CurrentUser::get('id') == $authorId;
 $userProfileUrl = $this->Url->build(array(
     'controller' => 'user',
@@ -72,7 +64,7 @@ $canReply = false;
             </span>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>
-                <md-tooltip ng-cloak><?= $dateLabel ?></md-tooltip>
+                <md-tooltip ng-cloak><?= $dateTooltip ?></md-tooltip>
             </span>
         </md-card-header-text>
 

--- a/src/Template/Element/wall/message.ctp
+++ b/src/Template/Element/wall/message.ctp
@@ -21,20 +21,16 @@ $editUrl = $this->Url->build(array(
 
 if (empty($modifiedDate) || $createdDate == $modifiedDate) {
     $dateLabel = $this->Date->ago($createdDate);
-    $fullDateLabel = $createdDate;
 } else {
     $dateLabel = format(
-        __('{createdDate}, edited {modifiedDate}'),
+        /* @translators: If you need to conjugate the verb "edited" you can indicate
+           the correct form here. The word itself and all its derived forms should be
+           translated at another place in this file. */
+        __x('wall message', '{createdDate}, {edited} {modifiedDate}'),
         array(
             'createdDate' => $this->Date->ago($createdDate),
-            'modifiedDate' => $this->Date->ago($modifiedDate)
-        )
-    );
-    $fullDateLabel = format(
-        __('{createdDate}, edited {modifiedDate}'),
-        array(
-            'createdDate' => $createdDate,
-            'modifiedDate' => $modifiedDate
+            'edited' => __('edited'),
+            'modifiedDate' => $this->Date->ago($modifiedDate, false)
         )
     );
 }
@@ -80,7 +76,7 @@ $canReply = false;
             </span>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>
-                <md-tooltip ng-cloak><?= $fullDateLabel ?></md-tooltip>
+                <md-tooltip ng-cloak><?= $dateLabel ?></md-tooltip>
             </span>
         </md-card-header-text>
 

--- a/src/Template/Sentences/show.ctp
+++ b/src/Template/Sentences/show.ctp
@@ -87,7 +87,7 @@ echo $this->element('/sentences/navigation', [
                 ),
                 array(
                     'class' => 'username',
-                    'title' => $correctness->modified
+                    'title' => $this->Time->nice($correctness->modified)
                 )
             );
             if ($correctness->dirty != 0) {

--- a/src/Template/User/profile.ctp
+++ b/src/Template/User/profile.ctp
@@ -37,15 +37,14 @@ use App\Model\CurrentUser;
  * @link     https://tatoeba.org
  */
 
-$dateFormat = 'Y-m-d';
+$dateFormat = [\IntlDateFormatter::LONG, \IntlDateFormatter::NONE];
 $userId = $user['id'];
 $realName = $user['name'];
 $username = $user['username'];
 $userDescription = h($user['description']);
 $homepage = $user['homepage'];
 $birthday = $user['birthday'];
-$userSince = $user['since'];
-$userSince = date($dateFormat, strtotime($userSince));
+$userSince = $this->Time->i18nFormat($user['since'], $dateFormat);
 $userStatus = $this->Members->groupName($user->role);
 $statusClass = 'status_'.$user->role;
 $currentMember = CurrentUser::get('username');

--- a/src/View/Helper/DateHelper.php
+++ b/src/View/Helper/DateHelper.php
@@ -42,6 +42,41 @@ class DateHelper extends AppHelper
 {
     private $_months;
 
+    public $helpers = array('Time');
+
+    /**
+     * Create the date label used for comments, wall messages, ...
+     *
+     * @param string  $text     Text for the label. It must contain both
+     *                          "{createdDate}" and "{modifiedDate}" placeholders.
+     * @param string  $created  Creation datetime (in MySQL format)
+     * @param string  $modified Modification datetime (in MySQL format)
+     * @param boolean $tooltip  When the label is used for a tooltip the dates will
+     *                          always be exact.
+     *
+     * @return string
+     */
+    public function getDateLabel($text, $created, $modified, $tooltip=false)
+    {
+        if (empty($modified) || $created == $modified) {
+            if ($tooltip) {
+                return $this->Time->nice($created);
+            } else {
+                return $this->ago($created);
+            }
+        } else {
+            if ($tooltip) {
+                return format($text,
+                              array('createdDate' => $this->Time->nice($created),
+                                    'modifiedDate' => $this->Time->nice($modified)));
+            } else {
+                return format($text,
+                              array('createdDate' => $this->ago($created),
+                                    'modifiedDate' => $this->ago($modified, false)));
+            }
+        }
+    }
+
     /**
      * Display how long ago compared to now.
      *

--- a/src/View/Helper/DateHelper.php
+++ b/src/View/Helper/DateHelper.php
@@ -56,12 +56,12 @@ class DateHelper extends AppHelper
             return __('date unknown');
         }
 
-        $dateObj = Time::createFromFormat('Y-m-d H:i:s', $date);
+        $dateObj = Time::parseDateTime($date);
 
         $diff = Time::fromNow($dateObj);
 
         if ($diff->days > 30) {
-            $formattedDate = $dateObj->i18nFormat([\IntlDateFormatter::LONG, \IntlDateFormatter::SHORT]);
+            $formattedDate = $dateObj->nice();
 
             if ($alone) {
                 return $formattedDate;
@@ -142,8 +142,7 @@ class DateHelper extends AppHelper
         }
 
         if ($this->_isCompleteDate($dateArray)) {
-            return Time::createFromFormat('Y-m-d H:i:s', $dateTime)
-                   ->i18nFormat($dateFormat);
+            return Time::parseDateTime($dateTime)->i18nFormat($dateFormat);
         }
 
         return $this->_formatIncompleteDate($dateArray);

--- a/src/View/Helper/LogsHelper.php
+++ b/src/View/Helper/LogsHelper.php
@@ -113,7 +113,7 @@ class LogsHelper extends AppHelper
     public function getInfoLabel($type, $action, $username = null, $date = null) {
         $date = $date ? $date->format('Y-m-d H:i:s') : null;
         $userProfileLink = $username ? $this->_linkToUserProfile($username) : null;
-        $dateLabel = $this->Date->ago($date);
+        $dateLabel = $this->Date->ago($date, false);
 
         switch ($action) {
             case 'insert' :

--- a/src/View/Helper/TagsHelper.php
+++ b/src/View/Helper/TagsHelper.php
@@ -45,6 +45,7 @@ class TagsHelper extends AppHelper
         'Html',
         'Form',
         'Sentences',
+        'Time'
     );
 
     /**
@@ -141,7 +142,7 @@ class TagsHelper extends AppHelper
         if ($username != null) {
             $options["title"] = format(
                 __("Added by {username}, {date}"),
-                compact('username', 'date')
+                array('username' => $username, 'date' => $this->Time->nice($date))
             );
         }
         echo $this->Html->link(

--- a/tests/TestCase/View/Helper/DateHelperTest.php
+++ b/tests/TestCase/View/Helper/DateHelperTest.php
@@ -87,4 +87,37 @@ class DateHelperTest extends TestCase {
         $result = $this->DateHelper->formatBirthday($dateTime, $dateFormat);
         $this->assertEquals($expected, $result);
     }
+
+    public function getDateLabelContentProvider() {
+        return [
+            'created within 30 days eng' =>
+            ['{createdDate}, edited {modifiedDate}', '2018-09-29 09:12:34', '2018-09-29 09:12:34', false, 'en', '25&nbsp;days ago'],
+            'created within 30 days tooltip eng' =>
+            ['{createdDate}, edited {modifiedDate}', '2018-09-09 09:12:34', '2018-09-09 09:12:34', true, 'en', 'September 9, 2018 at 9:12 AM'],
+            'created and modified within 30 days eng' =>
+            ['{createdDate}, edited {modifiedDate}', '2018-09-29 09:12:34', '2018-10-10 01:23:45', false, 'en', '25&nbsp;days ago, edited 14&nbsp;days ago'],
+            'created and modified within 30 days tooltip eng' =>
+            ['{createdDate}, edited {modifiedDate}', '2018-09-09 09:12:34', '2018-10-10 01:23:45', true, 'en', 'September 9, 2018 at 9:12 AM, edited October 10, 2018 at 1:23 AM'],
+            'created eng' =>
+            ['{createdDate}, edited {modifiedDate}', '2017-09-29 09:12:34', '2017-09-29 09:12:34', false, 'en', 'September 29, 2017 at 9:12 AM'],
+            'created tooltip eng' =>
+            ['{createdDate}, edited {modifiedDate}', '2017-09-09 09:12:34', '2017-09-09 09:12:34', true, 'en', 'September 9, 2017 at 9:12 AM'],
+            'created and modified eng' =>
+            ['{createdDate}, edited {modifiedDate}', '2017-09-29 09:12:34', '2017-10-10 01:23:45', false, 'en', 'September 29, 2017 at 9:12 AM, edited October 10, 2017 at 1:23 AM'],
+            'created and modified tooltip eng' =>
+            ['{createdDate}, edited {modifiedDate}', '2018-02-09 09:12:34', '2018-02-10 01:23:45', true, 'en', 'February 9, 2018 at 9:12 AM, edited February 10, 2018 at 1:23 AM'],
+        ];
+    }
+
+    /**
+     * @dataProvider getDateLabelContentProvider
+     */
+    public function testGetDateLabel($text, $created, $modified, $tooltip, $locale, $expected)
+    {
+        I18n::setLocale($locale);
+        Time::setTestNow(new Time('2018-10-24 17:28:36'));
+        $result = $this->DateHelper->getDateLabel($text, $created, $modified, $tooltip);
+        $this->assertEquals($expected, $result);
+        Time::setTestNow();
+    }
 }

--- a/tests/TestCase/View/Helper/DateHelperTest.php
+++ b/tests/TestCase/View/Helper/DateHelperTest.php
@@ -1,0 +1,90 @@
+<?php
+namespace App\Test\TestCase\View\Helper;
+
+use App\View\Helper\DateHelper;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+use Cake\I18n\I18n;
+use Cake\I18n\Time;
+
+class DateHelperTest extends TestCase {
+
+    public $DateHelper;
+
+    public function setUp() {
+        parent::setUp();
+        $View = new View();
+        $this->DateHelper = new DateHelper($View);
+    }
+
+    public function tearDown() {
+        unset($this->DateHelper);
+        parent::tearDown();
+    }
+
+    public function agoContentProvider() {
+        return [
+            'null date eng' => [NULL, true, 'en', 'date unknown'],
+            '0000-00-00 00:00:00 eng' => ['0000-00-00 00:00:00', false, 'en', 'date unknown'],
+            'old valid date alone eng' => ['2010-01-02 12:34:56', true, 'en', 'January 2, 2010 at 12:34 PM'],
+            'old valid date in phrase eng' => ['2013-04-25 02:37:23', false, 'en', 'April 25, 2013 at 2:37 AM'],
+            'date within 30 days eng' => ['2016-06-06 14:52:11', true, 'en', '17&nbsp;days ago'],
+            'date yesterday eng' => ['2016-06-23 13:32:12', false, 'en', 'yesterday'],
+            'date within last 24 hours eng' => ['2016-06-24 09:43:17', false, 'en', '4&nbsp;hours ago'],
+            'date one hour ago eng' => ['2016-06-24 12:45:34', true, 'en', 'an hour ago'],
+            'date within last hour eng' => ['2016-06-24 13:06:16', true, 'en', '44&nbsp;minutes ago'],
+            'date one minute ago eng' => ['2016-06-24 13:49:20', false, 'en', 'a minute ago'],
+            /*
+            'null date fra' => [NULL, false, 'fr', 'date inconnue'],
+            '0000-00-00 00:00:00 fra' => ['0000-00-00 00:00:00', true, 'fr', 'date inconnue'],
+            'old valid date alone fra' => ['1965-02-01 11:35:36', true, 'fr', '1 février 1965 à 11:35'],
+            'old valid date in phrase fra' => ['1969-05-10 21:39:21', false, 'fr', 'le 10 mai 1969 à 21:39'],
+            'date within 30 days fra' => ['2016-06-20 10:23:42', true, 'fr', 'il y a 4&nbsp;jours'],
+            'date yesterday fra' => ['2016-06-23 12:32:19', true, 'fr', 'hier'],
+            'date within last 24 hours fra' => ['2016-06-23 19:40:32', false, 'fr', 'il y a 18&nbsp;heures'],
+            'date one hour ago fra' => ['2016-06-24 11:59:12', false, 'fr', 'il y a une heure'],
+            'date within last hour fra' => ['2016-06-24 12:58:36', true, 'fr', 'il y a 52&nbsp;minutes'],
+            'date one minute ago fra' => ['2016-06-24 13:50:22', true, 'fr', 'il y a une minute']
+             */
+        ];
+    }
+
+    /**
+     * @dataProvider agoContentProvider
+     */
+    public function testAgo($dateTime, $alone, $locale, $expected) {
+        I18n::setLocale($locale);
+        Time::setTestNow(new Time('2016-06-24 13:50:43'));
+        $result = $this->DateHelper->ago($dateTime, $alone);
+        $this->assertEquals($expected, $result);
+        Time::setTestNow();
+    }
+
+    public function formatBirthdayContentProvider() {
+        $longFormat = [\IntlDateFormatter::LONG, \IntlDateFormatter::NONE];
+        $shortFormat = [\IntlDateFormatter::SHORT, \IntlDateFormatter::NONE];
+        return [
+            'complete birthday date long format eng' => ['2013-04-30 12:21:14', $longFormat, 'en', 'April 30, 2013'],
+            'complete birthday date short format eng' => ['1973-05-20 12:21:14', $shortFormat, 'en', '5/20/73'],
+            'only year eng' => ['1958-00-00 12:34:56', null, 'en', '1958'],
+            'month and year eng' => ['1995-04-00 00:43:21', [], 'en', 'April 1995'],
+            'day and month eng' => ['0000-03-18 00:00:00', null, 'en', 'March 18'],
+            /*
+            'complete birthday date long format fra' => ['1956-09-18 23:45:18', $longFormat, 'fr', '18 septembre 1956'],
+            'complete birthday date short format fra' => ['1966-10-11 12:21:14', $shortFormat, 'fr', '11/10/1966'],
+            'only year fra' => ['2000-00-00 23:12:54', false, 'fr', '2000'],
+            'month and year fra' => ['1962-12-00 22:51:12', null, 'fr', 'Décembre 1962'],
+            'day and month fra' => ['0000-06-22 00:00:00', 1, 'fr', 'Juin 22']
+             */
+        ];
+    }
+
+    /**
+     * @dataProvider formatBirthdayContentProvider
+     */
+    public function testFormatBirthday($dateTime, $dateFormat, $locale, $expected) {
+        I18n::setLocale($locale);
+        $result = $this->DateHelper->formatBirthday($dateTime, $dateFormat);
+        $this->assertEquals($expected, $result);
+    }
+}


### PR DESCRIPTION
This PR addresses issue #1219.

This is still unfinished work because at the moment I've just modified the `ago` and `formatBirthday` functions from the Date helper so that they output locale dependent dates and then modified the display of dates for wall messages to demonstrate how the new functionality works. If you like this I will go through the rest of the code.

The implementation enables to differentiate between stand-alone dates and dates in a phrase like "edited April 11, 2014" which is necessary for languages like French or German because these languages need to add some extra words before the date in the latter case ("le" and "am" respectively).

It also shows how another (related) problem [described on the wall](https://tatoeba.org/eng/wall/show_message/33547#message_33547) could be solved: changing the string `{createdDate} edited {modifiedDate}` to `{createdDate} {edited} {modifiedDate}` allows the translator to use the declension syntax. For example, a french translator would translate the latter string to `{createdDate} {edited.masc-sing} {modifiedDate}` and `{edited}` would be translated to `{; masc-sing: modifié; fem-sing: modifiée`. The result would be a grammatically correct output.

I've also added some tests for the Date helper, but I'm not sure about the french language tests, because they are dependent on the po-file. Thus I've commented them out for the moment.

As always I'm looking forward to your comments. :-) 