### PR TITLE
Remove AUTO_INCREMENT table option in some table creation scripts

### DIFF
--- a/docs/database/tables/favorites_users.sql
+++ b/docs/database/tables/favorites_users.sql
@@ -15,4 +15,4 @@ CREATE TABLE `favorites_users` (
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `favorite_id` (`favorite_id`,`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/docs/database/tables/sentences_lists.sql
+++ b/docs/database/tables/sentences_lists.sql
@@ -29,4 +29,4 @@ CREATE TABLE `sentences_lists` (
   `visibility` enum('private', 'unlisted', 'public') NOT NULL DEFAULT 'unlisted',
   `editable_by` enum('creator', 'anyone') NOT NULL DEFAULT 'creator',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3961 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/docs/database/tables/sentences_sentences_lists.sql
+++ b/docs/database/tables/sentences_sentences_lists.sql
@@ -17,4 +17,4 @@ CREATE TABLE `sentences_sentences_lists` (
   UNIQUE KEY `list_id` (`sentences_list_id`,`sentence_id`),
   KEY `sentences_list_id` (`sentences_list_id`),
   KEY `sentence_id` (`sentence_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/docs/database/tables/transcriptions.sql
+++ b/docs/database/tables/transcriptions.sql
@@ -18,4 +18,4 @@ CREATE TABLE `transcriptions` (
   `modified` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unique_transcriptions` (`sentence_id`,`script`)
-) ENGINE=InnoDB AUTO_INCREMENT=67 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
This is a minor change but it could prevent future troubles.

I've noticed that some table creation scripts in `docs/database/tables` use the `AUTO_INCREMENT` table option. With the version of MariaDB we use (10.1.38) this isn't really a problem because the [InnoDB engine stores the `AUTO_INCREMENT` counter in memory](https://mariadb.com/kb/en/auto_increment-handling-in-innodb/#setting-auto_increment-values). Using imouto, the tables are created with the Ansible scripts and so the MariaDB server is restarted before we insert any values. Here's a demo with a newly created VM:

    vagrant@stretch:~/Tatoeba$ echo 'show create table sentences_lists\G;' | mysql tatoeba | tail -n 1
    ) ENGINE=InnoDB DEFAULT CHARSET=latin1
    vagrant@stretch:~/Tatoeba$ mysql tatoeba < docs/database/tables/sentences_lists.sql
    vagrant@stretch:~/Tatoeba$ echo 'show create table sentences_lists\G;' | mysql tatoeba | tail -n 1
    ) ENGINE=InnoDB AUTO_INCREMENT=3961 DEFAULT CHARSET=latin1
    vagrant@stretch:~/Tatoeba$ sudo systemctl restart mariadb
    vagrant@stretch:~/Tatoeba$ echo 'show create table sentences_lists\G;' | mysql tatoeba | tail -n 1
    ) ENGINE=InnoDB DEFAULT CHARSET=latin1

But if we ever upgrade MariaDB to 10.2.4 or later we would get a problem because for any new database created by the scripts in `docs/database/tables` some tables would start with an autoincrement value not equal to 1. The problematic tables are:

    vagrant@stretch:~/Tatoeba$ grep -l 'AUTO_INCREMENT=' docs/database/tables/*sql
    docs/database/tables/favorites_users.sql
    docs/database/tables/sentences_lists.sql
    docs/database/tables/sentences_sentences_lists.sql
    docs/database/tables/transcriptions.sql

So I simply removed the `AUTO_INCREMENT` from this tables.