### PR TITLE
Translating sentences in the new sentence design

### DIFF
--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -28,6 +28,7 @@ files[] = jquery-1.11.3.min.js
 files[] = angular/angular.min.js
 files[] = angular/angular-animate.min.js
 files[] = angular/angular-aria.min.js
+files[] = angular/angular-cookies.min.js
 files[] = angular/angular-material.min.js
 files[] = angular/angular-messages.min.js
 files[] = watch.js

--- a/src/Controller/FavoritesController.php
+++ b/src/Controller/FavoritesController.php
@@ -117,7 +117,7 @@ class FavoritesController extends AppController
         $this->set('isLogged', $isLogged);
         $this->set('withRemoveOrUndo', $withRemoveOrUndo);
 
-        $this->layout = null;
+        $this->viewBuilder()->setLayout('ajax');
         $this->render('add_remove_favorite');
 
     }

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -33,6 +33,7 @@ use App\Lib\SphinxClient;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Utility\Hash;
+use Cake\View\ViewBuilder;
 use Exception;
 
 /**
@@ -345,15 +346,21 @@ class SentencesController extends AppController
      *
      * @return void
      */
-    public function edit_sentence()
+    public function edit_sentence($type = 'html')
     {
         $sentence = $this->Sentences->editSentence($this->request->data);
-        if (empty($sentence)) {
-            // TODO Better error handling.
-            $this->redirect(array('controller' => 'pages', 'action' => 'home'));
+        if ($type == 'json') {
+            $this->set('result', $sentence);
+            $this->layout = 'json';
+            $this->render('/Generic/json');
         } else {
-            $this->layout = null;
-            $this->set('sentence_text', $sentence->text);
+            if (empty($sentence)) {
+                // TODO Better error handling.
+                $this->redirect(array('controller' => 'pages', 'action' => 'home'));
+            } else {
+                $this->layout = null;
+                $this->set('sentence_text', $sentence->text);
+            }
         }
     }
 
@@ -456,10 +463,10 @@ class SentencesController extends AppController
         }
 
         if ($type == 'json') {
+            $this->set('result', $translation);
             $this->layout = 'json';
+            $this->render('/Generic/json');
         }
-        
-        $this->set('type', $type);
     }
 
     private function _find_sphinx_markers($query)

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -351,14 +351,14 @@ class SentencesController extends AppController
         $sentence = $this->Sentences->editSentence($this->request->data);
         if ($type == 'json') {
             $this->set('result', $sentence);
-            $this->layout = 'json';
+            $this->viewBuilder()->setLayout('json');
             $this->render('/Generic/json');
         } else {
             if (empty($sentence)) {
                 // TODO Better error handling.
                 $this->redirect(array('controller' => 'pages', 'action' => 'home'));
             } else {
-                $this->layout = null;
+                $this->viewBuilder()->setLayout('ajax');
                 $this->set('sentence_text', $sentence->text);
             }
         }
@@ -408,7 +408,7 @@ class SentencesController extends AppController
 
         $this->set('sentenceId', $id);
         $this->set('owner', $sentence->user);
-        $this->layout = null;
+        $this->viewBuilder()->setLayout('ajax');
         $this->render('adopt');
     }
 
@@ -464,7 +464,7 @@ class SentencesController extends AppController
 
         if ($type == 'json') {
             $this->set('result', $translation);
-            $this->layout = 'json';
+            $this->viewBuilder()->setLayout('json');
             $this->render('/Generic/json');
         }
     }
@@ -974,7 +974,7 @@ class SentencesController extends AppController
         $this->request->getSession()->write('random_lang_selected', $lang);
         $neighbors = $this->Sentences->getNeighborsSentenceIds($id, $lang);
         $this->set('result', $neighbors);
-        $this->layout = 'json';
+        $this->viewBuilder()->setLayout('json');
     }
 
 

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -411,7 +411,7 @@ class SentencesController extends AppController
      *
      * @return void
      */
-    public function save_translation()
+    public function save_translation($type = 'html')
     {
         $sentenceId = $this->request->getData('id');
         $translationLang = $this->request->getData('selectLang');
@@ -454,6 +454,12 @@ class SentencesController extends AppController
                 $this->set('parentId', $sentenceId);
             }
         }
+
+        if ($type == 'json') {
+            $this->layout = 'json';
+        }
+        
+        $this->set('type', $type);
     }
 
     private function _find_sphinx_markers($query)

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -507,7 +507,7 @@ class UsersController extends AppController
      */
     public function check_username($username)
     {
-        $this->layout = null;
+        $this->viewBuilder()->setLayout('ajax');
         $user = $this->Users->getIdFromUsername($username);
 
         if ($user) {
@@ -527,7 +527,7 @@ class UsersController extends AppController
      */
     public function check_email($email)
     {
-        $this->layout = null;
+        $this->viewBuilder()->setLayout('ajax');
         $userId = $this->Users->getIdFromEmail($email);
 
         if ($userId) {

--- a/src/Controller/VocabularyController.php
+++ b/src/Controller/VocabularyController.php
@@ -158,7 +158,7 @@ class VocabularyController extends AppController
         $result['numSentencesLabel'] = $numSentencesLabel;
 
         $this->set('result', $result);
-        $this->layout = 'json';
+        $this->viewBuilder()->setLayout('json');
     }
 
 
@@ -181,7 +181,7 @@ class VocabularyController extends AppController
 
         $this->set('vocabularyId', array('id' => $vocabularyId, 'data' => $data));
 
-        $this->layout = 'json';
+        $this->viewBuilder()->setLayout('json');
     }
 
 
@@ -220,6 +220,6 @@ class VocabularyController extends AppController
 
         $this->set('sentence', $sentence);
 
-        $this->layout = 'json';
+        $this->viewBuilder()->setLayout('json');
     }
 }

--- a/src/Controller/WallController.php
+++ b/src/Controller/WallController.php
@@ -163,7 +163,7 @@ class WallController extends AppController
         // now save to database
         $message = $this->Wall->saveReply($parentId, $content, $userId);
         $this->set('message', $message);
