### PR TITLE
Add wrapper for CakePHP nice()

### DIFF
--- a/src/Template/Collections/of.ctp
+++ b/src/Template/Collections/of.ctp
@@ -151,7 +151,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
                 echo $this->Html->div(
                     'correctness',
                     $this->Images->correctnessIcon($correctness),
-                    array('title' => $this->Time->nice($item->modified))
+                    array('title' => $this->Date->nice($item->modified))
                 );
 
                 echo '</div>';

--- a/src/Template/Sentences/show.ctp
+++ b/src/Template/Sentences/show.ctp
@@ -87,7 +87,7 @@ echo $this->element('/sentences/navigation', [
                 ),
                 array(
                     'class' => 'username',
-                    'title' => $this->Time->nice($correctness->modified)
+                    'title' => $this->Date->nice($correctness->modified)
                 )
             );
             if ($correctness->dirty != 0) {

--- a/src/View/Helper/DateHelper.php
+++ b/src/View/Helper/DateHelper.php
@@ -45,6 +45,24 @@ class DateHelper extends AppHelper
     public $helpers = array('Time');
 
     /**
+     * Wrap CakePHP nice() function/method
+     *
+     * @param $date string|DateTime Datetime to format
+     *
+     * @return string
+     */
+    public function nice($date)
+    {
+        if (empty($date) || $date == '0000-00-00 00:00:00') {
+            return __('date unknown');
+        } elseif ($date instanceof DateTime) {
+            return $date->nice();
+        } else {
+            return $this->Time->nice($date);
+        }
+    }
+
+    /**
      * Create the date label used for comments, wall messages, ...
      *
      * @param string  $text     Text for the label. It must contain both
@@ -60,15 +78,15 @@ class DateHelper extends AppHelper
     {
         if (empty($modified) || $created == $modified) {
             if ($tooltip) {
-                return $this->Time->nice($created);
+                return $this->nice($created);
             } else {
                 return $this->ago($created);
             }
         } else {
             if ($tooltip) {
                 return format($text,
-                              array('createdDate' => $this->Time->nice($created),
-                                    'modifiedDate' => $this->Time->nice($modified)));
+                              array('createdDate' => $this->nice($created),
+                                    'modifiedDate' => $this->nice($modified)));
             } else {
                 return format($text,
                               array('createdDate' => $this->ago($created),

--- a/src/View/Helper/TagsHelper.php
+++ b/src/View/Helper/TagsHelper.php
@@ -45,7 +45,7 @@ class TagsHelper extends AppHelper
         'Html',
         'Form',
         'Sentences',
-        'Time'
+        'Date'
     );
 
     /**
@@ -142,7 +142,7 @@ class TagsHelper extends AppHelper
         if ($username != null) {
             $options["title"] = format(
                 __("Added by {username}, {date}"),
-                array('username' => $username, 'date' => $this->Time->nice($date))
+                array('username' => $username, 'date' => $this->Date->nice($date))
             );
         }
         echo $this->Html->link(

--- a/tests/TestCase/View/Helper/DateHelperTest.php
+++ b/tests/TestCase/View/Helper/DateHelperTest.php
@@ -106,6 +106,10 @@ class DateHelperTest extends TestCase {
             ['{createdDate}, edited {modifiedDate}', '2017-09-29 09:12:34', '2017-10-10 01:23:45', false, 'en', 'September 29, 2017 at 9:12 AM, edited October 10, 2017 at 1:23 AM'],
             'created and modified tooltip eng' =>
             ['{createdDate}, edited {modifiedDate}', '2018-02-09 09:12:34', '2018-02-10 01:23:45', true, 'en', 'February 9, 2018 at 9:12 AM, edited February 10, 2018 at 1:23 AM'],
+            'empty date eng' =>
+            ['{createdDate}, edited {modifiedDate}', '0000-00-00 00:00:00', '0000-00-00 00:00:00', false, 'en', 'date unknown'],
+            'empty date tooltip eng' =>
+            ['{createdDate}, edited {modifiedDate}', '0000-00-00 00:00:00', '0000-00-00 00:00:00', true, 'en', 'date unknown']
         ];
     }
 
@@ -119,5 +123,23 @@ class DateHelperTest extends TestCase {
         $result = $this->DateHelper->getDateLabel($text, $created, $modified, $tooltip);
         $this->assertEquals($expected, $result);
         Time::setTestNow();
+    }
+
+    public function niceContentProvider() {
+        return [
+            'null' => [null, 'date unknown'],
+            '0000-00-00 00:00:00' => ['0000-00-00 00:00:00', 'date unknown'],
+            'CakePHP Time instance' => [new Time('1987-06-05 23:45:19'), 'June 5, 1987 at 11:45 PM'],
+            'string' => ['2000-12-07 01:23:45', 'December 7, 2000 at 1:23 AM']
+        ];
+    }
+
+    /**
+     * @dataProvider niceContentProvider
+     */
+    public function testNice($date, $expected)
+    {
+        $result = $this->DateHelper->nice($date);
+        $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
I've noticed (unfortunately too late) that the CakePHP nice() function/method outputs a meaningless date for the string "0000-00-00 00:00:00" and we rather want to display "unknown date" instead. Thus I've added a wrapper function to the Date Helper.