### PR TITLE
Fix deprecation warning for e-mail transport configuration

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -41,6 +41,7 @@ use Cake\Error\ErrorHandler;
 use Cake\Http\ServerRequest;
 use Cake\Log\Log;
 use Cake\Mailer\Email;
+use Cake\Mailer\TransportFactory;
 use Cake\Utility\Inflector;
 use Cake\Utility\Security;
 
@@ -157,7 +158,7 @@ if (!Configure::read('App.fullBaseUrl')) {
 
 Cache::setConfig(Configure::consume('Cache'));
 ConnectionManager::setConfig(Configure::consume('Datasources'));
-Email::setConfigTransport(Configure::consume('EmailTransport'));
+TransportFactory::setConfig(Configure::consume('EmailTransport'));
 Email::setConfig(Configure::consume('Email'));
 Log::setConfig(Configure::consume('Log'));
 Security::setSalt(Configure::consume('Security.salt'));


### PR DESCRIPTION
Since 3.7 `Email::setConfigTransport()` is deprecated.

This looks like a cosmetic change but I have the DebugKit plugin enabled in my VM and when I enable deprecation warnings this will break because this warning comes from `bootstrap.php` and results in `Unable to emit headers`/`headers already sent` warnings/errors (there should be [No output before sending headers!](https://stackoverflow.com/questions/8028957/how-to-fix-headers-already-sent-error-in-php#answer-8028987))