### PR TITLE
Avoid unnecessary redirections caused by Ajax calls

### DIFF
--- a/webroot/js/collections.add_remove.js
+++ b/webroot/js/collections.add_remove.js
@@ -25,7 +25,7 @@ $(document).ready(function(){
             var correctness = $(this).attr("data-sentence-correctness");
             var addToCorpusOption = $(this);
 
-            var requestUrl = "/collections";
+            var requestUrl = get_tatoeba_root_url() + "/collections";
             if ($(this).hasClass("selected")){
                 requestUrl += "/delete_sentence/" + sentenceId + "/" + correctness;
             } else {

--- a/webroot/js/favorites.add.js
+++ b/webroot/js/favorites.add.js
@@ -35,7 +35,7 @@ $(document).ready(function(){
                 action = 'add_favorite';
             }
 
-            var requestUrl = "/favorites/" + action + "/" + favoriteId;
+            var requestUrl = get_tatoeba_root_url() + "/favorites/" + action + "/" + favoriteId;
             if(favoriteOption.parent().hasClass("favorite-page")){
                 requestUrl += "/true";
             }

--- a/webroot/js/sentences.show_another.js
+++ b/webroot/js/sentences.show_another.js
@@ -35,7 +35,7 @@ function loadRandom(lang){
     
     $.ajax({
       type: "GET",
-      url: "/sentences/random/" + lang,
+      url: get_tatoeba_root_url() + "/sentences/random/" + lang,
       success: function (data){ 
           $("#random_sentence_display").watch("html", data);
           $("#random-progress").hide();

--- a/webroot/js/users/register.ctrl.js
+++ b/webroot/js/users/register.ctrl.js
@@ -27,6 +27,8 @@
         .directive('input',  ['$parse', assignDefaultValuesToModel])
         .directive('select', ['$parse', assignDefaultValuesToModel]);
 
+    const rootUrl = get_tatoeba_root_url();
+
     function assignDefaultValuesToModel($parse) {
         return {
             restrict: 'E',
@@ -71,7 +73,7 @@
                     if (!value) {
                         return $q.resolve();
                     }
-                    return $http.get('/users/check_username/' + value).then(
+                    return $http.get(rootUrl + '/users/check_username/' + value).then(
                         function(response) {
                             if (response.data === 'valid') {
                                 return $q.resolve();
@@ -93,7 +95,7 @@
                     if (!value) {
                         return $q.resolve();
                     }
-                    return $http.get('/users/check_email/' + value).then(
+                    return $http.get(rootUrl + '/users/check_email/' + value).then(
                         function(response) {
                             if (response.data === 'valid') {
                                 return $q.resolve();

--- a/webroot/js/vocabulary/add.ctrl.js
+++ b/webroot/js/vocabulary/add.ctrl.js
@@ -32,6 +32,7 @@
         vm.remove = remove;
         vm.isAdding = false;
 
+        const rootUrl = get_tatoeba_root_url();
         ///////////////////////////////////////////////////////////////////////////
 
         function add() {
@@ -40,7 +41,6 @@
             $('#add-vocabulary-form input[name^="_Token"]').each(function() {
                 vm.data[$(this).attr('name')] = $(this).val();
             });
-            var rootUrl = get_tatoeba_root_url();
             var req = {
                 method: 'POST',
                 url: rootUrl + '/vocabulary/save',
@@ -54,7 +54,7 @@
                     var data = response.data;
                     if (data.query) {
                         var query = encodeURIComponent(data.query);
-                        data.url = '/sentences/search?' +
+                        data.url = rootUrl + '/sentences/search?' +
                             'query=' + query + '&' +
                             'from=' + data.lang +
                             '&orphans=&unapproved=';
@@ -67,7 +67,7 @@
         }
 
         function remove(id) {
-            $http.get('/vocabulary/remove/' + id).then(
+            $http.get(rootUrl + '/vocabulary/remove/' + id).then(
                 function(response) {
                     $('#vocabulary_' + id).hide();
                 }

--- a/webroot/js/vocabulary/of.ctrl.js
+++ b/webroot/js/vocabulary/of.ctrl.js
@@ -29,7 +29,7 @@
         ///////////////////////////////////////////////////////////////////////////
 
         function remove(id) {
-            $http.get('/vocabulary/remove/' + id).then(
+            $http.get(get_tatoeba_root_url() + '/vocabulary/remove/' + id).then(
                 function(response) {
                     $('#vocabulary_' + id).hide();
                 }


### PR DESCRIPTION
While looking at #2072 I've noticed that we cause unnecessary redirections in the Ajax calls for checking the availability of the username. The reason is the missing language code in the URL.

I've also modified other js files where that happened.