-        $this->layout = 'json';
+        $this->viewBuilder()->setLayout('json');
     }
 
     /**

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -79,7 +79,7 @@ $indirectTranslationsJSON = $this->Sentences->translationsForAngular($indirectTr
             <?php
             if (CurrentUser::isMember()) {
                 echo $this->element('sentences/sentence_menu', [
-                    'sentenceId' => $sentence->id,
+                    'sentence' => $sentence,
                     'menu' => $sentenceMenu
                 ]);
             }

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -76,6 +76,7 @@ $sentenceMenu = [
             <?php
             if (CurrentUser::isMember()) {
                 echo $this->element('sentences/sentence_menu', [
+                    'sentenceId' => $sentence->id,
                     'menu' => $sentenceMenu
                 ]);
             }
@@ -106,8 +107,16 @@ $sentenceMenu = [
         </div>
     </div>
 
+    <?php
+    if (CurrentUser::isMember()) { 
+        echo $this->element('sentences/translation_form', [
+            'sentenceId' => $sentence->id
+        ]);
+    }
+    ?>
+
     <?php if (count($directTranslations) > 0) { ?>
-        <div layout="column" class="direct translations">
+        <div layout="column" class="direct translations" ng-if="!vm.isTranslationFormVisible">
             <md-divider></md-divider>
             <md-subheader><?= __('Translations') ?></md-subheader>
             <?php foreach ($directTranslations as $translation) {
@@ -131,7 +140,7 @@ $sentenceMenu = [
             $showExtra = 'ng-if="vm.isExpanded"';
         }
         ?>
-        <div layout="column" <?= $showExtra ?> class="indirect translations">
+        <div layout="column" <?= $showExtra ?> class="indirect translations" ng-if="!vm.isTranslationFormVisible">
             <md-subheader><?= __('Translations of translations') ?></md-subheader>
             <?php foreach ($indirectTranslations as $translation) {
                 $isExtra = $numExtra > 1 && $displayedTranslations >= $maxDisplayed;
@@ -149,7 +158,7 @@ $sentenceMenu = [
     <?php } ?>
 
     <?php if ($numExtra > 1) { ?>
-        <div layout="column">
+        <div layout="column" ng-if="!vm.isTranslationFormVisible">
             <md-button ng-click="vm.expandOrCollapse()">
                 <md-icon>{{vm.expandableIcon}}</md-icon>
                 <span ng-if="!vm.isExpanded">

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -6,7 +6,6 @@ $this->Html->script('/js/directives/sentence-and-translations.dir.js', array('bl
 
 list($directTranslations, $indirectTranslations) = $translations;
 $maxDisplayed = 5;
-$displayedTranslations = 0;
 $showExtra = '';
 $numExtra = count($directTranslations) + count($indirectTranslations) - $maxDisplayed;
 $sentenceLink = $this->Html->link(
@@ -38,9 +37,13 @@ $sentenceMenu = [
     'canDelete' => CurrentUser::canRemoveSentence($sentence->id, null, $username),
     'canLink' => CurrentUser::isTrusted(),
 ];
+
+$directTranslationsJSON = $this->Sentences->translationsForAngular($directTranslations);
+$indirectTranslationsJSON = $this->Sentences->translationsForAngular($indirectTranslations);
 ?>
 <div ng-cloak
      sentence-and-translations
+     ng-init="vm.initTranslations(<?= $directTranslationsJSON ?>, <?= $indirectTranslationsJSON ?>)"
      class="sentence-and-translations md-whiteframe-1dp">
     <div layout="column">
         <div layout="row" class="header">
@@ -119,41 +122,25 @@ $sentenceMenu = [
         <div layout="column" class="direct translations" ng-if="!vm.isTranslationFormVisible">
             <md-divider></md-divider>
             <md-subheader><?= __('Translations') ?></md-subheader>
-            <?php foreach ($directTranslations as $translation) {
-                $isExtra = $numExtra > 1 && $displayedTranslations >= $maxDisplayed;
-                echo $this->element(
-                    'sentences/translation',
-                    array(
-                        'sentenceId' => $sentence->id,
-                        'translation' => $translation,
-                        'isExtra' => $isExtra
-                    )
-                );
-                $displayedTranslations++;
-            }
+
+            <?php
+            echo $this->element('sentences/translation', [
+                'translations' => 'vm.directTranslations'
+            ]);
             ?>
         </div>
     <?php } ?>
 
-    <?php if (count($indirectTranslations) > 0) {
-        if ($numExtra > 1 && $displayedTranslations >= $maxDisplayed) {
-            $showExtra = 'ng-if="vm.isExpanded"';
-        }
-        ?>
-        <div layout="column" <?= $showExtra ?> class="indirect translations" ng-if="!vm.isTranslationFormVisible">
+    <?php if (count($indirectTranslations) > 0) { ?>
+        <div layout="column" <?= $showExtra ?> class="indirect translations" ng-if="!vm.isTranslationFormVisible && vm.indirectTranslations.length > 1"
+             ng-init="vm.initIndirectTranslations(<?= $this->Sentences->translationsForAngular($indirectTranslations) ?>)">
             <md-subheader><?= __('Translations of translations') ?></md-subheader>
-            <?php foreach ($indirectTranslations as $translation) {
-                $isExtra = $numExtra > 1 && $displayedTranslations >= $maxDisplayed;
-                echo $this->element(
-                    'sentences/translation',
-                    array(
-                        'sentenceId' => $sentence->id,
-                        'translation' => $translation,
-                        'isExtra' => $isExtra
-                    )
-                );
-                $displayedTranslations++;
-            } ?>
+            
+            <?php
+            echo $this->element('sentences/translation', [
+                'translations' => 'vm.indirectTranslations'
+            ]);
+            ?>
         </div>
     <?php } ?>
 

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -118,31 +118,28 @@ $indirectTranslationsJSON = $this->Sentences->translationsForAngular($indirectTr
     }
     ?>
 
-    <?php if (count($directTranslations) > 0) { ?>
-        <div layout="column" class="direct translations" ng-if="!vm.isTranslationFormVisible">
-            <md-divider></md-divider>
-            <md-subheader><?= __('Translations') ?></md-subheader>
+    <div layout="column" class="direct translations" ng-if="!vm.isTranslationFormVisible && vm.directTranslations.length > 0">
+        <md-divider></md-divider>
+        <md-subheader><?= __('Translations') ?></md-subheader>
 
-            <?php
-            echo $this->element('sentences/translation', [
-                'translations' => 'vm.directTranslations'
-            ]);
-            ?>
-        </div>
-    <?php } ?>
+        <?php
+        echo $this->element('sentences/translation', [
+            'translations' => 'vm.directTranslations'
+        ]);
+        ?>
+    </div>
+    
+    <div layout="column" <?= $showExtra ?> class="indirect translations" ng-if="!vm.isTranslationFormVisible && vm.indirectTranslations.length > 0"
+            ng-init="vm.initIndirectTranslations(<?= $this->Sentences->translationsForAngular($indirectTranslations) ?>)">
+        <md-subheader><?= __('Translations of translations') ?></md-subheader>
+        
+        <?php
+        echo $this->element('sentences/translation', [
+            'translations' => 'vm.indirectTranslations'
+        ]);
+        ?>
+    </div>
 
-    <?php if (count($indirectTranslations) > 0) { ?>
-        <div layout="column" <?= $showExtra ?> class="indirect translations" ng-if="!vm.isTranslationFormVisible && vm.indirectTranslations.length > 1"
-             ng-init="vm.initIndirectTranslations(<?= $this->Sentences->translationsForAngular($indirectTranslations) ?>)">
-            <md-subheader><?= __('Translations of translations') ?></md-subheader>
-            
-            <?php
-            echo $this->element('sentences/translation', [
-                'translations' => 'vm.indirectTranslations'
-            ]);
-            ?>
-        </div>
-    <?php } ?>
 
     <?php if ($numExtra > 1) { ?>
         <div layout="column" ng-if="!vm.isTranslationFormVisible">

--- a/src/Template/Element/sentences/sentence_menu.ctp
+++ b/src/Template/Element/sentences/sentence_menu.ctp
@@ -2,12 +2,13 @@
 extract($menu);
 $activeItems = array_filter($menu);
 $menuJSON = htmlspecialchars(json_encode($activeItems), ENT_QUOTES, 'UTF-8');
+$isUnapproved = $sentence->correctness == -1;
 ?>
 
 <div class="menu-wrapper" sentence-menu flex="{{vm.isMenuExpanded ? '100' : 'none'}}">
     <div class="menu" layout="row" layout-align="space-between center">
         <div>
-            <md-button class="md-icon-button" ng-click="vm.translate(<?= $sentenceId ?>)">
+            <md-button class="md-icon-button" ng-click="vm.translate(<?= $sentence->id ?>)" ng-disabled="<?= $isUnapproved ? 'true' : 'false' ?>">
                 <md-icon>translate</md-icon>
                 <md-tooltip><?= __('Translate') ?></md-tooltip>
             </md-button>

--- a/src/Template/Element/sentences/sentence_menu.ctp
+++ b/src/Template/Element/sentences/sentence_menu.ctp
@@ -1,0 +1,68 @@
+<?php
+extract($menu);
+$activeItems = array_filter($menu);
+$menuJSON = htmlspecialchars(json_encode($activeItems), ENT_QUOTES, 'UTF-8');
+?>
+
+<div class="menu-wrapper" sentence-menu flex="{{vm.isMenuExpanded ? '100' : 'none'}}">
+    <div class="menu" layout="row" layout-align="space-between center">
+        <div>
+            <md-button class="md-icon-button">
+                <md-icon>translate</md-icon>
+                <md-tooltip><?= __('Translate') ?></md-tooltip>
+            </md-button>
+
+            <?php if ($canEdit) { ?>
+            <md-button class="md-icon-button" ng-disabled="true">
+                <md-icon>edit</md-icon>
+            </md-button>
+            <?php } ?>
+
+            <md-button class="md-icon-button" ng-disabled="true">
+                <md-icon>list</md-icon>
+            </md-button>
+            
+            <md-button class="md-icon-button" ng-if="vm.isMenuExpanded" ng-disabled="true">
+                <md-icon>favorite</md-icon>
+            </md-button>
+
+            <?php if ($canLink) { ?>
+            <md-button class="md-icon-button" ng-if="vm.isMenuExpanded" ng-disabled="true">
+                <md-icon>link</md-icon>
+            </md-button>
+            <?php } ?>
+            
+            <?php if ($canDelete) { ?>
+            <md-button class="md-icon-button" ng-if="vm.isMenuExpanded" ng-disabled="true">
+                <md-icon>delete</md-icon>
+            </md-button>
+            <?php } ?>
+        </div>
+
+        <div ng-if="vm.isMenuExpanded">
+        <?php if ($canRate) { ?>
+            <md-button class="md-icon-button" ng-disabled="true">
+                <md-icon>check_circle</md-icon>
+            </md-button>
+            <md-button class="md-icon-button" ng-disabled="true">
+                <md-icon>help</md-icon>
+            </md-button>
+            <md-button class="md-icon-button" ng-disabled="true">
+                <md-icon>error</md-icon>
+            </md-button>
+        <?php } ?>
+        </div>
+
+        <div>
+            <?php if ($canAdopt) { ?>
+            <md-button class="md-icon-button" ng-if="vm.isMenuExpanded" ng-disabled="true">
+                <md-icon>person</md-icon>
+            </md-button>
+            <?php } ?>
+
+            <md-button class="md-icon-button" ng-click="vm.toggleMenu()">
+                <md-icon>more_horiz</md-icon>
+            </md-button>
+        </div>
+    </div>
+</div>

--- a/src/Template/Element/sentences/sentence_menu.ctp
+++ b/src/Template/Element/sentences/sentence_menu.ctp
@@ -7,7 +7,7 @@ $menuJSON = htmlspecialchars(json_encode($activeItems), ENT_QUOTES, 'UTF-8');
 <div class="menu-wrapper" sentence-menu flex="{{vm.isMenuExpanded ? '100' : 'none'}}">
     <div class="menu" layout="row" layout-align="space-between center">
         <div>
-            <md-button class="md-icon-button">
+            <md-button class="md-icon-button" ng-click="vm.translate(<?= $sentenceId ?>)">
                 <md-icon>translate</md-icon>
                 <md-tooltip><?= __('Translate') ?></md-tooltip>
             </md-button>

--- a/src/Template/Element/sentences/translation.ctp
+++ b/src/Template/Element/sentences/translation.ctp
@@ -13,7 +13,7 @@ $audioBaseUrl = Configure::read('Recordings.url');
     <md-icon class="chevron">chevron_right</md-icon>
 
     <div class="lang">
-        <img class="language-icon" src="/img/flags/{{translation.lang}}.svg" />
+        <img class="language-icon" src="/img/flags/{{translation.lang ? translation.lang : 'unknown'}}.svg" />
     </div>
 
     <div class="text" dir="{{translation.dir}}" flex>

--- a/src/Template/Element/sentences/translation.ctp
+++ b/src/Template/Element/sentences/translation.ctp
@@ -41,7 +41,7 @@ $audioBaseUrl = Configure::read('Recordings.url');
         </md-tooltip>
     </md-button>
 
-    <md-button class="md-icon-button audioUnavailable" target="_blank" ng-if="translation.audios && translation.audios.length === 0"
+    <md-button class="md-icon-button audioUnavailable" target="_blank" ng-if="!translation.audios || translation.audios.length === 0"
                 href="https://en.wiki.tatoeba.org/articles/show/contribute-audio">
         <md-icon>volume_off</md-icon>
         <md-tooltip md-direction="top">

--- a/src/Template/Element/sentences/translation.ctp
+++ b/src/Template/Element/sentences/translation.ctp
@@ -1,44 +1,55 @@
 <?php
-use App\Lib\LanguagesLib;
+use Cake\Core\Configure;
 
-$showExtra = '';
-if ($isExtra) {
-    $showExtra = 'ng-if="vm.isExpanded"';
-}
-$translationUrl = $this->Url->build(array(
+$sentenceBaseUrl = $this->Url->build([
     'controller' => 'sentences',
     'action' => 'show',
-    $translation->id
-));
-$notReliable = $translation->correctness == -1;
+]);
+$audioBaseUrl = Configure::read('Recordings.url');
 ?>
-<div layout="row" layout-align="start center" <?= $showExtra ?>
-     class="translation <?= $notReliable ? 'not-reliable' : '' ?>">
+<div ng-repeat="translation in <?= $translations ?>" layout="row" layout-align="start center"
+     class="translation" ng-class="{'not-reliable' : translation.correctness === -1}">
+    
     <md-icon class="chevron">chevron_right</md-icon>
+
     <div class="lang">
-        <?= $this->Languages->icon(
-                $translation->lang,
-                [
-                    'width' => 30,
-                    'height' => 20
-                ]
-            ) ?>
+        <img class="language-icon" src="/img/flags/{{translation.lang}}.svg" />
     </div>
-    <div class="text" flex
-         dir="<?= LanguagesLib::getLanguageDirection($translation->lang) ?>">
-        <?= h($translation->text) ?>
+
+    <div class="text" dir="{{translation.dir}}" flex>
+        {{translation.text}}
     </div>
-    <?php if ($notReliable) { ?>
-        <md-icon class="md-warn">warning</md-icon>
+    
+    <div ng-if="translation.correctness === -1">
+        <md-icon class="md-warn" >warning</md-icon>
         <md-tooltip md-direction="top">
             <?= __('This sentence is not reliable.') ?>
         </md-tooltip>
-    <?php } ?>
+    </div>
 
-    <?= $this->element('sentence_buttons/audio', ['sentence' => $translation]); ?>
+    <md-button class="md-icon-button audioAvailable" href="<?= $audioBaseUrl ?>{{translation.lang}}/{{translation.id}}.mp3"
+                ng-click="vm.playAudio($event)" ng-if="translation.audios && translation.audios.length > 0">
+        <md-icon>volume_up</md-icon>
+        <md-tooltip md-direction="top" ng-if="!vm.getAudioAuthor(translation)">
+            <?= __('Play audio'); ?>
+        </md-tooltip>
+        <md-tooltip md-direction="top" ng-if="vm.getAudioAuthor(translation)">
+            <?= format(
+                __('Play audio recorded by {author}', true),
+                ['author' => '{{vm.getAudioAuthor(translation)}}']
+            ); ?>
+        </md-tooltip>
+    </md-button>
+
+    <md-button class="md-icon-button audioUnavailable" target="_blank" ng-if="translation.audios && translation.audios.length === 0"
+                href="https://en.wiki.tatoeba.org/articles/show/contribute-audio">
+        <md-icon>volume_off</md-icon>
+        <md-tooltip md-direction="top">
+            <?= __('No audio for this sentence. Click to learn how to contribute.') ?>
+        </md-tooltip>
+    </md-button>
     
-    <md-button class="md-icon-button"
-               href="<?= $translationUrl ?>">
+    <md-button class="md-icon-button" href="<?= $sentenceBaseUrl ?>/{{translation.id}}">
         <md-icon>info</md-icon>
     </md-button>
 </div>

--- a/src/Template/Element/sentences/translation.ctp
+++ b/src/Template/Element/sentences/translation.ctp
@@ -27,6 +27,13 @@ $audioBaseUrl = Configure::read('Recordings.url');
         </md-tooltip>
     </div>
 
+    <md-button class="md-icon-button" ng-if="translation.editable" ng-click="vm.editTranslation(translation)">
+        <md-icon>edit</md-icon>
+        <md-tooltip>
+            <?= __('Edit this translation'); ?>
+        </md-tooltip>
+    </md-button>
+
     <md-button class="md-icon-button audioAvailable" href="<?= $audioBaseUrl ?>{{translation.lang}}/{{translation.id}}.mp3"
                 ng-click="vm.playAudio($event)" ng-if="translation.audios && translation.audios.length > 0">
         <md-icon>volume_up</md-icon>

--- a/src/Template/Element/sentences/translation.ctp
+++ b/src/Template/Element/sentences/translation.ctp
@@ -13,7 +13,7 @@ $audioBaseUrl = Configure::read('Recordings.url');
     <md-icon class="chevron">chevron_right</md-icon>
 
     <div class="lang">
-        <img class="language-icon" src="/img/flags/{{translation.lang ? translation.lang : 'unknown'}}.svg" />
+        <img class="language-icon" ng-src="/img/flags/{{translation.lang ? translation.lang : 'unknown'}}.svg" />
     </div>
 
     <div class="text" dir="{{translation.dir}}" flex>

--- a/src/Template/Element/sentences/translation_form.ctp
+++ b/src/Template/Element/sentences/translation_form.ctp
@@ -7,14 +7,14 @@ $userLanguagesJSON = htmlspecialchars(json_encode($langs), ENT_QUOTES, 'UTF-8');
     <form layout="column" layout-margin>
         <md-input-container>
             <label><?= __('Translation') ?></label>
-            <textarea id="translation-form-<?= $sentenceId ?>" ng-model="vm.translationText"></textarea>
+            <textarea id="translation-form-<?= $sentenceId ?>" ng-model="vm.newTranslation.text"></textarea>
         </md-input-container>
         
         <div layout="row" layout-align="start center">
             <md-input-container flex="50">
                 <label><?= __('Language') ?></label>
-                <md-select ng-model="vm.translationLang">
-                    <md-option ng-value="auto"><?= __('Auto detect') ?></md-option>
+                <md-select ng-model="vm.newTranslation.lang">
+                    <md-option value="auto"><?= __('Auto detect') ?></md-option>
                     <md-option ng-repeat="(code, name) in vm.userLanguages" ng-value="code">
                         {{name}}
                     </md-option>
@@ -22,7 +22,8 @@ $userLanguagesJSON = htmlspecialchars(json_encode($langs), ENT_QUOTES, 'UTF-8');
             </md-input-container>
             
             <div style="padding: 10px 10px 0 10px">
-                <img ng-src="/img/flags/{{vm.translationLang}}.svg" ng-if="vm.translationLang" width="30" height="20"/>
+                <img ng-src="/img/flags/{{vm.newTranslation.lang}}.svg" ng-if="vm.newTranslation.lang && vm.newTranslation.lang !== 'auto'" 
+                     width="30" height="20" class="language-icon"/>
             </div>
         </div>
 
@@ -30,7 +31,7 @@ $userLanguagesJSON = htmlspecialchars(json_encode($langs), ENT_QUOTES, 'UTF-8');
             <md-button class="md-raised" ng-click="vm.isTranslationFormVisible = false">
                 <?= __('Cancel') ?>
             </md-button>
-            <md-button class="md-raised md-primary">
+            <md-button class="md-raised md-primary" ng-click="vm.saveTranslation(<?= $sentenceId ?>)">
                 <?= __('Submit translation') ?>
             </md-button>
         </div>

--- a/src/Template/Element/sentences/translation_form.ctp
+++ b/src/Template/Element/sentences/translation_form.ctp
@@ -1,10 +1,13 @@
 <?php
 $langs = $this->Languages->profileLanguagesArray(false, false);
-$userLanguagesJSON = htmlspecialchars(json_encode($langs), ENT_QUOTES, 'UTF-8');
 ?>
-<div ng-if="vm.isTranslationFormVisible" style="background: #fafafa; padding-top: 10px; border-top: 1px solid #f1f1f1"
-     ng-init="vm.initUserLanguages(<?= $userLanguagesJSON ?>)">
-    <form layout="column" layout-margin>
+<div ng-if="vm.isTranslationFormVisible" style="background: #fafafa; padding-top: 10px; border-top: 1px solid #f1f1f1">
+
+<?php 
+if (!empty($langs)) { 
+    $userLanguagesJSON = htmlspecialchars(json_encode($langs), ENT_QUOTES, 'UTF-8');
+    ?>
+    <form layout="column" layout-margin ng-init="vm.initUserLanguages(<?= $userLanguagesJSON ?>)">
         <md-input-container>
             <label><?= __('Translation') ?></label>
             <textarea id="translation-form-<?= $sentenceId ?>" ng-model="vm.newTranslation.text"></textarea>
@@ -36,4 +39,12 @@ $userLanguagesJSON = htmlspecialchars(json_encode($langs), ENT_QUOTES, 'UTF-8');
             </md-button>
         </div>
     </form>
+<?php 
+} else {
+    ?><div layout-padding><?php
+    $this->Languages->displayAddLanguageMessage(false);
+    ?></div><?php
+} 
+?>
+
 </div>

--- a/src/Template/Element/sentences/translation_form.ctp
+++ b/src/Template/Element/sentences/translation_form.ctp
@@ -1,0 +1,38 @@
+<?php
+$langs = $this->Languages->profileLanguagesArray(false, false);
+$userLanguagesJSON = htmlspecialchars(json_encode($langs), ENT_QUOTES, 'UTF-8');
+?>
+<div ng-if="vm.isTranslationFormVisible" style="background: #fafafa; padding-top: 10px; border-top: 1px solid #f1f1f1"
+     ng-init="vm.initUserLanguages(<?= $userLanguagesJSON ?>)">
+    <form layout="column" layout-margin>
+        <md-input-container>
+            <label><?= __('Translation') ?></label>
+            <textarea id="translation-form-<?= $sentenceId ?>" ng-model="vm.translationText"></textarea>
+        </md-input-container>
+        
+        <div layout="row" layout-align="start center">
+            <md-input-container flex="50">
+                <label><?= __('Language') ?></label>
+                <md-select ng-model="vm.translationLang">
+                    <md-option ng-value="auto"><?= __('Auto detect') ?></md-option>
+                    <md-option ng-repeat="(code, name) in vm.userLanguages" ng-value="code">
+                        {{name}}
+                    </md-option>
+                </md-select>
+            </md-input-container>
+            
+            <div style="padding: 10px 10px 0 10px">
+                <img ng-src="/img/flags/{{vm.translationLang}}.svg" ng-if="vm.translationLang" width="30" height="20"/>
+            </div>
+        </div>
+
+        <div layout="row" layout-align="end center">
+            <md-button class="md-raised" ng-click="vm.isTranslationFormVisible = false">
+                <?= __('Cancel') ?>
+            </md-button>
+            <md-button class="md-raised md-primary">
+                <?= __('Submit translation') ?>
+            </md-button>
+        </div>
+    </form>
+</div>

--- a/src/Template/Element/sentences/translation_form.ctp
+++ b/src/Template/Element/sentences/translation_form.ctp
@@ -37,7 +37,12 @@ if (!empty($langs)) {
                 <?= __('Cancel') ?>
             </md-button>
             <md-button class="md-raised md-primary" ng-click="vm.saveTranslation(<?= $sentenceId ?>)">
-                <?= __('Submit translation') ?>
+                <span ng-if="!vm.newTranslation.editable">
+                    <?= __('Submit translation') ?>
+                </span>
+                <span ng-if="vm.newTranslation.editable">
+                    <?= __('Edit translation') ?>
+                </span>
             </md-button>
         </div>
     </form>

--- a/src/Template/Element/sentences/translation_form.ctp
+++ b/src/Template/Element/sentences/translation_form.ctp
@@ -1,13 +1,14 @@
 <?php
 $langs = $this->Languages->profileLanguagesArray(false, false);
 ?>
-<div ng-if="vm.isTranslationFormVisible" style="background: #fafafa; padding-top: 10px; border-top: 1px solid #f1f1f1">
+<div ng-if="vm.isTranslationFormVisible" style="background: #fafafa; border-top: 1px solid #f1f1f1">
 
 <?php 
 if (!empty($langs)) { 
     $userLanguagesJSON = htmlspecialchars(json_encode($langs), ENT_QUOTES, 'UTF-8');
     ?>
-    <form layout="column" layout-margin ng-init="vm.initUserLanguages(<?= $userLanguagesJSON ?>)">
+    <md-progress-linear ng-if="vm.inProgress"></md-progress-linear>
+    <form layout="column" layout-margin ng-init="vm.initUserLanguages(<?= $userLanguagesJSON ?>)" style="padding-top: 10px">
         <md-input-container>
             <label><?= __('Translation') ?></label>
             <textarea id="translation-form-<?= $sentenceId ?>" ng-model="vm.newTranslation.text" 

--- a/src/Template/Element/sentences/translation_form.ctp
+++ b/src/Template/Element/sentences/translation_form.ctp
@@ -10,7 +10,8 @@ if (!empty($langs)) {
     <form layout="column" layout-margin ng-init="vm.initUserLanguages(<?= $userLanguagesJSON ?>)">
         <md-input-container>
             <label><?= __('Translation') ?></label>
-            <textarea id="translation-form-<?= $sentenceId ?>" ng-model="vm.newTranslation.text"></textarea>
+            <textarea id="translation-form-<?= $sentenceId ?>" ng-model="vm.newTranslation.text" 
+                      ng-enter="vm.saveTranslation(<?= $sentenceId ?>)"></textarea>
         </md-input-container>
         
         <div layout="row" layout-align="start center">

--- a/src/Template/Generic/json.ctp
+++ b/src/Template/Generic/json.ctp
@@ -1,0 +1,3 @@
+<?php
+echo json_encode($result);
+?>

--- a/src/Template/Layout/json_angular.ctp
+++ b/src/Template/Layout/json_angular.ctp
@@ -1,6 +1,0 @@
-<?php
-header("Pragma: no-cache");
-header("Cache-Control: no-store, no-cache, max-age=0, must-revalidate");
-header('Content-Type: application/json; charset=utf-8');
-echo json_encode($result);
-?>

--- a/src/Template/Layout/json_angular.ctp
+++ b/src/Template/Layout/json_angular.ctp
@@ -1,0 +1,6 @@
+<?php
+header("Pragma: no-cache");
+header("Cache-Control: no-store, no-cache, max-age=0, must-revalidate");
+header('Content-Type: application/json; charset=utf-8');
+echo json_encode($result);
+?>

--- a/src/Template/Sentences/save_translation.ctp
+++ b/src/Template/Sentences/save_translation.ctp
@@ -27,11 +27,7 @@
 ?>
 
 <?php
-if ($type == 'json') {
-    
-    echo json_encode($translation);
-
-} else if (isset($translation)) {
+if (isset($translation)) {
     $type = 'directTranslation';
     $isEditable = true;
 

--- a/src/Template/Sentences/save_translation.ctp
+++ b/src/Template/Sentences/save_translation.ctp
@@ -27,7 +27,11 @@
 ?>
 
 <?php
-if (isset($translation)) {
+if ($type == 'json') {
+    
+    echo json_encode($translation);
+
+} else if (isset($translation)) {
     $type = 'directTranslation';
     $isEditable = true;
 

--- a/src/Template/Sentences/search.ctp
+++ b/src/Template/Sentences/search.ctp
@@ -134,7 +134,7 @@ if (!isset($results)) {
         </div>
     </md-toolbar>
 
-    <md-content layout-padding>
+    <md-content>
     <?php
     //echo $this->Pages->sentencesMayNotAppear($vocabulary, $real_total);
     

--- a/src/Template/Sentences/show_all_in.ctp
+++ b/src/Template/Sentences/show_all_in.ctp
@@ -52,7 +52,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
         </div>
     </md-toolbar>
 
-    <md-content layout-padding>
+    <md-content>
     <?php
     if (!empty($results)) {
         if ($total > $totalLimit) {

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -850,5 +850,13 @@ class SentencesHelper extends AppHelper
         }
         return $this->Html->tag('p', $msg, array('class' => 'derivation'));
     }
+
+    public function translationsForAngular($translations) {
+        foreach($translations as $translation) {
+            $translation->dir = LanguagesLib::getLanguageDirection($translation->lang);
+        }
+
+        return htmlspecialchars(json_encode($translations), ENT_QUOTES, 'UTF-8');
+    }
 }
 ?>

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1357,6 +1357,10 @@ div.hideLink {
     color: #D32F2F;
 }
 
+.sentence-and-translations .md-errors-spacer {
+    display: none;
+}
+
 
 /*
  * --------------------------------------------------------------------

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1300,9 +1300,16 @@ div.hideLink {
 /*
  *
  */
