### PR TITLE
Add a check for the log type in the log_entry.ctp

### DIFF
--- a/src/Template/Element/logs/log_entry.ctp
+++ b/src/Template/Element/logs/log_entry.ctp
@@ -50,13 +50,15 @@ $langDir = LanguagesLib::getLanguageDirection($langCode);
 <md-list-item class="md-2-line <?= $type.'-'.$style ?>">
     <?php
     echo $this->Members->image($username, $avatar, array('class' => 'md-avatar'));
-    echo $this->Languages->icon(
-        $langCode,
-        array(
-            'ng-cloak' => true,
-            'class' => 'md-secondary lang'
-        )
-    );
+    if ($type != 'link') {
+        echo $this->Languages->icon(
+            $langCode,
+            array(
+                'ng-cloak' => true,
+                'class' => 'md-secondary lang'
+            )
+        );
+    }
     ?>
     <div class="md-list-item-text" layout="column">
         <div class="content" dir="<?= $langDir ?>">


### PR DESCRIPTION
This resolves #1440. I added a check for the log type - if it is 'link', then the flag for the contribution is not showed (this corresponds to blue and orange contributions - linking and unlinking). 