### PR TITLE
Automatically detect writing direction for North Levantine Arabic

### DIFF
--- a/src/Lib/LanguagesLib.php
+++ b/src/Lib/LanguagesLib.php
@@ -631,7 +631,6 @@ class LanguagesLib
             "urd",
             "yid",
             "pnb",
-            "apc",
             "oar",
             "ary",
             "aii",
@@ -643,7 +642,8 @@ class LanguagesLib
         );
 
         $autoLangs = array(
-            "ota"
+            "apc",
+            "ota",
         );
 
         if (in_array($lang, $rightToLeftLangs)) {


### PR DESCRIPTION
Two different writing systems are in use for North Levantine Arabic,
one right-to-left using the Arabic script and one left-to-right using
the Latin script (the so-called Arabic chat alphabet).

North Levantine Arabic is currently configured as a right-to-left
language only, which has led to discussions on multiple Latin-script
sentences, e.g.
[#3074437 in 2016](https://tatoeba.org/eng/sentences/show/3074437)
and [#8430982 in 2020](https://tatoeba.org/eng/sentences/show/8430982).

This PR configures North Levantine Arabic to automatically detect
the correct writing direction for each sentence instead.