+.sentence-and-translations .header {
+    background: #fafafa;
+}
 
-.sentence-and-translations {
-    padding: 10px;
+.sentence-and-translations .menu-wrapper {
+    background: #fff;
+}
+.sentence-and-translations .menu {
+    background: #fafafa;
+    border-bottom-left-radius: 15px;
 }
 
 .sentence-and-translations .text,
@@ -1313,10 +1320,16 @@ div.hideLink {
 
 .sentence-and-translations .sentence {
     font-size: 24px;
+    padding: 10px;
+}
+
+.sentence-and-translations .translation {
+    padding: 2px 10px;
 }
 
 .sentence-and-translations .md-subheader {
-    background: transparent;
+    background: #fff;
+    border-top-right-radius: 15px;
 }
 
 .sentence-and-translations .md-subheader ._md-subheader-inner {

--- a/webroot/css/sentences/search.css
+++ b/webroot/css/sentences/search.css
@@ -23,7 +23,7 @@
 .sentence-and-translations,
 .sentences_set {
     background: #fff;
-    margin: 10px 0;
+    margin: 20px 10px;
 }
 
 .match {

--- a/webroot/css/sentences/show_all_in.css
+++ b/webroot/css/sentences/show_all_in.css
@@ -22,6 +22,6 @@
  */
 .sentence-and-translations,
 .sentences_set {
-    margin: 10px 0;
+    margin: 20px 10px;
     background: #fff;
 }

--- a/webroot/js/angular/angular-cookies.min.js
+++ b/webroot/js/angular/angular-cookies.min.js
@@ -1,0 +1,9 @@
+/*
+ AngularJS v1.6.1
+ (c) 2010-2016 Google, Inc. http://angularjs.org
+ License: MIT
+*/
+(function(n,c){'use strict';function l(b,a,g){var d=g.baseHref(),k=b[0];return function(b,e,f){var g,h;f=f||{};h=f.expires;g=c.isDefined(f.path)?f.path:d;c.isUndefined(e)&&(h="Thu, 01 Jan 1970 00:00:00 GMT",e="");c.isString(h)&&(h=new Date(h));e=encodeURIComponent(b)+"="+encodeURIComponent(e);e=e+(g?";path="+g:"")+(f.domain?";domain="+f.domain:"");e+=h?";expires="+h.toUTCString():"";e+=f.secure?";secure":"";f=e.length+1;4096<f&&a.warn("Cookie '"+b+"' possibly not set or overflowed because it was too large ("+
+f+" > 4096 bytes)!");k.cookie=e}}c.module("ngCookies",["ng"]).provider("$cookies",[function(){var b=this.defaults={};this.$get=["$$cookieReader","$$cookieWriter",function(a,g){return{get:function(d){return a()[d]},getObject:function(d){return(d=this.get(d))?c.fromJson(d):d},getAll:function(){return a()},put:function(d,a,m){g(d,a,m?c.extend({},b,m):b)},putObject:function(d,b,a){this.put(d,c.toJson(b),a)},remove:function(a,k){g(a,void 0,k?c.extend({},b,k):b)}}}]}]);c.module("ngCookies").factory("$cookieStore",
+["$cookies",function(b){return{get:function(a){return b.getObject(a)},put:function(a,c){b.putObject(a,c)},remove:function(a){b.remove(a)}}}]);l.$inject=["$document","$log","$browser"];c.module("ngCookies").provider("$$cookieWriter",function(){this.$get=l})})(window,window.angular);
+//# sourceMappingURL=angular-cookies.min.js.map

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -33,8 +33,8 @@
         };
     }
 
-    function SentenceAndTranslationsController() {
-        const MAX_TRANSLATIONS = 3;
+    function SentenceAndTranslationsController($http) {
+        const MAX_TRANSLATIONS = 5;
 
         var vm = this;
         var allDirectTranslations = [];
@@ -47,6 +47,7 @@
         vm.userLanguages = [];
         vm.directTranslations = [];
         vm.indirectTranslations = [];
+        vm.newTranslation = { lang: 'auto' };
 
         vm.initUserLanguages = initUserLanguages;
         vm.initTranslations = initTranslations;
@@ -55,6 +56,7 @@
         vm.playAudio = playAudio;
         vm.getAudioAuthor = getAudioAuthor;
         vm.translate = translate;
+        vm.saveTranslation = saveTranslation;
 
         /////////////////////////////////////////////////////////////////////////
 
@@ -125,6 +127,24 @@
                 var input = angular.element('#translation-form-' + id);
                 input.focus();
             }, 100);
+        }
+
+        function saveTranslation(sentenceId) {
+            if (vm.newTranslation) {
+                if (vm.newTranslation.text) {
+                    var data = {
+                        id: sentenceId,
+                        selectLang: vm.newTranslation.lang,
+                        value: vm.newTranslation.text
+                    };
+                    $http.post('/eng/sentences/save_translation/json', data).then(function(result) {
+                        allDirectTranslations.unshift(result.data);
+                        vm.newTranslation.text = null;
+                        vm.isTranslationFormVisible = false;
+                        showFewerTranslations();
+                    });
+                }
+            }
         }
     }
 

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -52,7 +52,7 @@
 
         var vm = this;
         var allDirectTranslations = [];
