### PR TITLE
Always get the CSRF token from cookie in JS

### DIFF
--- a/src/View/Helper/TranscriptionsHelper.php
+++ b/src/View/Helper/TranscriptionsHelper.php
@@ -162,9 +162,6 @@ class TranscriptionsHelper extends AppHelper
             'class' => $class,
             'escape' => false,
         ];
-        if ($isEditable) {
-            $options['data-csrf-token'] = $this->request->getParam('_csrfToken');
-        }
         $transcriptionDiv = $this->Languages->tagWithLang(
             'div', $lang, $html, $options, $transcr['script']
         );

--- a/webroot/js/generic_functions.js
+++ b/webroot/js/generic_functions.js
@@ -32,8 +32,11 @@ function get_tatoeba_root_url() {
 }
 
 function get_csrf_token() {
-    // Probably not worth importing jquery.cookie for this.
-    return document.cookie.replace(/^.*csrfToken=([^;]*);.*$/, "$1");
+    // Adapted from https://stackoverflow.com/a/15724300
+    // Licensed under CC BY-SA 4.0
+    var value = "; " + document.cookie;
+    var parts = value.split("; csrfToken=");
+    if (parts.length == 2) return parts.pop().split(";").shift();
 }
 
 /**

--- a/webroot/js/generic_functions.js
+++ b/webroot/js/generic_functions.js
@@ -31,6 +31,11 @@ function get_tatoeba_root_url() {
     return "//" + host + "/"+ interfaceLang;
 }
 
+function get_csrf_token() {
+    // Probably not worth importing jquery.cookie for this.
+    return document.cookie.replace(/^.*csrfToken=([^;]*);.*$/, "$1");
+}
+
 /**
  * Returns string without the new lines and stuff.
  */

--- a/webroot/js/links.add_and_delete.js
+++ b/webroot/js/links.add_and_delete.js
@@ -18,27 +18,19 @@
  
 function translationLink(action, sentenceId, translationId, langFilter)
 {
-    var rootUrl = get_tatoeba_root_url();
-
     // Show the loading icon
     $('#link_' + sentenceId + '_' + translationId).blur().html(
         "<div class='loader-small loader'></div>"
     );
     $("#_" + sentenceId + "_message").remove();
 
-    $.post(
-        rootUrl + "/links/" + action + "/" + sentenceId + "/" + translationId,
-        {
-            'returnTranslations': true,
-            'langFilter' : langFilter
-        },
-        function(data){
-            var wasExpanded = !$("#_" + sentenceId + "_translations .showLink").is(":visible");
-            $("#_" + sentenceId + "_translations").watch("replaceWith", data);
-            if (wasExpanded) {
-                $("#_" + sentenceId + "_translations .showLink").trigger("click");
-            }
-        },
-        'html'
-    );
+    function success(data){
+        var wasExpanded = !$("#_" + sentenceId + "_translations .showLink").is(":visible");
+        $("#_" + sentenceId + "_translations").watch("replaceWith", data);
+        if (wasExpanded) {
+            $("#_" + sentenceId + "_translations .showLink").trigger("click");
+        }
+    }
+
+    postLink(action, sentenceId, translationId, langFilter, success);
 }

