### PR TITLE
Apply sentences per page setting to user's sentences page

### DIFF
--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -285,7 +285,7 @@ class SentencesController extends AppController
                 __('The sentence #{id} has been deleted.'),
                 array('id' => $id)
             );
-            
+
         } else {
             $flashMessage = format(
                 __('Error: the sentence #{id} could not be deleted.'),
@@ -746,7 +746,7 @@ class SentencesController extends AppController
         $limit = CurrentUser::getSetting('sentences_per_page');
         $sphinx['page'] = $this->request->query('page');
         $sphinx['limit'] = $limit;
-        
+
         $model = 'Sentences';
         if (CurrentUser::isMember()) {
             $contain = $this->Sentences->contain();
@@ -845,7 +845,7 @@ class SentencesController extends AppController
         $this->Cookie->write('show_translations_into_lang', $translationLang, false, "+1 month");
         $this->render(null);
     }
-    
+
     /**
      * Show random sentence.
      *
@@ -915,7 +915,7 @@ class SentencesController extends AppController
                         'fields' => array('username')
                     )
                 ),
-                'limit' => 100,
+                'limit' => CurrentUser::getSetting('sentences_per_page'),
                 'order' => ['Sentences.modified' => 'DESC']
             )
         );

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -206,6 +206,7 @@ class UsersFixture extends TestFixture
                 'birthday' => NULL,
                 'description' => '',
                 'settings' => [
+                    'sentences_per_page' => 20,
                     'is_public' => false,
                     'lang' => null,
                     'default_license' => 'CC0 1.0',

--- a/tests/TestCase/Controller/SentencesControllerTest.php
+++ b/tests/TestCase/Controller/SentencesControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Test\TestCase\Controller;
 
+use App\Model\Entity\User;
 use App\Test\TestCase\Controller\TatoebaControllerTestTrait;
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
@@ -277,13 +278,12 @@ class SentencesControllerTest extends IntegrationTestCase {
         $this->assertRedirect('/jpn/sentences/show/1');
     }
 
-    public function testPaginateRedirectsPageOutOfBoundsToLastPage() {
+    public function testPaginateRedirectsPageOutOfBoundsToLastPage_asGuest() {
         $user = 'kazuki';
         $userId = 7;
-        $lastPage = 2;
-
+        $defaultNbPerPage = User::$defaultSettings['sentences_per_page'];
         $newSentences = array();
-        for ($i = 1; $i <= 100; $i++) {
+        for ($i = 1; $i <= rand(1,100); $i++) {
             $newSentences[] = [
                 'lang' => 'eng',
                 'text' => "Ay ay ay $i.",
@@ -295,12 +295,44 @@ class SentencesControllerTest extends IntegrationTestCase {
                 'user_id' => 1,
             ];
         }
-        $sentences = TableRegistry::get('Sentences');
+        $sentences = TableRegistry::getTableLocator()->get('Sentences');
         $entities = $sentences->newEntities($newSentences);
-        $result = $sentences->saveMany($entities);
+        $sentences->saveMany($entities);
+
+        $nbSentences = count($sentences->find()->where(['user_id' => $userId])->all());
+        $lastPage = ceil($nbSentences / $defaultNbPerPage);
 
         $this->get("/eng/sentences/of_user/$user?page=9999999");
+        $this->assertRedirect("/eng/sentences/of_user/$user?page=$lastPage");
+    }
 
+    public function testPaginateRedirectsPageOutOfBoundsToLastPage_withUserSetting() {
+        $user = 'kazuki';
+        $userId = 7;
+        $users = TableRegistry::getTableLocator()->get('Users');
+        $NbPerPageSetting = $users->getSettings($userId)['settings']['sentences_per_page'];
+        $newSentences = array();
+        for ($i = 1; $i <= rand(1,100); $i++) {
+            $newSentences[] = [
+                'lang' => 'eng',
+                'text' => "Ay ay ay $i.",
+                'user_id' => $userId,
+            ];
+            $newSentences[] = [
+                'lang' => 'eng',
+                'text' => "Oy oy oy $i.",
+                'user_id' => 1,
+            ];
+        }
+        $sentences = TableRegistry::getTableLocator()->get('Sentences');
+        $entities = $sentences->newEntities($newSentences);
+        $sentences->saveMany($entities);
+
+        $nbSentences = count($sentences->find()->where(['user_id' => $userId])->all());
+        $lastPage = ceil($nbSentences / $NbPerPageSetting);
+
+        $this->logInAs('kazuki');
+        $this->get("/eng/sentences/of_user/$user?page=9999999");
         $this->assertRedirect("/eng/sentences/of_user/$user?page=$lastPage");
     }
 }

--- a/tests/TestCase/Controller/SentencesControllerTest.php
+++ b/tests/TestCase/Controller/SentencesControllerTest.php
@@ -283,7 +283,7 @@ class SentencesControllerTest extends IntegrationTestCase {
         $userId = 7;
         $defaultNbPerPage = User::$defaultSettings['sentences_per_page'];
         $newSentences = array();
-        for ($i = 1; $i <= rand(1,100); $i++) {
+        for ($i = 1; $i <= $defaultNbPerPage + 1; $i++) {
             $newSentences[] = [
                 'lang' => 'eng',
                 'text' => "Ay ay ay $i.",
@@ -312,7 +312,7 @@ class SentencesControllerTest extends IntegrationTestCase {
         $users = TableRegistry::getTableLocator()->get('Users');
         $NbPerPageSetting = $users->getSettings($userId)['settings']['sentences_per_page'];
         $newSentences = array();
-        for ($i = 1; $i <= rand(1,100); $i++) {
+        for ($i = 1; $i <= $NbPerPageSetting + 1; $i++) {
             $newSentences[] = [
                 'lang' => 'eng',
                 'text' => "Ay ay ay $i.",

--- a/tests/TestCase/Controller/SentencesControllerTest.php
+++ b/tests/TestCase/Controller/SentencesControllerTest.php
@@ -116,7 +116,7 @@ class SentencesControllerTest extends IntegrationTestCase {
         $entities = $sentences->newEntities($newSentences);
         $sentences->saveMany($entities);
 
-        return count($sentences->find()->where(['user_id' => $userId])->all());
+        return $sentences->find()->where(['user_id' => $userId])->count();
     }
 
     /**


### PR DESCRIPTION
This PR solves #1597 by removing the limit of 100 sentences per page and using the user's setting instead.