### PR TITLE
Improve UI strings consistency

### DIFF
--- a/src/Template/Element/private_messages/message.ctp
+++ b/src/Template/Element/private_messages/message.ctp
@@ -28,7 +28,7 @@ $menu = $this->PrivateMessages->getMenu($message->folder, $message->id, $message
 
         <?php foreach ($menu as $menuItem) {
             if ($menuItem['text'] == '#') {
-                $itemLabel = $replyIcon ? __('reply') : __('permalink');
+                $itemLabel = $replyIcon ? __('Reply') : __('Permalink');
             } else {
                 $itemLabel = $menuItem['text'];
             }
@@ -47,7 +47,7 @@ $menu = $this->PrivateMessages->getMenu($message->folder, $message->id, $message
             </md-button>
         <?php } ?>
     </md-card-header>
-    
+
     <md-card-content>
         <p class="content" dir="auto">
             <?= $this->Messages->formatContent($message->content) ?>

--- a/src/Template/Element/sentence_comments/comment.ctp
+++ b/src/Template/Element/sentence_comments/comment.ctp
@@ -121,7 +121,7 @@ if ($sentenceOwnerLink) {
 
         <?php foreach ($menu as $menuItem) {
             if ($menuItem['text'] == '#') {
-                $itemLabel = $replyIcon ? __('reply') : __('permalink');
+                $itemLabel = $replyIcon ? __('Reply') : __('Permalink');
             } else {
                 $itemLabel = $menuItem['text'];
             }

--- a/src/Template/Element/wall/reply_form.ctp
+++ b/src/Template/Element/wall/reply_form.ctp
@@ -27,15 +27,15 @@ $editUrl = $this->Url->build([
             </span>
         </md-card-header-text>
 
-        <md-button class="md-icon-button" aria-label="<?= __('edit') ?>" 
+        <md-button class="md-icon-button" aria-label="<?= __('edit') ?>"
                    ng-if="vm.savedReplies[<?= $parentId ?>].id"
                    ng-href="<?= $editUrl ?>/{{vm.savedReplies[<?= $parentId ?>].id}}">
             <md-icon>edit</md-icon>
-            <md-tooltip><?= __('edit') ?></md-tooltip>
+            <md-tooltip><?= __('Edit') ?></md-tooltip>
         </md-button>
     </md-card-header>
 
-    <md-progress-linear ng-if="vm.isSaving[<?= $parentId ?>]" 
+    <md-progress-linear ng-if="vm.isSaving[<?= $parentId ?>]"
                         md-mode="indeterminate"></md-progress-linear>
 
     <md-card-content class="content">

--- a/src/Template/PrivateMessages/folder.ctp
+++ b/src/Template/PrivateMessages/folder.ctp
@@ -24,14 +24,14 @@
  * @license  Affero General Public License
  * @link     https://tatoeba.org
  */
- 
+
 $folderName = '';
 if ($folder == 'Inbox') {
     if ($status == 'unread') {
         $folderName = __('Unread');
     } else {
         $folderName = __('Inbox');
-    }    
+    }
 } elseif ($folder == 'Sent') {
     $folderName = __('Sent');
 } elseif ($folder == 'Trash') {
@@ -59,7 +59,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(
         <md-toolbar class="md-hue-1">
             <div class="md-toolbar-tools">
                 <h2 flex>
-                    <?php 
+                    <?php
                     $n = $this->Paginator->param('count');
                     echo format(__n('{folderName} ({n}&nbsp;message)',
                                     '{folderName} ({n}&nbsp;messages)',
@@ -68,7 +68,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(
                     ?>
                 </h2>
 
-                <?php if ($folder == 'Trash') { 
+                <?php if ($folder == 'Trash') {
                     $url = $this->Url->build(['empty_folder', 'Trash']);
                     $msg = __('Are you sure?');
                     ?>
@@ -84,8 +84,8 @@ $this->set('title_for_layout', $this->Pages->formatTitle(
         $this->Pagination->display();
         ?>
         <md-list id="pm-list" ng-cloak>
-            <?php 
-            foreach ($content as $msg) {             
+            <?php
+            foreach ($content as $msg) {
                 list($user, $label) = $this->Messages->getUserAndLabel($msg, $folder);
 
                 $unread = $msg->isnonread == 1 ? 'unread' : '';
@@ -118,11 +118,11 @@ $this->set('title_for_layout', $this->Pages->formatTitle(
                         $msg->id
                     ]);
                     $deleteConfirmation = 'onclick="return confirm(\''.__('Are you sure?').'\');"';
-                    $deleteLabel = __('permanently delete');
+                    $deleteLabel = __('Permanently delete');
                     $deleteIcon = 'delete_forever';
                 } else {
                     $deleteConfirmation = '';
-                    $deleteLabel = __('delete');
+                    $deleteLabel = __('Delete');
                     $deleteIcon = 'delete';
                 }
 
@@ -148,7 +148,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(
                     <?php if ($folder == 'Trash') { ?>
                     <md-button class="md-icon-button" href="<?= $restoreUrl ?>">
                         <md-icon>restore</md-icon>
-                        <md-tooltip><?= __('restore') ?></md-tooltip>
+                        <md-tooltip><?= __('Restore') ?></md-tooltip>
                     </md-button>
                     <?php } ?>
 
@@ -157,8 +157,8 @@ $this->set('title_for_layout', $this->Pages->formatTitle(
                         <md-tooltip><?= $deleteLabel ?></md-tooltip>
                     </md-button>
                 </md-list-item>
-                <?php 
-            } 
+                <?php
+            }
             ?>
         </md-list>
         <?php

--- a/src/Template/User/settings.ctp
+++ b/src/Template/User/settings.ctp
@@ -60,7 +60,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                     ng-init="sendNotifications = <?= $sendNotifications ?>"
                     class="md-primary">
                 </md-checkbox>
-                <p> <?php echo __('Send email notifications.') ?></p>
+                <p> <?php echo __('Send email notifications') ?></p>
                 <div ng-hide="true">
                 <?php
                     echo $this->Form->text(
@@ -83,7 +83,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                     class="md-primary">
                 </md-checkbox>
 
-                <p><?php echo __('Set your profile public.') ?></p>
+                <p><?php echo __('Set your profile public') ?></p>
                 <div ng-hide="true">
                 <?php
                     echo $this->Form->input(
@@ -109,7 +109,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                 </md-checkbox>
                 <p><?php echo __(
                 'Remember the last list to which you assigned' .
-                ' a sentence, and select it by default.'
+                ' a sentence, and select it by default'
                 ) ?> </p>
                 <div ng-hide="true">
                 <?php
@@ -135,7 +135,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                 </md-checkbox>
                 <p><?php echo __(
                 'Display a link to expand/collapse translations ' .
-                'when there are too many translations.'
+                'when there are too many translations'
                 ) ?></p>
                 <div ng-hide="true">
                 <?php
@@ -158,7 +158,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                     ng-init="showTranscriptions = <?= $showTranscriptions ?>"
                     class="md-primary">
                 </md-checkbox>
-                <p><?php echo __('Always show transcriptions and alternative scripts.') ?> </p>
+                <p><?php echo __('Always show transcriptions and alternative scripts') ?> </p>
                 <div ng-hide="true">
                 <?php
                     echo $this->Form->input(
@@ -256,7 +256,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                     ng-init="collectionRatings = <?= $collectionRatings ?>"
                     class="md-primary">
                 </md-checkbox>
-                <p><?php echo __('Activate the feature to rate sentences and build your collection of sentences.') ?></p>
+                <p><?php echo __('Activate the feature to rate sentences and build your collection of sentences') ?></p>
                 <div ng-hide="true">
                 <?php
                     echo $this->Form->input(
@@ -280,7 +280,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                 <p><?php echo __(
                 'Display "(native)" next to username on sentences ' .
                 'when the owner indicated in their profile that they have a native '.
-                'level in the language of the sentence.'
+                'level in the language of the sentence'
                 ) ?></p>
                 <div ng-hide="true">
                 <?php
@@ -302,7 +302,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                     ng-init="copyButton = <?= $copyButton ?>"
                     class="md-primary">
                 </md-checkbox>
-                <p><?php echo __('Display button to copy a sentence to the clipboard.') ?></p>
+                <p><?php echo __('Display button to copy a sentence to the clipboard') ?></p>
                 <div ng-hide="true">
                 <?php
                     echo $this->Form->input(
@@ -326,7 +326,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                 <p><?php echo __(
                     'Display sentences with the new design. '.
                     'Note that you will not have all the features '.
-                    'from the old design.'
+                    'from the old design'
                 ) ?></p>
                 <div ng-hide="true">
                 <?php

--- a/src/Template/User/settings.ctp
+++ b/src/Template/User/settings.ctp
@@ -60,7 +60,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                     ng-init="sendNotifications = <?= $sendNotifications ?>"
                     class="md-primary">
                 </md-checkbox>
-                <p> <?php echo __('Email notifications') ?></p>
+                <p> <?php echo __('Send email notifications.') ?></p>
                 <div ng-hide="true">
                 <?php
                     echo $this->Form->text(
@@ -83,7 +83,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                     class="md-primary">
                 </md-checkbox>
 
-                <p><?php echo __('Set your profile public') ?></p>
+                <p><?php echo __('Set your profile public.') ?></p>
                 <div ng-hide="true">
                 <?php
                     echo $this->Form->input(
@@ -158,7 +158,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                     ng-init="showTranscriptions = <?= $showTranscriptions ?>"
                     class="md-primary">
                 </md-checkbox>
-                <p><?php echo __('Always show transcriptions and alternative scripts') ?> </p>
+                <p><?php echo __('Always show transcriptions and alternative scripts.') ?> </p>
                 <div ng-hide="true">
                 <?php
                     echo $this->Form->input(

--- a/src/Template/Users/register.ctp
+++ b/src/Template/Users/register.ctp
@@ -149,7 +149,7 @@ $label = format(
             <md-icon ng-if="ctrl.isPasswordVisible">visibility</md-icon>
             <md-icon ng-if="!ctrl.isPasswordVisible">visibility_off</md-icon>
             <md-tooltip ng-if="!ctrl.isPasswordVisible">
-                <?= __('unmask password') ?>
+                <?= __('Unmask password') ?>
             </md-tooltip>
         </md-button>
     </md-input-container>

--- a/src/View/Helper/CommentsHelper.php
+++ b/src/View/Helper/CommentsHelper.php
@@ -59,7 +59,7 @@ class CommentsHelper extends AppHelper
             $this->Sentences->displaySimpleSentencesGroup($sentence);
         } else {
             echo '<em>'.__('sentence deleted').'</em>';
-        }        
+        }
     }
 
     /**
@@ -75,12 +75,12 @@ class CommentsHelper extends AppHelper
         //send message
         if ($permissions['canPM']) {
             $menu[] = array(
-                'text' => __('send message'),
+                'text' => __('Send message'),
                 'icon' => 'mail',
                 'url' => array(
-                    'controller' => 'private_messages', 
-                    'action' => 'write', 
-                    $comment->user->username      
+                    'controller' => 'private_messages',
+                    'action' => 'write',
+                    $comment->user->username
                 )
             );
         }
@@ -90,10 +90,10 @@ class CommentsHelper extends AppHelper
             $hidden = $comment['hidden'];
 
             if ($hidden) {
-                $hiddenLinkText = __('unhide');
+                $hiddenLinkText = __('Unhide');
                 $hiddenLinkAction = 'unhide_message';
             } else {
-                $hiddenLinkText = __('hide');
+                $hiddenLinkText = __('Hide');
                 $hiddenLinkAction = 'hide_message';
             }
 
@@ -111,7 +111,7 @@ class CommentsHelper extends AppHelper
         // delete
         if ($permissions['canDelete']) {
             $menu[] = array(
-                'text' => __('delete'),
+                'text' => __('Delete'),
                 'icon' => 'delete',
                 'url' => array(
                     "controller" => "sentence_comments",
@@ -125,7 +125,7 @@ class CommentsHelper extends AppHelper
         // edit
         if ($permissions['canEdit']) {
             $menu[] = array(
-                'text' => __('edit'),
+                'text' => __('Edit'),
                 'icon' => 'edit',
                 'url' => array(
                     "controller" => "sentence_comments",

--- a/src/View/Helper/PrivateMessagesHelper.php
+++ b/src/View/Helper/PrivateMessagesHelper.php
@@ -157,7 +157,7 @@ class PrivateMessagesHelper extends AppHelper
 
         if ($folder == 'Trash') {
             $menu[] = array(
-                'text' => __('restore'),
+                'text' => __('Restore'),
                 'icon' => 'restore',
                 'url' => array(
                     'action' => 'restore',
@@ -166,7 +166,7 @@ class PrivateMessagesHelper extends AppHelper
             );
 
             $menu[] = array(
-                'text' => __('permanently delete'),
+                'text' => __('Permanently delete'),
                 'icon' => 'delete_forever',
                 'url' => array(
                     'action' => 'delete_forever',
@@ -176,7 +176,7 @@ class PrivateMessagesHelper extends AppHelper
             );
         } else {
             $menu[] = array(
-                'text' => __('delete'),
+                'text' => __('Delete'),
                 'icon' => 'delete',
                 'url' => array(
                     'action' => 'delete',
@@ -187,7 +187,7 @@ class PrivateMessagesHelper extends AppHelper
 
         if ($folder == 'Inbox') {
             $menu[] = array(
-                'text' => __('mark as unread'),
+                'text' => __('Mark as unread'),
                 'icon' => 'markunread_mailbox',
                 'url' => array(
                     'action' => 'mark',
@@ -198,7 +198,7 @@ class PrivateMessagesHelper extends AppHelper
 
             if ($type == 'human') {
                 $menu[] = array(
-                    'text' => __('reply'),
+                    'text' => __('Reply'),
                     'icon' => 'reply',
                     'url' => '#reply'
                 );

--- a/src/View/Helper/TagsHelper.php
+++ b/src/View/Helper/TagsHelper.php
@@ -261,7 +261,7 @@ class TagsHelper extends AppHelper
     private function _displayRemoveLink($tagId, $tagName, $sentenceId)
     {
         $removeTagFromSentenceAlt = format(
-            __("remove tag '{tagName}' from this sentence."),
+            __("Remove tag '{tagName}' from this sentence."),
             compact('tagName')
         );
         // X link to remove tag from sentence
@@ -296,7 +296,7 @@ class TagsHelper extends AppHelper
         ?>
         <span class="removeFromList">
         <?php
-        $removeFromListAlt = __("remove tag from sentence");
+        $removeFromListAlt = __("Remove tag from sentence");
         $removeTagFromSentenceImg =  $this->Html->image(
             IMG_PATH . 'close.png',
             array(


### PR DESCRIPTION
This is a candidate PR to #2101 and #2109. It aims to slightly improve consistency of UI strings by:
- Starting tooltip messages by a capital letter. Difficult to list them so I may have forgotten some of them.
- Make settings starts by a verb and end by a period. Consequently "Email notifications" would become "Send email notifications". "Hide random sentence on the homepage" was not modified as it will be erased when #2100 is merged.