### PR TITLE
Make "native" feature more specific

### DIFF
--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -754,7 +754,10 @@ class SentencesController extends AppController
             $contain = $this->Sentences->minimalContain();
         }
         $pagination = [
-            'finder' => ['withSphinx' => ['translationLang' => $to]],
+            'finder' => ['withSphinx' => [
+                'translationLang' => $to,
+                'nativeMarker' => CurrentUser::getSetting('native_indicator')
+            ]],
             'fields' => $this->Sentences->fields(),
             'contain' => $contain,
             'limit' => CurrentUser::getSetting('sentences_per_page'),
@@ -819,7 +822,8 @@ class SentencesController extends AppController
 
         $pagination = [
             'finder' => ['filteredTranslations' => [
-                'translationLang' => $translationLang
+                'translationLang' => $translationLang,
+                'nativeMarker' => CurrentUser::getSetting('native_indicator')
             ]],
             'fields' => $this->Sentences->fields(),
             'contain' => $this->Sentences->paginateContain($translationLang),

--- a/src/Event/UsersLanguagesListener.php
+++ b/src/Event/UsersLanguagesListener.php
@@ -29,8 +29,11 @@ class UsersLanguagesListener implements EventListenerInterface {
         );
     }
 
-    public function reportNativeness($event, $query) {
-        $UsersLanguages = TableRegistry::getTableLocator()->get('UsersLanguages');
-        $UsersLanguages->reportNativeness($event, $query);
+    public function reportNativeness($event, $query, $options) {
+        $nativeMarker = $options['nativeMarker'] ?? false;
+        if ($nativeMarker) {
+            $UsersLanguages = TableRegistry::getTableLocator()->get('UsersLanguages');
+            $UsersLanguages->reportNativeness($query);
+        }
     }
 }

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -691,7 +691,10 @@ class SentencesTable extends Table
      */
     public function getSentenceWithId($id)
     {
-        $result = $this->find('filteredTranslations')
+        $result = $this->find(
+                'filteredTranslations',
+                ['nativeMarker' => CurrentUser::getSetting('native_indicator')]
+            )
             ->where(['Sentences.id' => $id])
             ->contain($this->contain())
             ->select($this->fields())

--- a/src/Model/Table/UsersLanguagesTable.php
+++ b/src/Model/Table/UsersLanguagesTable.php
@@ -144,32 +144,22 @@ class UsersLanguagesTable extends Table
     /**
      * Executed on Sentence's beforeFind
      */
-    public function reportNativeness($event, $query) {
-        if (CurrentUser::getSetting('native_indicator')) {
-            $defaultTypes = $query->getDefaultTypes();
-            if (is_array($defaultTypes) &&
-                array_key_exists('lang', $defaultTypes) &&
-                array_key_exists('user_id', $defaultTypes) &&
-                array_key_exists('Users.level', $defaultTypes) &&
-                array_key_exists('Users.role', $defaultTypes)
-               ) {
-                   $query->join([
-                       'table' => 'users_languages',
-                       'alias' => 'UsersLanguages',
-                       'type' => 'LEFT',
-                       'conditions' => [
-                           'Sentences.user_id = UsersLanguages.of_user_id',
-                           'Sentences.lang = UsersLanguages.language_code',
-                           'UsersLanguages.level' => 5
-                       ]
-                   ]);
-                   $isNative = $query->newExpr()
-                                      ->isNotNull('UsersLanguages.id')
-                                      ->notEq('Users.role', 'spammer')
-                                      ->gt('Users.level', '-1');
-                   $query->select(['Users__is_native' => $isNative]);
-            }
-        }
+    public function reportNativeness($query) {
+        $query->join([
+            'table' => 'users_languages',
+            'alias' => 'UsersLanguages',
+            'type' => 'LEFT',
+            'conditions' => [
+                'Sentences.user_id = UsersLanguages.of_user_id',
+                'Sentences.lang = UsersLanguages.language_code',
+                'UsersLanguages.level' => 5
+            ]
+        ]);
+        $isNative = $query->newExpr()
+                          ->isNotNull('UsersLanguages.id')
+                          ->notEq('Users.role', 'spammer')
+                          ->gt('Users.level', '-1');
+        $query->select(['Users__is_native' => $isNative]);
         return $query;
     }
 


### PR DESCRIPTION
This PR addresses #2121 

The implementation for the "native" feature was too general and tried to modify queries which have nothing to do with that feature.

I've added a flag to mark the queries which should add the `is_native` column to the result.