### PR TITLE
Use correct sentence ID when adding sentences to a list

### DIFF
--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -386,6 +386,7 @@ class MenuHelper extends AppHelper
             array(
                 'type' => 'button',
                 'class' => 'validateButton',
+                'data-sentence-id' => $sentenceId
             )
         );
         ?>

--- a/webroot/js/sentences_lists.menu.js
+++ b/webroot/js/sentences_lists.menu.js
@@ -52,6 +52,7 @@ $(document).ready(function() {
         // directly after the selection in the <select>.
         $(".validateButton").off();
         $(".validateButton").click(function(){
+            sentenceId = $(this).parent().attr("id").replace("addToList", "");
             var listId = $("#listSelection"+sentenceId).val();
             var rootUrl = get_tatoeba_root_url();
 

--- a/webroot/js/sentences_lists.menu.js
+++ b/webroot/js/sentences_lists.menu.js
@@ -52,7 +52,7 @@ $(document).ready(function() {
         // directly after the selection in the <select>.
         $(".validateButton").off();
         $(".validateButton").click(function(){
-            sentenceId = $(this).parent().attr("id").replace("addToList", "");
+            sentenceId = this.dataset.sentenceId;
             var listId = $("#listSelection"+sentenceId).val();
             var rootUrl = get_tatoeba_root_url();
 


### PR DESCRIPTION
Fix for bugs #1743 and #1841.

If there are several list selection boxes opened on a page we need to use the correct sentence ID when the user clicks on the OK button.