### PR TITLE
Improve handling of 'datetime' database columns

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -269,3 +269,5 @@ if (!function_exists('__format_decompose_list')) {
 Cake\I18n\I18n::setDefaultFormatter('sprintf');
 Cake\I18n\Time::setToStringFormat('yyyy-MM-dd HH:mm:ss');
 Cake\I18n\Time::$niceFormat = [\IntlDateFormatter::LONG, \IntlDateFormatter::SHORT];
+Cake\I18n\FrozenTime::setToStringFormat('yyyy-MM-dd HH:mm:ss');
+Cake\I18n\FrozenTime::$niceFormat = [\IntlDateFormatter::LONG, \IntlDateFormatter::SHORT];

--- a/src/Model/Table/AudiosTable.php
+++ b/src/Model/Table/AudiosTable.php
@@ -54,8 +54,6 @@ class AudiosTable extends Table
     protected function _initializeSchema(TableSchema $schema)
     {
         $schema->setColumnType('external', 'json');
-        $schema->setColumnType('modified', 'string');
-        $schema->setColumnType('created', 'string');
         return $schema;
     }
 
@@ -81,10 +79,10 @@ class AudiosTable extends Table
             ->numeric('sentence_id');
 
         $validator
-            ->notBlank('created');
+            ->dateTime('created');
 
         $validator
-            ->notBlank('modified');
+            ->dateTime('modified');
 
         return $validator;
     }
@@ -152,6 +150,15 @@ class AudiosTable extends Table
             ->count();
     }
 
+    /**
+     * Assign audio to a sentence.
+     *
+     * @param int     $sentenceId                  ID of sentence.
+     * @param string  $ownerName                   Owner of the audio file.
+     * @param boolean $allowedExternal (optional)  Whether metadata is stored as JSON.
+     *
+     * @return Cake\ORM\Entity|false
+     */
     public function assignAudioTo($sentenceId, $ownerName, $allowExternal = true) {
         $data = array(
             'sentence_id' => $sentenceId,

--- a/src/Model/Table/SentenceCommentsTable.php
+++ b/src/Model/Table/SentenceCommentsTable.php
@@ -33,8 +33,6 @@ class SentenceCommentsTable extends Table
     protected function _initializeSchema(TableSchema $schema)
     {
         $schema->setColumnType('text', 'text');
-        $schema->setColumnType('modified', 'string');
-        $schema->setColumnType('created', 'string');
         return $schema;
     }
 
@@ -62,6 +60,10 @@ class SentenceCommentsTable extends Table
                 'rule' => 'notBlank',
                 'message' => __('Comments cannot be empty.')
             ]);
+
+        $validator->dateTime('created');
+
+        $validator->dateTime('modified');
 
         return $validator;
     }

--- a/src/Model/Table/SentencesListsTable.php
+++ b/src/Model/Table/SentencesListsTable.php
@@ -26,13 +26,6 @@ use App\Model\CurrentUser;
 
 class SentencesListsTable extends Table
 {
-    protected function _initializeSchema(TableSchema $schema)
-    {
-        $schema->setColumnType('created', 'string');
-        $schema->setColumnType('modified', 'string');
-        return $schema;
-    }
-
     public function initialize(array $config)
     {
         parent::initialize($config);
@@ -392,7 +385,7 @@ class SentencesListsTable extends Table
      * @param int $sentenceId Id of the sentence.
      * @param int $listId     Id of the list.
      *
-     * @return array
+     * @return boolean
      */
     public function addSentenceToList($sentenceId, $listId, $currentUserId)
     {
@@ -429,7 +422,7 @@ class SentencesListsTable extends Table
      * @param int   $listId        Id of the list.
      * @param int   $currentUserId Id of the user performing the action.
      *
-     * @return array
+     * @return boolean
      */
     public function addSentencesToList($sentences, $listId, $currentUserId)
     {
@@ -623,7 +616,12 @@ class SentencesListsTable extends Table
     }
 
     /**
-     * Create new list.
+     * Create a new list.
+     *
+     * @param string $name           Name of the list.
+     * @param int    $currentUserId  ID of user who creates the list.
+     *
+     * @return Cake\ORM\Entity|false
      */
     public function createList($name, $currentUserId) 
     {

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -40,8 +40,6 @@ class SentencesTable extends Table
     protected function _initializeSchema(TableSchema $schema)
     {
         $schema->setColumnType('text', 'text');
-        $schema->setColumnType('created', 'string');
-        $schema->setColumnType('modified', 'string');
         $schema->setColumnType('hash', 'string');
         return $schema;
     }
@@ -123,7 +121,11 @@ class SentencesTable extends Table
                     'rule' => ['inList', $languages]
                 ]
             ]);
-            
+
+        $validator->dateTime('created');
+
+        $validator->dateTime('modified');
+
         return $validator;
     }
 
