### PR TITLE
Stop furigana from interfering with copying (fixes #1077) (for real this time)

### DIFF
--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -181,6 +181,14 @@ svg {
 rt {
     font-size: 50%;
     color: #A1A1A1;
+    /* Prevent selecting ruby text, for which copying is disabled.
+     * From https://stackoverflow.com/a/4407335 */
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+     -khtml-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
 }
 
 .translations rt {

--- a/webroot/js/generic_functions.js
+++ b/webroot/js/generic_functions.js
@@ -146,3 +146,15 @@ if (!Array.prototype.find) {
       writable: true
     });
   }
+
+// Fix for Chrome: prevent copy-pasting furigana when selecting a sentence
+// https://stackoverflow.com/questions/13438391
+$(document).on('copy', function (e) {
+    var sel = window.getSelection();
+    if (sel.rangeCount > 0) {
+        e.preventDefault();
+        $('rt').css('visibility', 'hidden');
+        e.originalEvent.clipboardData.setData('text', sel.toString());
+        $('rt').css('visibility', 'visible');
+    }
+});

--- a/webroot/js/generic_functions.js
+++ b/webroot/js/generic_functions.js
@@ -150,6 +150,10 @@ if (!Array.prototype.find) {
 // Fix for Chrome: prevent copy-pasting furigana when selecting a sentence
 // https://stackoverflow.com/questions/13438391
 $(document).on('copy', function (e) {
+    // ClipboardJS uses a textarea to implement copying in Firefox.
+    // We shouldn't mess with that event.
+    if(e.target.tagName == 'TEXTAREA') return;
+
     var sel = window.getSelection();
     if (sel.rangeCount > 0) {
         e.preventDefault();


### PR DESCRIPTION
#1077 was marked as fixed by 70ef314, but unfortunately that change was later reverted in 0fbcf53 because it broke the copy button functionality.

This PR:

1. Restores the Chrome copy-paste hack as it existed in 0fbcf53
2. Adds a workaround for ignoring copy events generated by the hidden textarea ClipboardJS uses in Firefox.
3. Adds some CSS to make ruby text non-selectable, so that it is obvious to users that it won't be copied.

The Chrome copy-paste hack actually also fixes the problem that copying in Firefox and pasting in LibreOffice Writer loses the kanji, which I mentioned in [this issue comment](https://github.com/Tatoeba/tatoeba2/issues/2064#issuecomment-581401790)

Tested in Firefox and Chromium on LInux, as well as Firefox for Android, Firefox Preview and Chrome for Android.