### PR TITLE
Indicate current sort criterion for pagination

### DIFF
--- a/src/Controller/TagsController.php
+++ b/src/Controller/TagsController.php
@@ -108,6 +108,12 @@ class TagsController extends AppController
             'conditions' => $conditions
         ];
 
+        // We use two columns for ordering the results so in order to indicate the
+        // initial sorting direction we need to set the 'sort' key manually
+        if (empty($this->request->getQuery('sort'))) {
+            $this->paginate['sort'] = 'nbrOfSentences';
+        }
+
         $allTags = $this->paginate();
         $this->set("allTags", $allTags);
         $this->set("filter", $filter);

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -488,6 +488,12 @@ class UsersController extends AppController
             'fields' => array('id', 'username', 'since', 'image', 'role'),
         );
 
+        // We use two columns for ordering the results so in order to indicate the
+        // initial sorting direction we need to set the 'sort' key manually
+        if (empty($this->request->getQuery('sort'))) {
+            $this->paginate['sort'] = 'role';
+        }
+
         $query = $this->Users->find()->where(['Users.role IN' => User::ROLE_CONTRIBUTOR_OR_HIGHER]);
         try {
             $users = $this->paginate($query);

--- a/src/Template/Users/all.ctp
+++ b/src/Template/Users/all.ctp
@@ -99,7 +99,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Members')));
             echo ' | ';
             echo $this->Paginator->sort('since', __('Member since'));
             echo ' | ';
-            echo $this->Paginator->sort('role', __('Member status'));
+            echo $this->Pagination->sortForRole();
             ?>
         </div>
 

--- a/src/View/Helper/PaginationHelper.php
+++ b/src/View/Helper/PaginationHelper.php
@@ -132,5 +132,27 @@ class PaginationHelper extends AppHelper
         </ul>
         <?php
     }
+
+    /**
+     * Swap sort link templates for ordering by user role
+     *
+     * User roles are stored as an enum in the database where the highest role
+     * (admin) is represented by the smallest value (1). Thus using the default
+     * templates for Paginator->sort() would produce the wrong arrows. In order
+     * to display the correct arrows, we need to swap the 'sortAsc' and 'sortDesc'
+     * templates before calling Paginator->sort().
+     *
+     * @return string
+     **/
+    public function sortForRole() {
+        $templates = $this->Paginator->getTemplates();
+        $this->Paginator->setTemplates([
+            'sortAsc' => $this->Paginator->getTemplates('sortDesc'),
+            'sortDesc' => $this->Paginator->getTemplates('sortAsc')
+        ]);
+        $sortLink = $this->Paginator->sort('role', __('Member status'));
+        $this->Paginator->setTemplates($templates);
+        return $sortLink;
+    }
 }
 ?>

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1561,6 +1561,20 @@ div.hideLink {
     margin: 20px;
 }
 
+.sortBy .desc, .sortBy .asc {
+/*    font-weight: bold; */
+}
+
+.sortBy .desc::after {
+    content: "\02B07";
+    vertical-align: middle;
+}
+
+.sortBy .asc::after {
+    content: "\02B06";
+    vertical-align: middle;
+}
+
 
 
 /*


### PR DESCRIPTION
This PR addresses #1991

Add an arrow next to the current sort key in the pagination header which indicates the current sort direction.