-        var alIndirectTranslations = [];
+        var allIndirectTranslations = [];
 
         vm.inProgress = false;
         vm.isExpanded = false;
@@ -82,7 +82,7 @@
 
         function initTranslations(directTranslations, indirectTranslations) {
             allDirectTranslations = directTranslations;
-            alIndirectTranslations = indirectTranslations;
+            allIndirectTranslations = indirectTranslations;
             showFewerTranslations();
         }
 
@@ -100,14 +100,14 @@
 
         function showAllTranslations() {
             vm.directTranslations = allDirectTranslations;
-            vm.indirectTranslations = alIndirectTranslations;
+            vm.indirectTranslations = allIndirectTranslations;
         }
 
         function showFewerTranslations() {
             vm.directTranslations = allDirectTranslations.filter(function(item, index) {
                 return index <= MAX_TRANSLATIONS - 1;
             });
-            vm.indirectTranslations = alIndirectTranslations.filter(function(item, index) {
+            vm.indirectTranslations = allIndirectTranslations.filter(function(item, index) {
                 return index + allDirectTranslations.length <= MAX_TRANSLATIONS - 1;
             });
         }

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -34,25 +34,38 @@
     }
 
     function SentenceAndTranslationsController() {
+        const MAX_TRANSLATIONS = 3;
+
         var vm = this;
+        var allDirectTranslations = [];
+        var alIndirectTranslations = [];
 
         vm.isExpanded = false;
         vm.isMenuExpanded = false;
         vm.isTranslationFormVisible = false;
         vm.expandableIcon = 'expand_more';
         vm.userLanguages = [];
+        vm.directTranslations = [];
+        vm.indirectTranslations = [];
 
         vm.initUserLanguages = initUserLanguages;
+        vm.initTranslations = initTranslations;
         vm.expandOrCollapse = expandOrCollapse;
         vm.toggleMenu = toggleMenu;
         vm.playAudio = playAudio;
+        vm.getAudioAuthor = getAudioAuthor;
         vm.translate = translate;
 
         /////////////////////////////////////////////////////////////////////////
 
         function initUserLanguages(data) {
             vm.userLanguages = data;
-            console.log(vm.userLanguages);
+        }
+
+        function initTranslations(directTranslations, indirectTranslations) {
+            allDirectTranslations = directTranslations;
+            alIndirectTranslations = indirectTranslations;
+            showFewerTranslations();
         }
 
         function expandOrCollapse() {
@@ -60,18 +73,50 @@
 
             if (vm.isExpanded) {
                 vm.expandableIcon = 'expand_less';
+                showAllTranslations();
             } else {
                 vm.expandableIcon = 'expand_more';
+                showFewerTranslations();
             }
+        }
+
+        function showAllTranslations() {
+            vm.directTranslations = allDirectTranslations;
+            vm.indirectTranslations = alIndirectTranslations;
+        }
+
+        function showFewerTranslations() {
+            vm.directTranslations = allDirectTranslations.filter(function(item, index) {
+                return index <= MAX_TRANSLATIONS - 1;
+            });
+            vm.indirectTranslations = alIndirectTranslations.filter(function(item, index) {
+                return index + allDirectTranslations.length <= MAX_TRANSLATIONS - 1;
+            });
         }
 
         function toggleMenu() {
             vm.isMenuExpanded = !vm.isMenuExpanded;
         }
 
-        function playAudio(audioURL) {
+        function playAudio($event) {
+            $event.stopPropagation();
+            $event.preventDefault();
+
+            var audioURL = $event.currentTarget.href;
             var audio = new Audio(audioURL);
             audio.play();
+        }
+
+        function getAudioAuthor(sentence) {
+            var audio = sentence.audios ? sentence.audios[0] : null;
+
+            if (audio && audio.user) {
+                return audio.user.username;
+            } else if (audio && audio.external) {
+                return audio.external.username;
+            } else {
+                return null;
+            }
         }
 
         function translate(id) {

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -38,13 +38,22 @@
 
         vm.isExpanded = false;
         vm.isMenuExpanded = false;
+        vm.isTranslationFormVisible = false;
         vm.expandableIcon = 'expand_more';
+        vm.userLanguages = [];
 
+        vm.initUserLanguages = initUserLanguages;
         vm.expandOrCollapse = expandOrCollapse;
         vm.toggleMenu = toggleMenu;
         vm.playAudio = playAudio;
+        vm.translate = translate;
 
         /////////////////////////////////////////////////////////////////////////
+
+        function initUserLanguages(data) {
+            vm.userLanguages = data;
+            console.log(vm.userLanguages);
+        }
 
         function expandOrCollapse() {
             vm.isExpanded = !vm.isExpanded;
@@ -63,6 +72,14 @@
         function playAudio(audioURL) {
             var audio = new Audio(audioURL);
             audio.play();
+        }
+
+        function translate(id) {
+            vm.isTranslationFormVisible = true;
+            setTimeout(function() {
+                var input = angular.element('#translation-form-' + id);
+                input.focus();
+            }, 100);
         }
     }
 

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -144,12 +144,11 @@
                 vm.newTranslation = {};
             }
 
-            if ($cookies.get('translationLang') && !vm.newTranslation.lang) {
+            if ($cookies.get('translationLang') && !vm.newTranslation.text) {
                 vm.newTranslation.lang = $cookies.get('translationLang');
-            } else {
+            } else if (!vm.newTranslation.lang) {
                 vm.newTranslation.lang = 'auto';
             }
-
             focusTranslationInput(id);
         }
 

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -23,7 +23,20 @@
         .directive(
             'sentenceAndTranslations',
             sentenceAndTranslations
-        );
+        )
+        // https://stackoverflow.com/questions/28851893/angularjs-textaera-enter-key-submit-form-with-autocomplete
+        .directive('ngEnter', function() {
+            return function(scope, element, attrs) {
+                element.bind('keydown', function(e) {
+                    if(e.which === 13) {
+                        scope.$apply(function(){
+                            scope.$eval(attrs.ngEnter, {'e': e});
+                        });
+                        e.preventDefault();
+                    }
+                });
+            };
+        });
 
     function sentenceAndTranslations() {
         return {

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -37,9 +37,11 @@
         var vm = this;
 
         vm.isExpanded = false;
+        vm.isMenuExpanded = false;
         vm.expandableIcon = 'expand_more';
 
         vm.expandOrCollapse = expandOrCollapse;
+        vm.toggleMenu = toggleMenu;
         vm.playAudio = playAudio;
 
         /////////////////////////////////////////////////////////////////////////
@@ -52,6 +54,10 @@
             } else {
                 vm.expandableIcon = 'expand_more';
             }
+        }
+
+        function toggleMenu() {
+            vm.isMenuExpanded = !vm.isMenuExpanded;
         }
 
         function playAudio(audioURL) {

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -46,7 +46,7 @@
         };
     }
 
-    function SentenceAndTranslationsController($http) {
+    function SentenceAndTranslationsController($http, $cookies) {
         const MAX_TRANSLATIONS = 5;
 
         var vm = this;
@@ -61,7 +61,7 @@
         vm.userLanguages = [];
         vm.directTranslations = [];
         vm.indirectTranslations = [];
-        vm.newTranslation = { lang: 'auto' };
+        vm.newTranslation = {};
 
         vm.initUserLanguages = initUserLanguages;
         vm.initTranslations = initTranslations;
@@ -137,6 +137,13 @@
 
         function translate(id) {
             vm.isTranslationFormVisible = true;
+            
+            if ($cookies.get('translationLang') && !vm.newTranslation.lang) {
+                vm.newTranslation.lang = $cookies.get('translationLang');
+            } else {
+                vm.newTranslation.lang = 'auto';
+            }
+
             setTimeout(function() {
                 var input = angular.element('#translation-form-' + id);
                 input.focus();
@@ -144,6 +151,8 @@
         }
 
         function saveTranslation(sentenceId) {
+            $cookies.put('translationLang', vm.newTranslation.lang);
+
             if (vm.newTranslation) {
                 if (vm.newTranslation.text) {
                     vm.inProgress = true;
@@ -154,7 +163,7 @@
                     };
                     $http.post('/eng/sentences/save_translation/json', data).then(function(result) {
                         allDirectTranslations.unshift(result.data);
-                        vm.newTranslation.text = null;
+                        vm.newTranslation = {};
                         vm.isTranslationFormVisible = false;
                         vm.inProgress = false;
                         showFewerTranslations();

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -53,6 +53,7 @@
         var allDirectTranslations = [];
         var alIndirectTranslations = [];
 
+        vm.inProgress = false;
         vm.isExpanded = false;
         vm.isMenuExpanded = false;
         vm.isTranslationFormVisible = false;
@@ -145,6 +146,7 @@
         function saveTranslation(sentenceId) {
             if (vm.newTranslation) {
                 if (vm.newTranslation.text) {
+                    vm.inProgress = true;
                     var data = {
                         id: sentenceId,
                         selectLang: vm.newTranslation.lang,
@@ -154,6 +156,7 @@
                         allDirectTranslations.unshift(result.data);
                         vm.newTranslation.text = null;
                         vm.isTranslationFormVisible = false;
+                        vm.inProgress = false;
                         showFewerTranslations();
                     });
                 }

--- a/webroot/js/responsive/app.module.js
+++ b/webroot/js/responsive/app.module.js
@@ -2,7 +2,7 @@
     'use strict';
 
     angular
-        .module('app', ['ngMaterial', 'ngMessages'])
+        .module('app', ['ngMaterial', 'ngMessages', 'ngCookies'])
         .config(['$mdThemingProvider', '$mdIconProvider', '$httpProvider', function($mdThemingProvider, $mdIconProvider, $httpProvider) {
             $mdThemingProvider.theme('default')
                 .primaryPalette('green')


### PR DESCRIPTION
This PR implements the translation feature in the new sentence design. It also solves #72.

**Sentence menu**

- Even though only the "Translate" feature is implemented, all the buttons are already displayed. Each user should see the same buttons as they would see in the old sentence design. However, only the "Translate" button is enabled for now.
- I felt it was too much use of vertical space to create one more line for the sentence menu, so I put the menu in on the same level as the sentence header (with the id and owner). The drawback is that not all the elements can be displayed so I made the menu expandable.
- Currently, the two buttons that will always be displayed when the menu is collapsed are the "Translate", "Edit" (if the user can edit) and "List" buttons. The other buttons are always hidden by default.
- This behavior isn't going to be optimal in all situations, for instance when people are in the process of adopting or rating sentences. This is for now just a beginning of implementation to get people used to the idea of having an collapsed menu. I will think of a solution when migrating more features to the new sentence design.

**Adding translations**

For the most part, adding a translation will feel the same as in the old sentence design:
- If the user has no language in their profile, a warning message appears with a button that redirects to the page to add a language. Otherwise, all the translations are hidden and only the form is displayed.
- The text input is focused when the form is displayed.
- The translation can be submitted when pressing enter from the text input.
- The language is preselected with what was selected in the last submitted translation.
- There's a "Cancel" button to close the form. The text and language will remain there if the user clicks again on the "Translate" button.
- The translation can be edited right after being submitted.

Some differences:
- To edit a new translation, instead of clicking on the sentence itself, there's an edit button.
- This button opens a form that looks almost the same as the translation form, with the only difference that the submit button instead says "Edit translation".
- This form allows to edit both the text and the language, so changing the language is no longer done by clicking on the language icon, but by clicking on this edit button.
- In case the user edits a translation and then clicks on the "Translate" button before saving the edited translation, the edited information will be erased. In the old sentence component, the information would still be there. I don't think this is a big loss since a user who chooses to add a new translation before submitting an edited translation most likely didn't want to save the changes anyway.