### PR TITLE
Avoid listing lists in the "Add to list" selection box which already contain the sentence

### DIFF
--- a/src/Model/Table/SentencesListsTable.php
+++ b/src/Model/Table/SentencesListsTable.php
@@ -140,11 +140,14 @@ class SentencesListsTable extends Table
     /**
      * Returns the sentences lists that the given user can add sentences to.
      *
-     * @param int $userId Id of the user.
+     * @param int $userId     Id of the user.
+     * @param int $sentenceId Id of the sentence the user wants to add to a list.
+     *                        Used for filtering out the lists which already contain the
+     *                        sentence.
      *
      * @return array
      */
-    public function getUserChoices($userId)
+    public function getUserChoices($userId, $sentenceId)
     {
         $results = $this->find()
             ->where([
@@ -156,6 +159,9 @@ class SentencesListsTable extends Table
                     'editable_by' => 'no_one'
                 ]
             ])
+            ->notMatching('SentencesSentencesLists', function ($q) use ($sentenceId) {
+                return $q->where(['SentencesSentencesLists.sentence_id' => $sentenceId]);
+            })
             ->select(['id', 'name', 'user_id'])
             ->order(['name']);
 

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -356,13 +356,17 @@ class MenuHelper extends AppHelper
 
         $SentencesLists = TableRegistry::getTableLocator()->get('SentencesLists');
         $lists = $SentencesLists->getUserChoices(
-            CurrentUser::get('id')
+            CurrentUser::get('id'), $sentenceId
         );
 
-        $listsOfCurrentUser = __('Add to one of your lists');
-        $listsEditableByAnyone = __('Add to a collaborative list');
-        $selectItems[$listsOfCurrentUser] = $lists['OfUser'];
-        $selectItems[$listsEditableByAnyone] = $lists['Collaborative'];
+        if (empty($lists['OfUser']) && empty($lists['Collaborative'])) {
+            $selectItems[__('Sentence already in all possible lists')] = [];
+        } else {
+            $listsOfCurrentUser = __('Add to one of your lists');
+            $listsEditableByAnyone = __('Add to a collaborative list');
+            $selectItems[$listsOfCurrentUser] = $lists['OfUser'];
+            $selectItems[$listsEditableByAnyone] = $lists['Collaborative'];
+        }
         ?>
 
         <li style="display:none" id="addToList<?php echo $sentenceId; ?>">

--- a/tests/TestCase/Model/Table/SentencesListsTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesListsTableTest.php
@@ -319,12 +319,27 @@ class SentencesListsTableTest extends TestCase {
         $this->assertFalse($result);
     }
 
-    function testGetUserChoices() {
+    function testGetUserChoices_sentenceNotInLists() {
         CurrentUser::store(['id' => 7]);
-        $result = $this->SentencesList->getUserChoices(7);
+        $result = $this->SentencesList->getUserChoices(7, 1);
         $expected = [
             'OfUser' => [
                 '1' => 'Interesting French sentences',
+                '2' => 'Public list',
+                '3' => 'Private list'
+            ],
+            'Collaborative' => [
+                '5' => 'Collaborative list'
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    function testGetUserChoices_sentenceInOneList() {
+        CurrentUser::store(['id' => 7]);
+        $result = $this->SentencesList->getUserChoices(7, 4);
+        $expected = [
+            'OfUser' => [
                 '2' => 'Public list',
                 '3' => 'Private list'
             ],


### PR DESCRIPTION
While working on #1743 and #1841 I've noticed that there may be lists in the "Add to list" selection which already contain the sentence we want to add. Thus I've added a clause to the query which filters out these lists.

I'm not sure about how to show to the user that the sentence is already in all possible lists. Using the optiongroup feels rather hackish. Maybe disable the "Add to list" button in that case?
(This scenario is currently very unlikely with all the collaborative lists. But after implementing #1911 it will be more realistic.)