### PR TITLE
Add check for authenticated user in Translate and Adopt Sentence Actions 

### DIFF
--- a/config/auth_actions.php
+++ b/config/auth_actions.php
@@ -4,7 +4,7 @@ use App\Model\Entity\User;
 $config = [
     // actions available to everyone, even guests
     'public_actions' => [
-        'activities' => '*',
+        'activities' => [ 'improve_sentences', 'translate_sentences_of' ],
         'audio' => [ 'of', 'index' ],
         'autocompletions' => '*',
         'collections' => [ 'of' ],
@@ -71,6 +71,10 @@ $config = [
 
     // actions not available for guests or some users
     'auth_actions' => [
+        'activities' => [
+            'translate_sentences'  => User::ROLE_CONTRIBUTOR_OR_HIGHER,
+            'adopt_sentences'      => User::ROLE_CONTRIBUTOR_OR_HIGHER,
+        ],    
         'audio' => [
             'import' => [ User::ROLE_ADMIN ],
             'save_settings' => User::ROLE_CONTRIBUTOR_OR_HIGHER,

--- a/src/Controller/ActivitiesController.php
+++ b/src/Controller/ActivitiesController.php
@@ -149,6 +149,7 @@ class ActivitiesController extends AppController
             ));
         }
     }
+    
 
     /**
      * Translate sentences of a specific user.

--- a/src/Controller/ActivitiesController.php
+++ b/src/Controller/ActivitiesController.php
@@ -52,10 +52,7 @@ class ActivitiesController extends AppController
     {
         $this->helpers[] = 'CommonModules';
         $this->helpers[] = 'Pagination';
-
-        if (empty($this->Auth->user('id'))) { 
-            return $this->redirect(array('controller' => 'pages', 'action' => 'index'));
-        }    
+        
         $conditions = array('user_id IS' => null);
         if(!empty($lang)) {
             $conditions['lang'] = $lang;
@@ -119,10 +116,7 @@ class ActivitiesController extends AppController
     public function translate_sentences()
     {
         $this->helpers[] = 'Languages';
-
-        if (empty($this->Auth->user('id'))) { 
-            return $this->redirect(array('controller' => 'pages', 'action' => 'index'));
-        }        
+        
         $langFrom = $this->request->getQuery('langFrom');
         $langTo = $this->request->getQuery('langTo');
         if ($langFrom && $langTo)

--- a/src/Controller/ActivitiesController.php
+++ b/src/Controller/ActivitiesController.php
@@ -53,6 +53,9 @@ class ActivitiesController extends AppController
         $this->helpers[] = 'CommonModules';
         $this->helpers[] = 'Pagination';
 
+        if (empty($this->Auth->user('id'))) { 
+            return $this->redirect(array('controller' => 'pages', 'action' => 'index'));
+        }    
         $conditions = array('user_id IS' => null);
         if(!empty($lang)) {
             $conditions['lang'] = $lang;
@@ -117,6 +120,9 @@ class ActivitiesController extends AppController
     {
         $this->helpers[] = 'Languages';
 
+        if (empty($this->Auth->user('id'))) { 
+            return $this->redirect(array('controller' => 'pages', 'action' => 'index'));
+        }        
         $langFrom = $this->request->getQuery('langFrom');
         $langTo = $this->request->getQuery('langTo');
         if ($langFrom && $langTo)
@@ -143,7 +149,6 @@ class ActivitiesController extends AppController
             ));
         }
     }
-
 
     /**
      * Translate sentences of a specific user.

--- a/tests/TestCase/Controller/ActivitiesControllerTest.php
+++ b/tests/TestCase/Controller/ActivitiesControllerTest.php
@@ -24,9 +24,9 @@ class ActivitiesControllerTest extends IntegrationTestCase {
     public function accessesProvider() {
         return [
             // url; user; is accessible or redirection url
-            [ '/eng/activities/adopt_sentences', null, '/eng/users/login?redirect=%2Feng%2Factivities%2Fadopt_sentences%2Feng' ],
+            [ '/eng/activities/adopt_sentences', null, '/eng/users/login?redirect=%2Feng%2Factivities%2Fadopt_sentences' ],
             [ '/eng/activities/adopt_sentences', 'contributor', true ],
-            [ '/eng/activities/adopt_sentences/jav', null, '/eng/users/login?redirect=%2Feng%2Factivities%2Fadopt_sentences%2Feng' ],
+            [ '/eng/activities/adopt_sentences/jav', null, '/eng/users/login?redirect=%2Feng%2Factivities%2Fadopt_sentences' ],
             [ '/eng/activities/adopt_sentences/jav', 'contributor', true ],
             [ '/eng/activities/translate_sentences', null, '/eng/users/login?redirect=%2Feng%2Factivities%2Ftranslate_sentences' ],
             [ '/eng/activities/translate_sentences', 'contributor', true ],

--- a/tests/TestCase/Controller/ActivitiesControllerTest.php
+++ b/tests/TestCase/Controller/ActivitiesControllerTest.php
@@ -24,12 +24,11 @@ class ActivitiesControllerTest extends IntegrationTestCase {
     public function accessesProvider() {
         return [
             // url; user; is accessible or redirection url
-            [ '/eng/activities/adopt_sentences', null, 'eng/users/login?redirect=%2Feng%2Factivities%2Fadopt_sentences%2Feng' ],
+            [ '/eng/activities/adopt_sentences', null, '/eng/users/login?redirect=%2Feng%2Factivities%2Fadopt_sentences%2Feng' ],
             [ '/eng/activities/adopt_sentences', 'contributor', true ],
-            [ '/eng/activities/adopt_sentences/jav', null, 'eng/users/login?redirect=%2Feng%2Factivities%2Fadopt_sentences%2Feng' ],
+            [ '/eng/activities/adopt_sentences/jav', null, '/eng/users/login?redirect=%2Feng%2Factivities%2Fadopt_sentences%2Feng' ],
             [ '/eng/activities/adopt_sentences/jav', 'contributor', true ],
             [ '/eng/activities/translate_sentences', null, '/eng/users/login?redirect=%2Feng%2Factivities%2Ftranslate_sentences' ],
-            [ '/eng/activities/translate_sentences', 'contributor', true ],
             [ '/eng/activities/translate_sentences', 'contributor', true ],
             [ '/eng/activities/translate_sentences_of/admin', null, true ],
             [ '/eng/activities/translate_sentences_of/admin', 'contributor', true ],

--- a/tests/TestCase/Controller/ActivitiesControllerTest.php
+++ b/tests/TestCase/Controller/ActivitiesControllerTest.php
@@ -24,11 +24,12 @@ class ActivitiesControllerTest extends IntegrationTestCase {
     public function accessesProvider() {
         return [
             // url; user; is accessible or redirection url
-            [ '/eng/activities/adopt_sentences', null, true ],
+            [ '/eng/activities/adopt_sentences', null, 'eng/users/login?redirect=%2Feng%2Factivities%2Fadopt_sentences%2Feng' ],
             [ '/eng/activities/adopt_sentences', 'contributor', true ],
-            [ '/eng/activities/adopt_sentences/jav', null, true ],
+            [ '/eng/activities/adopt_sentences/jav', null, 'eng/users/login?redirect=%2Feng%2Factivities%2Fadopt_sentences%2Feng' ],
             [ '/eng/activities/adopt_sentences/jav', 'contributor', true ],
-            [ '/eng/activities/translate_sentences', null, true ],
+            [ '/eng/activities/translate_sentences', null, '/eng/users/login?redirect=%2Feng%2Factivities%2Ftranslate_sentences' ],
+            [ '/eng/activities/translate_sentences', 'contributor', true ],
             [ '/eng/activities/translate_sentences', 'contributor', true ],
             [ '/eng/activities/translate_sentences_of/admin', null, true ],
             [ '/eng/activities/translate_sentences_of/admin', 'contributor', true ],


### PR DESCRIPTION
This resolves #1582. I asked Trang a question in the Issue's thread - is it better the redirection to be to the home page or to the Log-in page. If need be, I can make further changes to the MR.