--- a/webroot/js/sentences.add_translation.js
+++ b/webroot/js/sentences.add_translation.js
@@ -60,7 +60,6 @@ $(document).ready(function() {
                         'selectLang': selectLang,
                         'value': sentenceText
                     };
-                    var csrfHeader = $('#translation-form [name="_csrfToken"]').val();
                     $('#translation-form input[name^="_Token"]').each(function() {
                         data[$(this).attr('name')] = $(this).val();
                     });
@@ -70,7 +69,7 @@ $(document).ready(function() {
                         url: rootUrl + '/sentences/save_translation', 
                         data: data,
                         headers: {
-                            'X-CSRF-Token': csrfHeader
+                            'X-CSRF-Token': get_csrf_token()
                         },
                         success: function(data) {
                             translating = false;

--- a/webroot/js/sentences.contribute.js
+++ b/webroot/js/sentences.contribute.js
@@ -48,7 +48,6 @@ $(document).ready(function() {
                 'selectedLang': selectedLang,
                 'sentenceLicense': sentenceLicense
             };
-            var csrfHeader = $('#sentence-form input[name="_csrfToken"]').val();
             $('#sentence-form input[name^="_Token"]').each(function() {
                 data[$(this).attr('name')] = $(this).val();
             });
@@ -58,7 +57,7 @@ $(document).ready(function() {
                 url: rootUrl + '/sentences/add_an_other_sentence',
                 data: data,
                 headers: {
-                    'X-CSRF-Token': csrfHeader
+                    'X-CSRF-Token': get_csrf_token()
                 },
                 success: function(data) {
                     $("#SentenceText").val("");

--- a/webroot/js/sentences.link.js
+++ b/webroot/js/sentences.link.js
@@ -57,7 +57,6 @@ function linkToSentence(sentenceId, langFilter) {
     };
 
     var linkTo = function(){
-        var rootUrl = get_tatoeba_root_url();
         var linkToSentenceId = $("#linkToSentence" + sentenceId).val();
 
         // if the field appears to contain a link to another sentence,
@@ -73,21 +72,16 @@ function linkToSentence(sentenceId, langFilter) {
         $("#_" + sentenceId +"_in_process").show();
 
         $(this).unbind('click', linkTo); // to prevent double submission
-        $.post(
-            rootUrl + "/links/add/" + sentenceId + "/" + linkToSentenceId,
-            {
-                'returnTranslations': true,
-                'langFilter': langFilter
-            },
-            function(data){
-                $("#_" + sentenceId +"_in_process").hide();
-                $("#_" + sentenceId + "_translations").watch("replaceWith", data);
-                $("#linkTo" + sentenceId).hide();
-                $("#linkToSentence" + sentenceId).val("");
-                $(this).click(linkTo);
-            },
-            'html'
-        );
+
+        function success(data){
+            $("#_" + sentenceId +"_in_process").hide();
+            $("#_" + sentenceId + "_translations").watch("replaceWith", data);
+            $("#linkTo" + sentenceId).hide();
+            $("#linkToSentence" + sentenceId).val("");
+            $(this).click(linkTo);
+        }
+
+        postLink("add", sentenceId, linkToSentenceId, langFilter, success);
     };
 
     $("#linkToSubmitButton" + sentenceId).unbind('click').click(linkTo);
@@ -99,4 +93,18 @@ function linkToSentence(sentenceId, langFilter) {
         linkTo.show();
         $("#linkToSentence" + sentenceId).focus();
     }
+}
+
+function postLink(action, sentenceId, translationId, langFilter, success)
+{
+    var rootUrl = get_tatoeba_root_url();
+    $.post(
+        rootUrl + "/links/" + action + "/" + sentenceId + "/" + translationId,
+        {
+            'returnTranslations': true,
+            'langFilter': langFilter,
+        },
+        success,
+        'html'
+    );
 }

--- a/webroot/js/tags.add.js
+++ b/webroot/js/tags.add.js
@@ -37,7 +37,6 @@ $(document).ready(function() {
 			var rootUrl = get_tatoeba_root_url();
 			var data = { "sentence_id": sentenceId, "tag_name": tagName };
 
-			var csrfHeader = $('#tag-form [name="_csrfToken"]').val();
 			$('#tag-form input[name^="_Token"]').each(function() {
 				data[$(this).attr('name')] = $(this).val();
 			});
@@ -50,7 +49,7 @@ $(document).ready(function() {
 				method: 'POST',
 				url: rootUrl + '/tags/add_tag_post',
 				headers: {
-					'X-CSRF-Token': csrfHeader
+					'X-CSRF-Token': get_csrf_token()
 				},
 				data: data,
 				success: function(data){

--- a/webroot/js/transcriptions.js
+++ b/webroot/js/transcriptions.js
@@ -129,7 +129,7 @@ $(document).ready(function() {
                     return contents.find('.markup').text() || contents.text();
                 },
                 ajaxoptions : {
-                    headers : { 'X-CSRF-Token': div.attr('data-csrf-token') },
+                    headers : { 'X-CSRF-Token': get_csrf_token() },
                     success : function(result, status) {
                         div.editing = false;
                         div.parent().watch("replaceWith", result);

--- a/webroot/js/vocabulary/add-sentences.ctrl.js
+++ b/webroot/js/vocabulary/add-sentences.ctrl.js
@@ -58,7 +58,6 @@
             loader.removeClass('ng-hide');
             hideForm(id);
 
-            var csrfHeader = $('#form_' + id + ' [name="_csrfToken"]').val();
             $('#form_' + id + ' input[name^="_Token"]').each(function() {
                 body[$(this).attr('name')] = $(this).val();
             });
@@ -67,7 +66,7 @@
                 method: 'POST',
                 url: rootUrl + '/vocabulary/save_sentence/' + id,
                 headers: {
-                    'X-CSRF-Token': csrfHeader
+                    'X-CSRF-Token': get_csrf_token()
                 },
                 data: body
             }

--- a/webroot/js/vocabulary/add.ctrl.js
+++ b/webroot/js/vocabulary/add.ctrl.js
@@ -37,7 +37,6 @@
         function add() {
             vm.isAdding = true;
 
-            var csrfHeader = $('#add-vocabulary-form [name="_csrfToken"]').val();
             $('#add-vocabulary-form input[name^="_Token"]').each(function() {
                 vm.data[$(this).attr('name')] = $(this).val();
             });
@@ -46,7 +45,7 @@
                 method: 'POST',
                 url: rootUrl + '/vocabulary/save',
                 headers: {
-                    'X-CSRF-Token': csrfHeader
+                    'X-CSRF-Token': get_csrf_token()
                 },
                 data: vm.data
             }


### PR DESCRIPTION
Debugging story on the CSRF token mismatch in #2006:
It was caused by the transcription missing the `data-csrf-token` attribute, which led to the subsequent request missing the `X-CSRF-Token` header. The `data-csrf-token` attribute was missing because it was set from the `_csrfToken` parameter, which wasn't being sent for `add` and `delete` actions on links. Those two actions are apparently intentionally excluded from CSRF protection, which is why the lack of CSRF token didn't produce an error.

My first attempt to fix this was to simply send the `_csrfToken` parameter with link changes. That didn't work. CakePHP (I guess?) completely removes that parameter if CSRF protection is disabled.

Then I realized that using hidden attributes to pass the token around is actually much too complicated, since the CSRF token is stored as a cookie. Hidden attributes are only necessary for forms that are submitted without JavaScript.

For consistency, I changed all functions where the CSRF token was accessed in JavaScript to use the cookie instead. I tested all affected endpoints at least once and didn't see any CSRF mismatches, so I probably didn't break anything.