@@ -826,7 +828,7 @@ class SentencesTable extends Table
      * @param string $translationText Text of the translation.
      * @param string $translationLang Language of the translation.
      *
-     * @return boolean
+     * @return Cake\ORM\Entity|false
      */
     public function saveTranslation(
         $sentenceId,
@@ -858,15 +860,15 @@ class SentencesTable extends Table
     /**
      * Add a new sentence in the database
      *
-     * @param string $text        The text of the sentence.
-     * @param string $lang        The lang of the sentence.
-     * @param int    $userId      The id of the user who added this sentence.
-     * @param int    $correctness Correctness level of sentence.
-     * @param in     $basedOnId   The ID of the sentence this sentence is translated from,
-     *                            or 0 if it's an original sentence, or null if unknown.
-     * @param string $license     The license of the sentence.
+     * @param string   $text        The text of the sentence.
+     * @param string   $lang        The lang of the sentence.
+     * @param int      $userId      The id of the user who added this sentence.
+     * @param int      $correctness Correctness level of sentence.
+     * @param int|null $basedOnId   The ID of the sentence this sentence is translated from,
+     *                              or 0 if it's an original sentence, or null if unknown.
+     * @param string   $license     The license of the sentence.
      *
-     * @return bool
+     * @return Cake\ORM\Entity|false
      */
     public function saveNewSentence($text, $lang, $userId, $correctness = 0, $basedOnId = 0, $license = null)
     {
@@ -906,7 +908,7 @@ class SentencesTable extends Table
      * @param string $translationLang The lang of the translation.
      * @param int    $userId          The id of the user who added them.
      *
-     * @return bool
+     * @return void
      */
     public function saveNewSentenceWithTranslation(
         $sentenceText,
@@ -1091,7 +1093,7 @@ class SentencesTable extends Table
      *
      * @param int $sentenceId Id of the sentence
      *
-     * @return void
+     * @return string
      */
     public function getSentenceTextForId($sentenceId)
     {

--- a/src/Model/Table/TagsSentencesTable.php
+++ b/src/Model/Table/TagsSentencesTable.php
@@ -36,12 +36,6 @@ class TagsSentencesTable extends Table
         'Tag',
         );
 
-    protected function _initializeSchema(TableSchema $schema)
-    {
-        $schema->setColumnType('added_time', 'string');
-        return $schema;
-    }
-
     public function initialize(array $config)
     {
         $this->belongsTo('Users');
@@ -51,6 +45,12 @@ class TagsSentencesTable extends Table
         if (Configure::read('Search.enabled')) {
             $this->addBehavior('Sphinx', ['alias' => $this->getAlias()]);
         }
+
+        $this->addBehavior('Timestamp', [
+            'events' => [
+                'Model.beforeSave' => ['added_time' => 'new']
+            ]
+        ]);
     }
 
     protected function _findCount($state, $query, $results = array()) {
@@ -69,7 +69,6 @@ class TagsSentencesTable extends Table
             'user_id' => $userId,
             'tag_id' => $tagId,
             'sentence_id' => $sentenceId,
-            'added_time' => date('Y-m-d H:i:s'),
             'alreadyExists' => $isTagged
         ]);
 

--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -46,12 +46,6 @@ class TagsTable extends Table
         return 'OK';
     }
 
-    protected function _initializeSchema(TableSchema $schema)
-    {
-        $schema->setColumnType('created', 'string');
-        return $schema;
-    }
-
     public function initialize(array $config) 
     {
         $this->hasMany('TagsSentences');
@@ -75,8 +69,13 @@ class TagsTable extends Table
     }
 
     /**
+     * Add a tag (and optionally tag a sentence)
      *
+     * @param string   $tagName
+     * @param int      $userId
+     * @param int|null $sentenceId
      *
+     * @return Cake\ORM\Entity|false
      */
     public function addTag($tagName, $userId, $sentenceId = null)
     {
@@ -100,7 +99,6 @@ class TagsTable extends Table
         $data = $this->newEntity([
             'name' => $tagName,
             'user_id' => $userId,
-            'created' => date('Y-m-d H:i:s')
         ]);
         // try to add it as a new tag
         $added = $this->save($data);

--- a/src/Model/Table/TranscriptionsTable.php
+++ b/src/Model/Table/TranscriptionsTable.php
@@ -133,8 +133,6 @@ class TranscriptionsTable extends Table
     protected function _initializeSchema(TableSchema $schema)
     {
         $schema->setColumnType('text', 'text');
-        $schema->setColumnType('created', 'string');
-        $schema->setColumnType('modified', 'string');
         return $schema;
     }
 
@@ -155,10 +153,10 @@ class TranscriptionsTable extends Table
             ->requirePresence('text', 'create');
 
         $validator
-            ->notBlank('created');
+            ->dateTime('created');
 
         $validator
-            ->notBlank('modified');
+            ->dateTime('modified');
 
         $validator
             ->numeric('user_id')

--- a/src/Model/Table/TranslationsTable.php
+++ b/src/Model/Table/TranslationsTable.php
@@ -28,8 +28,6 @@ class TranslationsTable extends Table
     protected function _initializeSchema(TableSchema $schema)
     {
         $schema->setColumnType('text', 'text');
-        $schema->setColumnType('created', 'string');
-        $schema->setColumnType('modified', 'string');
         return $schema;
     }
 

--- a/src/Model/Table/UsersLanguagesTable.php
+++ b/src/Model/Table/UsersLanguagesTable.php
@@ -31,8 +31,6 @@ class UsersLanguagesTable extends Table
     protected function _initializeSchema(TableSchema $schema)
     {
         $schema->setColumnType('details', 'text');
-        $schema->setColumnType('created', 'string');
-        $schema->setColumnType('modified', 'string');
         return $schema;
     }
 

--- a/src/Model/Table/UsersSentencesTable.php
+++ b/src/Model/Table/UsersSentencesTable.php
@@ -24,13 +24,6 @@ use Cake\Datasource\Exception\RecordNotFoundException;
 
 class UsersSentencesTable extends Table
 {
-    protected function _initializeSchema(TableSchema $schema)
-    {
-        $schema->setColumnType('created', 'string');
-        $schema->setColumnType('modified', 'string');
-        return $schema;
-    }
-
     public function initialize(array $config)
     {
         $this->setTable('users_sentences');
@@ -42,7 +35,13 @@ class UsersSentencesTable extends Table
     }
 
     /**
-     * 
+     * Add sentence to users collection
+     *
+     * @param int $sentenceId
+     * @param int $correctness
+     * @param int $userId
+     *
+     * @return array
      */
     public function saveSentence($sentenceId, $correctness, $userId) 
     {
@@ -65,7 +64,12 @@ class UsersSentencesTable extends Table
     }
 
     /**
-     * 
+     * Delete sentence from users collection
+     *
+     * @param int $sentenceId
+     * @param int $userId
+     *
+     * @return boolean
      */
     public function deleteSentence($sentenceId, $userId) 
     {

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -39,7 +39,6 @@ class UsersTable extends Table
     protected function _initializeSchema(TableSchema $schema)
     {
         $schema->setColumnType('birthday', 'string');
-        $schema->setColumnType('since', 'string');
         $schema->setColumnType('description', 'text');
         $schema->setColumnType('settings', 'json');
         return $schema;

--- a/src/Model/Table/UsersVocabularyTable.php
+++ b/src/Model/Table/UsersVocabularyTable.php
@@ -30,6 +30,7 @@ class UsersVocabularyTable extends Table
         $this->belongsTo('Users');
 
         $this->addBehavior('Hashable');
+        $this->addBehavior('Timestamp');
     }
 
     /**
@@ -38,7 +39,7 @@ class UsersVocabularyTable extends Table
      * @param string $vocabularyId Binary version of vocabulary_id.
      * @param int    $userId       Id of current user.
      *
-     * @return array               UsersVocabulary item.
+     * @return Cake\ORM\Entity|false
      */
     public function add($vocabularyId, $userId)
     {

--- a/src/Model/Table/VocabularyTable.php
+++ b/src/Model/Table/VocabularyTable.php
@@ -30,7 +30,6 @@ class VocabularyTable extends Table
     protected function _initializeSchema(TableSchema $schema)
     {
         $schema->setColumnType('text', 'text');
-        $schema->setColumnType('created', 'string');
         $schema->setColumnType('hash', 'string');
         return $schema;
     }
@@ -61,16 +60,16 @@ class VocabularyTable extends Table
     /**
      * Adds an item into the vocabulary list of current user.
      *
-     * @param $lang string Language of the vocabulary item.
-     * @param $text string Text of the vocabulary item.
+     * @param string $lang Language of the vocabulary item.
+     * @param string $text Text of the vocabulary item.
      *
-     * @return $data array
+     * @return Cake\ORM\Entity|false
      */
     public function addItem($lang, $text)
     {
         $text = trim($text);
         if (empty($text) || empty($lang)) {
-            return null;
+            return false;
         }
 
         $hash = $this->makeHash($lang, $text);

--- a/src/Model/Table/WallTable.php
+++ b/src/Model/Table/WallTable.php
@@ -31,8 +31,6 @@ class WallTable extends Table
     protected function _initializeSchema(TableSchema $schema)
     {
         $schema->setColumnType('content', 'text');
-        $schema->setColumnType('modified', 'string');
-        $schema->setColumnType('date', 'string');
         return $schema;
     }
 
@@ -73,6 +71,10 @@ class WallTable extends Table
                 'rule' => 'notBlank',
                 'message'    => __('You cannot save an empty message.'),
             ]);
+
+        $validator->dateTime('date');
+
+        $validator->dateTime('modified');
 
         return $validator;
     }

--- a/src/Model/Table/WallThreadsTable.php
+++ b/src/Model/Table/WallThreadsTable.php
@@ -34,12 +34,6 @@ class WallThreadsTable extends Table
         )
     );
 
-    protected function _initializeSchema(TableSchema $schema)
-    {
-        $schema->setColumnType('last_message_date', 'string');
-        return $schema;
-    }
-
     public function initialize(array $config)
     {
         $this->setTable('wall_threads_last_message');

--- a/src/Shell/SentenceDerivationShell.php
+++ b/src/Shell/SentenceDerivationShell.php
@@ -5,6 +5,7 @@ namespace App\Shell;
 use Cake\Console\Shell;
 use Cake\Utility\Hash;
 use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\I18n\Time;
 
 class Walker {
     private $model;
@@ -189,7 +190,7 @@ class SentenceDerivationShell extends Shell {
         $total = 0;
         $derivations = array();
         $saveExtraOptions = array(
-            'modified' => false,
+            'modified' => Time::now(),
             'callbacks' => false
         );
         $this->out("Setting 'based_on_id' field for all sentences", 0);

--- a/src/View/Helper/DateHelper.php
+++ b/src/View/Helper/DateHelper.php
@@ -28,6 +28,7 @@ namespace App\View\Helper;
 
 use App\View\Helper\AppHelper;
 use Cake\I18n\Time;
+use DateTimeInterface;
 
 /**
  * Helper to display date.
@@ -47,15 +48,16 @@ class DateHelper extends AppHelper
     /**
      * Wrap CakePHP nice() function/method
      *
-     * @param $date string|DateTime Datetime to format
+     * @param $date DateTime|string Datetime to format
      *
      * @return string
      */
     public function nice($date)
     {
+
         if (empty($date) || $date == '0000-00-00 00:00:00') {
             return __('date unknown');
-        } elseif ($date instanceof DateTime) {
+        } elseif ($date instanceof DateTimeInterface) {
             return $date->nice();
         } else {
             return $this->Time->nice($date);
@@ -65,12 +67,12 @@ class DateHelper extends AppHelper
     /**
      * Create the date label used for comments, wall messages, ...
      *
-     * @param string  $text     Text for the label. It must contain both
-     *                          "{createdDate}" and "{modifiedDate}" placeholders.
-     * @param string  $created  Creation datetime (in MySQL format)
-     * @param string  $modified Modification datetime (in MySQL format)
-     * @param boolean $tooltip  When the label is used for a tooltip the dates will
-     *                          always be exact.
+     * @param string          $text     Text for the label. It must contain both
+     *                                  "{createdDate}" and "{modifiedDate}" placeholders.
+     * @param DateTime|string $created  Creation datetime (in MySQL format if string)
+     * @param DateTime|string $modified Modification datetime (in MySQL format if string)
+     * @param boolean         $tooltip  When the label is used for a tooltip the dates will
+     *                                  always be exact.
      *
      * @return string
      */
@@ -98,18 +100,26 @@ class DateHelper extends AppHelper
     /**
      * Display how long ago compared to now.
      *
-     * @param string  $date        Format for the date is 'Y-m-d H:i:s'.
-     * @param boolean $alone       Indicates whether the date is shown alone or in a phrase
+     * @param DateTime|string $date  If the date is given as a string, the format should be
+     *                               'Y-m-d H:i:s' (MySQL format).
+     * @param boolean         $alone Indicates whether the date is shown alone or in a phrase
      *
      * @return string
      */
     public function ago($date, $alone=true)
     {
-        if (empty($date) || $date == '0000-00-00 00:00:00') {
-            return __('date unknown');
+        if (!($date instanceof DateTimeInterface)) {
+            if (empty($date) || $date == '0000-00-00 00:00:00') {
+                return __('date unknown');
+            } else {
+                $dateObj = Time::parseDateTime($date);
+                if (!$dateObj) {
+                    return __('date unknown');
+                }
+            }
+        } else {
+            $dateObj = $date;
         }
-
-        $dateObj = Time::parseDateTime($date);
 
         $diff = Time::fromNow($dateObj);
 

--- a/src/View/Helper/TranscriptionsHelper.php
+++ b/src/View/Helper/TranscriptionsHelper.php
@@ -30,6 +30,7 @@ class TranscriptionsHelper extends AppHelper
         'Languages',
         'Pinyin',
         'Search',
+        'Date',
     );
 
     /**
@@ -138,10 +139,10 @@ class TranscriptionsHelper extends AppHelper
         if (isset($transcr['User']['username'])) {
             $log = format(
                 /* @translators: refers to a transcription */
-                __('Last edited by {author} the {date}'),
+                __('Last edited by {author} on {date}'),
                 array(
                     'author' => $transcr['User']['username'],
-                    'date' => $transcr['modified'],
+                    'date' => $this->Date->nice($transcr['modified']),
                 )
             );
         } else {

--- a/tests/TestCase/Model/Table/AudiosTableTest.php
+++ b/tests/TestCase/Model/Table/AudiosTableTest.php
@@ -6,6 +6,7 @@ use Cake\TestSuite\TestCase;
 use Cake\ORM\TableRegistry;
 use App\Test\Fixture\AudiosFixture;
 use Cake\Utility\Hash;
+use Cake\I18n\I18n;
 
 class AudiosTableTest extends TestCase {
     public $fixtures = array(
@@ -226,5 +227,13 @@ class AudiosTableTest extends TestCase {
         $result = $this->Audio->delete($audioToDelete);
         $after = $Languages->get(4)->audio;
         $this->assertEquals(1, $before - $after);
+    }
+
+    function testAssignAudioTo_correctDateUsingArabicLocale() {
+        I18n::setLocale('ar');
+        $added = $this->Audio->assignAudioTo(2, 'contributor');
+        $returned = $this->Audio->get($added->id);
+        $this->assertEquals($added->created, $returned->created);
+        $this->assertEquals($added->modified, $returned->modified);
     }
 }

--- a/tests/TestCase/Model/Table/SentenceCommentsTableTest.php
+++ b/tests/TestCase/Model/Table/SentenceCommentsTableTest.php
@@ -6,6 +6,7 @@ use Cake\TestSuite\TestCase;
 use Cake\ORM\TableRegistry;
 use Cake\Event\Event;
 use App\Model\CurrentUser;
+use Cake\I18n\I18n;
 
 class SentenceCommentTest extends TestCase {
 
@@ -125,5 +126,18 @@ class SentenceCommentTest extends TestCase {
     public function testGetLatestComments_hasSentenceOwnerInfo() {
         $result = $this->SentenceComment->getLatestComments(1);
         $this->assertEquals('contributor', $result[0]->sentence->user->username);
+    }
+
+    public function testSave_correctDateUsingArabicLocale() {
+        I18n::setLocale('ar');
+        $comment = $this->SentenceComment->newEntity([
+            'sentence_id' => 1,
+            'text' => 'test',
+            'user_id' => 1,
+        ]);
+        $added = $this->SentenceComment->save($comment);
+        $returned = $this->SentenceComment->get($added->id);
+        $this->assertEquals($added->created, $returned->created);
+        $this->assertEquals($added->modified, $returned->modified);
     }
 }

--- a/tests/TestCase/Model/Table/SentencesListsTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesListsTableTest.php
@@ -6,6 +6,7 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use App\Model\CurrentUser;
 use Cake\Utility\Hash;
+use Cake\I18n\I18n;
 
 class SentencesListsTableTest extends TestCase {
     public $fixtures = array(
@@ -406,5 +407,13 @@ class SentencesListsTableTest extends TestCase {
         CurrentUser::store(null);
         $result = $this->SentencesList->isSearchableList(3);
         $this->assertNull($result);
+    }
+
+    function testCreateList_correctDateUsingArabicLocale() {
+        I18n::setLocale('ar');
+        $added = $this->SentencesList->createList('arabic', 1);
+        $returned = $this->SentencesList->get($added->id);
+        $this->assertEquals($added->created, $returned->created);
+        $this->assertEquals($added->modified, $returned->modified);
     }
 }

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -13,6 +13,7 @@ use Cake\Datasource\Exception\RecordNotFoundException;
 use App\Model\Entity\Contribution;
 use App\Model\Entity\User;
 use Cake\Utility\Hash;
+use Cake\I18n\I18n;
 
 class SentencesTableTest extends TestCase {
 	public $fixtures = array(
@@ -1134,4 +1135,12 @@ class SentencesTableTest extends TestCase {
 		];
 		$this->assertEquals($expected, $result);
 	}
+
+    function testSaveNewSentence_correctDateUsingArabicLocale() {
+        I18n::setLocale('ar');
+        $added = $this->Sentence->saveNewSentence('test', 'eng', 1);
+        $returned = $this->Sentence->get($added->id);
+        $this->assertEquals($added->created, $returned->created);
+        $this->assertEquals($added->modified, $returned->modified);
+    }
 }

--- a/tests/TestCase/Model/Table/TagsSentencesTableTest.php
+++ b/tests/TestCase/Model/Table/TagsSentencesTableTest.php
@@ -4,6 +4,7 @@ namespace App\Test\TestCase\Model\Table;
 use App\Model\Table\TagsSentencesTable;
 use Cake\TestSuite\TestCase;
 use Cake\ORM\TableRegistry;
+use Cake\I18n\I18n;
 
 class TagsSentencesTableTest extends TestCase {
     public $fixtures = array(
@@ -39,5 +40,12 @@ class TagsSentencesTableTest extends TestCase {
     function testTagSentence_failsBecauseAlreadyAdded() {
         $result = $this->TagsSentences->tagSentence(2, 2, 1);
         $this->assertTrue($result->alreadyExists);
+    }
+
+    function testTagSentence_correctDateUsingArabicLocale() {
+        I18n::setLocale('ar');
+        $added = $this->TagsSentences->tagSentence(1, 2, 3);
+        $returned = $this->TagsSentences->get($added->id);
+        $this->assertEquals($added->added_time, $returned->added_time);
     }
 }

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -6,6 +6,7 @@ use App\Test\TestCase\Model\Table\TatoebaTableTestTrait;
 use Cake\TestSuite\TestCase;
 use Cake\ORM\TableRegistry;
 use Cake\Event\Event;
+use Cake\I18n\I18n;
 
 class TagsTableTest extends TestCase {
     use TatoebaTableTestTrait;
@@ -154,5 +155,12 @@ class TagsTableTest extends TestCase {
     public function testAdminDoesRemoveTag() {
         $delta = $this->removeAsUser('admin', 2, 2);
         $this->assertEquals(-1, $delta);
+    }
+
+    public function testAddTag_correctDateUsingArabicLocale() {
+        I18n::setLocale('ar');
+        $added = $this->Tag->addTag('arabic', 4, 1);
+        $returned = $this->Tag->get($added->id);
+        $this->assertEquals($added->added_time, $returned->created);
     }
 }

--- a/tests/TestCase/Model/Table/TranscriptionsTableTest.php
+++ b/tests/TestCase/Model/Table/TranscriptionsTableTest.php
@@ -6,6 +6,7 @@ use Cake\TestSuite\TestCase;
 use Cake\ORM\TableRegistry;
 use App\Test\Fixture\TranscriptionsFixture;
 use Cake\Utility\Hash;
+use Cake\I18n\I18n;
 
 class TranscriptionsTableTest extends TestCase {
     public $fixtures = array(
@@ -598,5 +599,17 @@ class TranscriptionsTableTest extends TestCase {
             $cmnSentence->lang,
             $cmnSentence->text
         );
+    }
+
+    function testSave_correctDateUsingArabicLocale() {
+        I18n::setLocale('ar');
+        $data = $this->_getRecord(0);
+        $this->Transcription->deleteAll('true');
+        unset($data['id'], $data['created'], $data['modified']);
+        $transcription = $this->Transcription->newEntity($data);
+        $added = $this->Transcription->save($transcription);
+        $returned = $this->Transcription->get($added->id);
+        $this->assertEquals($added->created, $returned->created);
+        $this->assertEquals($added->modified, $returned->modified);
     }
 }

--- a/tests/TestCase/Model/Table/UsersLanguagesTableTest.php
+++ b/tests/TestCase/Model/Table/UsersLanguagesTableTest.php
@@ -4,6 +4,8 @@ namespace App\Test\TestCase\Model\Table;
 use App\Model\Table\UsersLanguagesTable;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\I18n\I18n;
+use Cake\I18n\Time;
 
 class UsersLanguagesTableTest extends TestCase {
     public $fixtures = array(
@@ -141,8 +143,22 @@ class UsersLanguagesTableTest extends TestCase {
         $this->assertEquals(null, $result);
     }
 
-    function testGetNumberOfUsersForEachLanguage() {{
+    function testGetNumberOfUsersForEachLanguage() {
         $result = $this->UsersLanguages->getNumberOfUsersForEachLanguage();
         $this->assertEquals(1, count($result));
-    }}
+    }
+
+    function testSaveUserLanguage_correctDateUsingArabicLocale() {
+        I18n::setLocale('ar');
+        $now = Time::now();
+        Time::setTestNow($now);
+        $added = $this->UsersLanguages->saveUserLanguage(
+            ['language_code' => 'npi', 'details' => ''],
+            100
+        );
+        $id = $added['UsersLanguages']['id'];
+        $returned = $this->UsersLanguages->get($id);
+        $this->assertEquals($now, $returned->created);
+        $this->assertEquals($now, $returned->modified);
+    }
 }

--- a/tests/TestCase/Model/Table/UsersSentencesTableTest.php
+++ b/tests/TestCase/Model/Table/UsersSentencesTableTest.php
@@ -4,6 +4,8 @@ namespace App\Test\TestCase\Model\Table;
 use App\Model\Table\UsersSentencesTable;
 use Cake\TestSuite\TestCase;
 use Cake\ORM\TableRegistry;
+use Cake\I18n\I18n;
+use Cake\I18n\Time;
 
 class UsersSentencesTest extends TestCase {
     public $fixtures = array(
@@ -107,5 +109,14 @@ class UsersSentencesTest extends TestCase {
     function testGetCorrectnessForSentence_hasNoResult() {
         $result = $this->UsersSentences->getCorrectnessForSentence(999);
         $this->assertEquals(0, count($result));
+    }
+
+    function testSaveSentence_correctDateUsingArabicLocale() {
+        I18n::setLocale('ar');
+        $now = Time::now();
+        Time::setTestNow($now);
+        $this->UsersSentences->saveSentence(1, 1, 4);
+        $returned = $this->UsersSentences->findBySentenceIdAndUserId(1, 4)->first();
+        $this->assertEquals($now, $returned->created);
     }
 }

--- a/tests/TestCase/Model/Table/UsersVocabularyTableTest.php
+++ b/tests/TestCase/Model/Table/UsersVocabularyTableTest.php
@@ -4,6 +4,7 @@ namespace App\Test\TestCase\Model\Table;
 use App\Model\Table\UsersVocabularyTable;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\I18n\I18n;
 
 class UsersVocabularyTableTest extends TestCase
 {
@@ -40,12 +41,16 @@ class UsersVocabularyTableTest extends TestCase
 
     public function testAdd()
     {
-        $result = $this->UsersVocabulary->add(1, 2);
-        $expected = [
-            'id' => 2,
-            'vocabulary_id' => 1,
-            'user_id' => 2
-        ];
-        $this->assertEquals($expected, $result->toArray());
+        $added = $this->UsersVocabulary->add(1, 2);
+        $returned = $this->UsersVocabulary->get($added->id);
+        $this->assertEquals($added->user_id, $returned->user_id);
+        $this->assertEquals($added->vocabulary_id, $returned->vocabulary_id);
+    }
+
+    public function testAdd_correctDateUsingArabicLocale() {
+        I18n::setLocale('ar');
+        $added = $this->UsersVocabulary->add(1, 3);
+        $returned = $this->UsersVocabulary->get($added->id);
+        $this->assertEquals($added->created, $returned->created);
     }
 }

--- a/tests/TestCase/Model/Table/VocabularyTableTest.php
+++ b/tests/TestCase/Model/Table/VocabularyTableTest.php
@@ -5,6 +5,7 @@ use App\Model\Table\VocabularyTable;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use App\Model\CurrentUser;
+use Cake\I18n\I18n;
 
 class VocabularyTableTest extends TestCase
 {
@@ -53,5 +54,12 @@ class VocabularyTableTest extends TestCase
     {
         $result = $this->Vocabulary->incrementNumSentences(1, 'This is just blue.');
         $this->assertEquals(1, $result);
+    }
+
+    public function testAddItem_correctDateUsingArabicLocale() {
+        I18n::setLocale('ar');
+        $added = $this->Vocabulary->addItem('eng', 'test');
+        $returned = $this->Vocabulary->get($added->id);
+        $this->assertEquals($added->created, $returned->created);
     }
 }

--- a/tests/TestCase/Model/Table/WallTableTest.php
+++ b/tests/TestCase/Model/Table/WallTableTest.php
@@ -6,6 +6,8 @@ use Cake\TestSuite\TestCase;
 use Cake\ORM\TableRegistry;
 use Cake\Event\Event;
 use App\Model\CurrentUser;
+use Cake\I18n\I18n;
+use Cake\I18n\Time;
 
 class WallTest extends TestCase {
 
@@ -93,7 +95,7 @@ class WallTest extends TestCase {
     }
 
     public function testSave_newPostUpdatesExistingThreadDate() {
-        $date = '2018-01-02 03:04:05';
+        $date = new Time('2018-01-02 03:04:05');
         $reply = $this->Wall->newEntity([
             'owner' => 7,
             'date' => $date,
@@ -108,7 +110,7 @@ class WallTest extends TestCase {
     }
 
     public function testSave_newPostUpdatesNewThreadDate() {
-        $date = '2018-01-02 03:04:05';
+        $date = new Time('2018-01-02 03:04:05');
         $newPost = $this->Wall->newEntity([
             'owner' => 2,
             'date' => $date,
@@ -130,7 +132,7 @@ class WallTest extends TestCase {
 
         $this->Wall->save($post);
 
-        $this->_assertThreadDate($postId, '2014-04-15 16:38:36');
+        $this->_assertThreadDate($postId, new Time('2014-04-15 16:38:36'));
     }
 
     public function testSave_editExistingPostUpdatesModifiedDate() {
@@ -261,5 +263,14 @@ class WallTest extends TestCase {
     public function testGetWholeThreadContaining_failsBecauseWrongId() {
         $result = $this->Wall->getWholeThreadContaining(999999);
         $this->assertEquals([], $result);
+    }
+
+    public function testSave_correctDateUsingArabicLocale() {
+        I18n::setLocale('ar');
+        $post = $this->Wall->newEntity(['content' => 'test', 'owner' => 1]);
+        $added = $this->Wall->save($post);
+        $returned = $this->Wall->get($added->id);
+        $this->assertEquals($added->date, $returned->date);
+        $this->assertEquals($added->modified, $returned->modified);
     }
 }

--- a/tests/TestCase/View/Helper/DateHelperTest.php
+++ b/tests/TestCase/View/Helper/DateHelperTest.php
@@ -6,6 +6,7 @@ use Cake\TestSuite\TestCase;
 use Cake\View\View;
 use Cake\I18n\I18n;
 use Cake\I18n\Time;
+use Cake\I18n\FrozenTime;
 
 class DateHelperTest extends TestCase {
 
@@ -129,7 +130,10 @@ class DateHelperTest extends TestCase {
         return [
             'null' => [null, 'date unknown'],
             '0000-00-00 00:00:00' => ['0000-00-00 00:00:00', 'date unknown'],
-            'CakePHP Time instance' => [new Time('1987-06-05 23:45:19'), 'June 5, 1987 at 11:45 PM'],
+            'CakePHP Time instance' =>
+                [new Time('1987-06-05 23:45:19'), 'June 5, 1987 at 11:45 PM'],
+            'CakePHP FrozenTime instance' =>
+                [new FrozenTime('1983-06-05 23:45:19'), 'June 5, 1983 at 11:45 PM'],
             'string' => ['2000-12-07 01:23:45', 'December 7, 2000 at 1:23 AM']
         ];
     }
@@ -141,5 +145,27 @@ class DateHelperTest extends TestCase {
     {
         $result = $this->DateHelper->nice($date);
         $this->assertEquals($expected, $result);
+    }
+
+    public function testAgoWorksWithEmptyObject() {
+        $this->assertEquals('date unknown', $this->DateHelper->ago(null));
+    }
+
+    public function testAgoWorksWithStrings() {
+        $this->assertEquals('date unknown', $this->DateHelper->ago('0000-00-00 00:00:00'));
+        $this->assertEquals('date unknown', $this->DateHelper->ago(''));
+        $this->assertEquals('date unknown', $this->DateHelper->ago('2017-03-04'));
+        $expected = 'March 5, 2004 at 9:27 AM';
+        $this->assertEquals($expected, $this->DateHelper->ago('2004-03-05 09:27:00'));
+    }
+
+    public function testAgoWorksWithDateTimeObjects() {
+        $expected = 'November 23, 1988 at 1:45 PM';
+        $this->assertEquals($expected, $this->DateHelper->ago(new Time('1988-11-23 13:45:00')));
+    }
+
+    public function testAgoWorksWithFrozenTimeObjects() {
+        $expected = 'November 24, 1988 at 1:45 PM';
+        $this->assertEquals($expected, $this->DateHelper->ago(new FrozenTime('1988-11-24 13:45:00')));
     }
 }


### PR DESCRIPTION
In most parts we still used strings for the content of `datetime`
columns. But in combination with the `Timestamp` behavior and locales
which don't use arabic numerals (in our current UI Arabic, Bangla and
Marathi) this is broken because CakePHP internally represents
`Timestamp` dates as `FrozenTime` objects and when these get converted
to strings, the locale numerals are used. MySQL can't use these
strings and as a consequence the dates are stored as
`0000-00-00 00:00:00` in the database.

#1948 demonstrated this problem.

I've changed all problematic tables to use `FrozenTime` objects for
representing dates. There are still tables which use strings for dates
(mainly `PrivateMessages` and the tables handling contributions) but
since we currently don't use the `Timestamp` behavior there they still
work and I left them as is (it's probably a good idea to change them in
the near future).

I've also added tests and as a bonus fixed some function documentation
comments. :-)