### PR TITLE
Make the sender's name in private messages clickable

### DIFF
--- a/src/Template/Element/private_messages/message.ctp
+++ b/src/Template/Element/private_messages/message.ctp
@@ -1,7 +1,11 @@
 <?php
 $username = $user->username;
 $avatar = $user->image;
-$userProfileUrl = '';
+$userProfileUrl = $this->Url->build(array(
+    'controller' => 'user',
+    'action' => 'profile',
+    $username
+));
 $dateLabel = $this->Date->ago($message->date);
 $fullDateLabel = $message->date;
 $menu = $this->PrivateMessages->getMenu($message->folder, $message->id, $message->type);


### PR DESCRIPTION
Add the URL for userProfileUrl variable in the message.ctp for making the Username clickable in the Private messages page (#2043 )