### PR TITLE
Avoid reflow/layout thrashing in sidebar

### DIFF
--- a/src/Template/Activities/translate_sentences_of.ctp
+++ b/src/Template/Activities/translate_sentences_of.ctp
@@ -43,7 +43,7 @@ if (!empty($lang)) {
 $this->set('title_for_layout', $this->Pages->formatTitle($title));
 ?>
 
-<div id="annexe_content">    
+<div id="annexe_content" ng-cloak>
     <?php     
     echo $this->element(
         'users_menu', 

--- a/src/Template/Audio/of.ctp
+++ b/src/Template/Audio/of.ctp
@@ -28,7 +28,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
 <?php
 if (isset($sentencesWithAudio)) {
 ?>
-    <div id="annexe_content">
+    <div id="annexe_content" ng-cloak>
     <?php
         echo $this->element(
         'users_menu',

--- a/src/Template/Collections/of.ctp
+++ b/src/Template/Collections/of.ctp
@@ -53,7 +53,7 @@ if ($userExists) {
 $this->set('title_for_layout', $this->Pages->formatTitle($title));
 ?>
 
-<div id="annexe_content">
+<div id="annexe_content" ng-cloak>
     <?php
     if (!CurrentUser::get('settings.users_collections_ratings')) {
         echo '<div class="module">';

--- a/src/Template/Sentences/of_user.ctp
+++ b/src/Template/Sentences/of_user.ctp
@@ -48,7 +48,7 @@ if ($userExists === true) {
 $this->set('title_for_layout', $this->Pages->formatTitle($title));
 ?>
 
-<div id="annexe_content">
+<div id="annexe_content" ng-cloak>
     <?php
     echo $this->element(
         'users_menu',

--- a/src/Template/User/profile.ctp
+++ b/src/Template/User/profile.ctp
@@ -61,7 +61,7 @@ $title = empty($realName) ? $username : "$username ($realName)";
 $this->set('title_for_layout', h($this->Pages->formatTitle($title)));
 ?>
 
-<div id="annexe_content">
+<div id="annexe_content" ng-cloak>
     <?php
         echo $this->element(
         'users_menu',


### PR DESCRIPTION
As described by [deniko on the wall](https://tatoeba.org/deu/wall/show_message/33862#message_33862) some elements of the sidebar may appear earlier than others which causes a reflow later on.

I've added the ng-cloak directive to all sidebar containers which currently contain other elements in addition to the user menu.