### PR TITLE
Favorites and adoption in new sentence design

### DIFF
--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -129,8 +129,6 @@ class SentencesController extends AppController
           'edit_sentence'
         ]);
 
-        $this->loadComponent('RequestHandler');
-
         return parent::beforeFilter($event);
     }
 
@@ -411,6 +409,7 @@ class SentencesController extends AppController
         ]);
 
         if ($acceptsJson) {
+            $this->loadComponent('RequestHandler');
             $this->set('user', $sentence->user);
             $this->set('_serialize', ['user']);
             $this->RequestHandler->renderAs($this, 'json');

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -346,10 +346,11 @@ class SentencesController extends AppController
      *
      * @return void
      */
-    public function edit_sentence($type = 'html')
+    public function edit_sentence()
     {
+        $acceptsJson = $this->request->accepts('application/json');
         $sentence = $this->Sentences->editSentence($this->request->data);
-        if ($type == 'json') {
+        if ($acceptsJson) {
             $sentence->dir = LanguagesLib::getLanguageDirection($sentence->lang);
             $this->set('result', $sentence);
             $this->viewBuilder()->setLayout('json');
@@ -373,13 +374,13 @@ class SentencesController extends AppController
      *
      * @return void
      */
-    public function adopt($id, $type = 'html')
+    public function adopt($id)
     {
         $userId = $this->Auth->user('id');
 
         $this->Sentences->setOwner($id, $userId, CurrentUser::get('role'));
 
-        $this->renderAdopt($id, $type);
+        $this->renderAdopt($id);
     }
 
     /**
@@ -391,22 +392,23 @@ class SentencesController extends AppController
      *
      * @return void
      */
-    public function let_go($id, $type = 'html')
+    public function let_go($id)
     {
         $userId = $this->Auth->user('id');
 
         $this->Sentences->unsetOwner($id, $userId);
 
-        $this->renderAdopt($id, $type);
+        $this->renderAdopt($id);
     }
 
-    private function renderAdopt($id, $type)
+    private function renderAdopt($id)
     {
+        $acceptsJson = $this->request->accepts('application/json');
         $sentence = $this->Sentences->get($id, [
             'contain' => ['Users' => ['fields' => ['username']]]
         ]);
 
-        if ($type == 'json') {
+        if ($acceptsJson) {
             $this->set('sentence', $sentence);
             $this->viewBuilder()->setLayout('json');
         } else {
@@ -414,7 +416,7 @@ class SentencesController extends AppController
             $this->set('owner', $sentence->user);
             $this->viewBuilder()->setLayout('ajax');
         }
-        $this->set('type', $type);
+        $this->set('acceptsJson', $acceptsJson);
         $this->render('adopt');
     }
 
@@ -424,7 +426,7 @@ class SentencesController extends AppController
      *
      * @return void
      */
-    public function save_translation($type = 'html')
+    public function save_translation()
     {
         $sentenceId = $this->request->getData('id');
         $translationLang = $this->request->getData('selectLang');
@@ -468,7 +470,8 @@ class SentencesController extends AppController
             }
         }
 
-        if ($type == 'json') {
+        $acceptsJson = $this->request->accepts('application/json');
+        if ($acceptsJson) {
             $this->set('result', $translation);
             $this->viewBuilder()->setLayout('json');
             $this->render('/Generic/json');

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -129,6 +129,8 @@ class SentencesController extends AppController
           'edit_sentence'
         ]);
 
+        $this->loadComponent('RequestHandler');
+
         return parent::beforeFilter($event);
     }
 
@@ -409,15 +411,15 @@ class SentencesController extends AppController
         ]);
 
         if ($acceptsJson) {
-            $this->set('sentence', $sentence);
-            $this->viewBuilder()->setLayout('json');
+            $this->set('user', $sentence->user);
+            $this->set('_serialize', ['user']);
+            $this->RequestHandler->renderAs($this, 'json');
         } else {
             $this->set('sentenceId', $id);
             $this->set('owner', $sentence->user);
             $this->viewBuilder()->setLayout('ajax');
+            $this->render('adopt');
         }
-        $this->set('acceptsJson', $acceptsJson);
-        $this->render('adopt');
     }
 
 

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -373,13 +373,13 @@ class SentencesController extends AppController
      *
      * @return void
      */
-    public function adopt($id)
+    public function adopt($id, $type = 'html')
     {
         $userId = $this->Auth->user('id');
 
         $this->Sentences->setOwner($id, $userId, CurrentUser::get('role'));
 
-        $this->renderAdopt($id);
+        $this->renderAdopt($id, $type);
     }
 
     /**
@@ -391,25 +391,30 @@ class SentencesController extends AppController
      *
      * @return void
      */
-    public function let_go($id)
+    public function let_go($id, $type = 'html')
     {
         $userId = $this->Auth->user('id');
 
         $this->Sentences->unsetOwner($id, $userId);
 
-        $this->renderAdopt($id);
+        $this->renderAdopt($id, $type);
     }
 
-    private function renderAdopt($id)
+    private function renderAdopt($id, $type)
     {
         $sentence = $this->Sentences->get($id, [
-            'contain' => ['Users' => ['fields' => ['username']]],
-            'fields' => ['id'],
+            'contain' => ['Users' => ['fields' => ['username']]]
         ]);
 
-        $this->set('sentenceId', $id);
-        $this->set('owner', $sentence->user);
-        $this->viewBuilder()->setLayout('ajax');
+        if ($type == 'json') {
+            $this->set('sentence', $sentence);
+            $this->viewBuilder()->setLayout('json');
+        } else {
+            $this->set('sentenceId', $id);
+            $this->set('owner', $sentence->user);
+            $this->viewBuilder()->setLayout('ajax');
+        }
+        $this->set('type', $type);
         $this->render('adopt');
     }
 

--- a/src/Model/CurrentUser.php
+++ b/src/Model/CurrentUser.php
@@ -388,8 +388,8 @@ class CurrentUser
         if (!$user || !$user->id || $user->id === self::get('id')) {
             return self::isMember();
         } else {
-            $userAccountDeactivated = isset($user['role']) ?
-                in_array($user['role'], [User::ROLE_SPAMMER, User::ROLE_INACTIVE]) : false;
+            $userAccountDeactivated = isset($user->role) ?
+                in_array($user->role, [User::ROLE_SPAMMER, User::ROLE_INACTIVE]) : false;
             return self::isTrusted() && $userAccountDeactivated;
         }
     }

--- a/src/Model/CurrentUser.php
+++ b/src/Model/CurrentUser.php
@@ -382,4 +382,15 @@ class CurrentUser
     {
         return !self::isMember() || self::getSetting('new_terms_of_use');
     }
+    
+    public static function canAdoptOrUnadoptSentenceOfUser($user)
+    {
+        if (!$user || !$user->id || $user->id === self::get('id')) {
+            return self::isMember();
+        } else {
+            $userAccountDeactivated = isset($user['role']) ?
+                in_array($user['role'], [User::ROLE_SPAMMER, User::ROLE_INACTIVE]) : false;
+            return self::isTrusted() && $userAccountDeactivated;
+        }
+    }
 }

--- a/src/Template/Activities/adopt_sentences.ctp
+++ b/src/Template/Activities/adopt_sentences.ctp
@@ -24,6 +24,7 @@
  * @license  Affero General Public License
  * @link     https://tatoeba.org
  */
+use App\Model\CurrentUser;
 
 if (empty($lang)){
     $title = __('Orphan sentences');
@@ -93,14 +94,28 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
         </div>
     </md-toolbar>
 
-    <md-content layout-padding>
+    <md-content>
     <?php 
 
     $this->Pagination->display();
     
-    foreach ($results as $sentence) {
-        $sentence->translations = [];
-        $this->Sentences->displaySentencesGroup($sentence);
+    if (!CurrentUser::isMember() || CurrentUser::getSetting('use_new_design')) {
+        foreach ($results as $sentence) {
+            echo $this->element(
+                'sentences/sentence_and_translations',
+                array(
+                    'sentence' => $sentence,
+                    'translations' => [0 =>[], 1 => []],
+                    'user' => $sentence->user,
+                    'menuExpanded' => true
+                )
+            );
+        }
+    } else {
+        foreach ($results as $sentence) {
+            $sentence->translations = [];
+            $this->Sentences->displaySentencesGroup($sentence);
+        }
     }
         
     $this->Pagination->display();

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -27,7 +27,7 @@ $username = $user ? $user->username : null;
 $sentenceMenu = [
     'canEdit' => CurrentUser::canEditSentenceOfUser($username),
     'canReview' => CurrentUser::get('settings.users_collections_ratings'),
-    'canAdopt' => CurrentUser::isTrusted() && !$user,
+    'canAdopt' => CurrentUser::canAdoptOrUnadoptSentenceOfUser($user),
     'canDelete' => CurrentUser::canRemoveSentence($sentence->id, null, $username),
     'canLink' => CurrentUser::isTrusted(),
 ];

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -4,6 +4,10 @@ use App\Model\CurrentUser;
 
 $this->Html->script('/js/directives/sentence-and-translations.dir.js', array('block' => 'scriptBottom'));
 
+if (!isset($menuExpanded)) {
+    $menuExpanded = false;
+}
+
 list($directTranslations, $indirectTranslations) = $translations;
 $maxDisplayed = 5;
 $showExtra = '';
@@ -73,7 +77,8 @@ $sentenceUrl = $this->Url->build([
             if (CurrentUser::isMember()) {
                 echo $this->element('sentences/sentence_menu', [
                     'sentence' => $sentence,
-                    'menu' => $sentenceMenu
+                    'menu' => $sentenceMenu,
+                    'expanded' => $menuExpanded
                 ]);
             }
             ?>

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -111,7 +111,7 @@ $sentenceUrl = $this->Url->build([
 
             <?= $this->element('sentence_buttons/audio', ['angularVar' => 'vm.sentence']); ?>
 
-            <md-button class="md-icon-button" href="<?= $sentenceUrl ?>">
+            <md-button class="md-icon-button" ng-href="<?= $sentenceUrl ?>/{{vm.sentence.id}}">
                 <md-icon>info</md-icon>
             </md-button>
         </div>

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -8,14 +8,6 @@ list($directTranslations, $indirectTranslations) = $translations;
 $maxDisplayed = 5;
 $showExtra = '';
 $numExtra = count($directTranslations) + count($indirectTranslations) - $maxDisplayed;
-$sentenceLink = $this->Html->link(
-    '#'.$sentence->id,
-    array(
-        'controller' => 'sentences',
-        'action' => 'show',
-        $sentence->id
-    )
-);
 $sentenceUrl = $this->Url->build(array(
     'controller' => 'sentences',
     'action' => 'show',
@@ -37,6 +29,15 @@ $userLanguagesJSON = htmlspecialchars(json_encode($langs), ENT_QUOTES, 'UTF-8');
 $sentenceJSON = $this->Sentences->sentenceForAngular($sentence);
 $directTranslationsJSON = $this->Sentences->translationsForAngular($directTranslations);
 $indirectTranslationsJSON = $this->Sentences->translationsForAngular($indirectTranslations);
+
+$profileUrl = $this->Url->build([
+    'controller' => 'user',
+    'action' => 'profile'
+]);
+$sentenceUrl = $this->Url->build([
+    'controller' => 'sentences',
+    'action' => 'show'
+]);
 ?>
 <div ng-cloak
      sentence-and-translations
@@ -45,32 +46,27 @@ $indirectTranslationsJSON = $this->Sentences->translationsForAngular($indirectTr
     <div layout="column">
         <div layout="row" class="header">
             <md-subheader flex class="ellipsis">
-                <?php
-                if ($user) {
-                    $userLink = $this->Html->link(
-                        $user->username,
-                        array(
-                            'controller' => 'user',
-                            'action' => 'profile',
-                            $user->username
-                        )
-                    );
+                <span ng-if="vm.sentence.user && vm.sentence.user.username">
+                    <?php
                     echo format(
                         __('Sentence {number} — belongs to {username}'),
                         array(
-                            'number' => $sentenceLink,
-                            'username' => $userLink
+                            'number' => '<a ng-href="'.$sentenceUrl.'/{{vm.sentence.id}}">#{{vm.sentence.id}}</a>',
+                            'username' => '<a ng-href="'.$profileUrl.'/{{vm.sentence.user.username}}">{{vm.sentence.user.username}}</a>'
                         )
                     );
-                } else {
+                    ?>
+                </span>
+                <span ng-if="!vm.sentence.user || !vm.sentence.user.username">
+                    <?php
                     echo format(
                         __('Sentence {number}'),
                         array(
-                            'number' => $sentenceLink
+                            'number' => '<a ng-href="'.$sentenceUrl.'/{{vm.sentence.id}}">#{{vm.sentence.id}}</a>'
                         )
                     );
-                }
-                ?>
+                    ?>
+                </span>
             </md-subheader>
 
             <?php

--- a/src/Template/Element/sentences/sentence_menu.ctp
+++ b/src/Template/Element/sentences/sentence_menu.ctp
@@ -5,7 +5,7 @@ $menuJSON = htmlspecialchars(json_encode($activeItems), ENT_QUOTES, 'UTF-8');
 $isUnapproved = $sentence->correctness == -1;
 ?>
 
-<div class="menu-wrapper" sentence-menu flex="{{vm.isMenuExpanded ? '100' : 'none'}}">
+<div class="menu-wrapper" sentence-menu flex="{{vm.isMenuExpanded ? '100' : 'none'}}" ng-init="vm.isMenuExpanded = <?= $expanded ?>">
     <div class="menu" layout="row" layout-align="space-between center">
         <div>
             <md-button class="md-icon-button" ng-click="vm.translate(<?= $sentence->id ?>)" ng-disabled="<?= $isUnapproved ? 'true' : 'false' ?>">

--- a/src/Template/Element/sentences/sentence_menu.ctp
+++ b/src/Template/Element/sentences/sentence_menu.ctp
@@ -16,6 +16,7 @@ $isUnapproved = $sentence->correctness == -1;
             <?php if ($canEdit) { ?>
             <md-button class="md-icon-button" ng-click="vm.edit()">
                 <md-icon>edit</md-icon>
+                <md-tooltip><?= __('Edit') ?></md-tooltip>
             </md-button>
             <?php } ?>
 
@@ -40,6 +41,7 @@ $isUnapproved = $sentence->correctness == -1;
                        onclick="return confirm('<?= __('Are you sure?') ?>');"
                        href="<?= $this->Url->build(['controller' => 'sentences', 'action' => 'delete', $sentence->id]) ?>">
                 <md-icon>delete</md-icon>
+                <md-tooltip><?= __('Delete') ?></md-tooltip>
             </md-button>
             <?php } ?>
         </div>

--- a/src/Template/Element/sentences/sentence_menu.ctp
+++ b/src/Template/Element/sentences/sentence_menu.ctp
@@ -23,8 +23,10 @@ $isUnapproved = $sentence->correctness == -1;
                 <md-icon>list</md-icon>
             </md-button>
 
-            <md-button class="md-icon-button" ng-if="vm.isMenuExpanded" ng-disabled="true">
-                <md-icon>favorite</md-icon>
+            <md-button class="md-icon-button" ng-if="vm.isMenuExpanded" ng-click="vm.favorite()">
+                <md-icon>{{vm.sentence.isFavorite ? 'favorite' : 'favorite_border'}}</md-icon>
+                <md-tooltip ng-if="!vm.sentence.isFavorite"><?= __('Add to favorites') ?></md-tooltip>
+                <md-tooltip ng-if="vm.sentence.isFavorite"><?= __('Remove from favorites') ?></md-tooltip>
             </md-button>
 
             <?php if ($canLink) { ?>

--- a/src/Template/Element/sentences/sentence_menu.ctp
+++ b/src/Template/Element/sentences/sentence_menu.ctp
@@ -60,8 +60,10 @@ $isUnapproved = $sentence->correctness == -1;
 
         <div>
             <?php if ($canAdopt) { ?>
-            <md-button class="md-icon-button" ng-if="vm.isMenuExpanded" ng-disabled="true">
-                <md-icon>person</md-icon>
+            <md-button class="md-icon-button" ng-if="vm.isMenuExpanded" ng-click="vm.adopt()">
+                <md-icon>{{vm.sentence.isOwnedByCurrentUser ? 'person' : 'person_outline'}}</md-icon>
+                <md-tooltip ng-if="!vm.sentence.isOwnedByCurrentUser"><?= __('Click to adopt') ?></md-tooltip>
+                <md-tooltip ng-if="vm.sentence.isOwnedByCurrentUser"><?= __('Click to unadopt') ?></md-tooltip>
             </md-button>
             <?php } ?>
 

--- a/src/Template/Element/sentences/sentence_menu.ctp
+++ b/src/Template/Element/sentences/sentence_menu.ctp
@@ -5,7 +5,7 @@ $menuJSON = htmlspecialchars(json_encode($activeItems), ENT_QUOTES, 'UTF-8');
 $isUnapproved = $sentence->correctness == -1;
 ?>
 
-<div class="menu-wrapper" sentence-menu flex="{{vm.isMenuExpanded ? '100' : 'none'}}" ng-init="vm.isMenuExpanded = <?= $expanded ?>">
+<div class="menu-wrapper" sentence-menu flex="{{vm.isMenuExpanded ? '100' : 'none'}}" ng-init="vm.isMenuExpanded = <?= (int)$expanded ?>">
     <div class="menu" layout="row" layout-align="space-between center">
         <div>
             <md-button class="md-icon-button" ng-click="vm.translate(<?= $sentence->id ?>)" ng-disabled="<?= $isUnapproved ? 'true' : 'false' ?>">

--- a/src/Template/Sentences/adopt.ctp
+++ b/src/Template/Sentences/adopt.ctp
@@ -37,4 +37,10 @@
  * @link     https://tatoeba.org
  */
 
-$this->Menu->adoptButton($sentenceId, $owner);
+if ($type === 'json') {
+    $result = $this->Sentences->getSentenceData($sentence);
+    echo json_encode($result);
+} else {
+    $this->Menu->adoptButton($sentenceId, $owner);
+}
+

--- a/src/Template/Sentences/adopt.ctp
+++ b/src/Template/Sentences/adopt.ctp
@@ -37,7 +37,7 @@
  * @link     https://tatoeba.org
  */
 
-if ($type === 'json') {
+if ($acceptsJson) {
     $result = $this->Sentences->getSentenceData($sentence);
     echo json_encode($result);
 } else {

--- a/src/Template/Sentences/adopt.ctp
+++ b/src/Template/Sentences/adopt.ctp
@@ -37,10 +37,4 @@
  * @link     https://tatoeba.org
  */
 
-if ($acceptsJson) {
-    $result = $this->Sentences->getSentenceData($sentence);
-    echo json_encode($result);
-} else {
-    $this->Menu->adoptButton($sentenceId, $owner);
-}
-
+$this->Menu->adoptButton($sentenceId, $owner);

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -882,7 +882,8 @@ class SentencesHelper extends AppHelper
             'dir' => LanguagesLib::getLanguageDirection($sentence->lang),
             'audios' => $sentence->audios,
             'correctness' => $sentence->correctness,
-            'isFavorite' => CurrentUser::hasFavorited($sentence->id)
+            'isFavorite' => CurrentUser::hasFavorited($sentence->id),
+            'isOwnedByCurrentUser' => $sentence->user && $sentence->user->id === CurrentUser::get('id')
         ];
     }
 }

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -872,7 +872,7 @@ class SentencesHelper extends AppHelper
         return htmlspecialchars(json_encode($data), ENT_QUOTES, 'UTF-8');
     }
 
-    private function getSentenceData($sentence) {
+    public function getSentenceData($sentence) {
         return [
             'id' => $sentence->id,
             'text' => $sentence->text,
@@ -883,7 +883,8 @@ class SentencesHelper extends AppHelper
             'audios' => $sentence->audios,
             'correctness' => $sentence->correctness,
             'isFavorite' => CurrentUser::hasFavorited($sentence->id),
-            'isOwnedByCurrentUser' => $sentence->user && $sentence->user->id === CurrentUser::get('id')
+            'isOwnedByCurrentUser' => $sentence->user && $sentence->user->username === CurrentUser::get('username'),
+            'user' => $sentence->user
         ];
     }
 }

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -881,7 +881,8 @@ class SentencesHelper extends AppHelper
             'script' => $sentence->script,
             'dir' => LanguagesLib::getLanguageDirection($sentence->lang),
             'audios' => $sentence->audios,
-            'correctness' => $sentence->correctness
+            'correctness' => $sentence->correctness,
+            'isFavorite' => CurrentUser::hasFavorited($sentence->id)
         ];
     }
 }

--- a/webroot/css/activities/adopt_sentences.css
+++ b/webroot/css/activities/adopt_sentences.css
@@ -20,7 +20,8 @@
 /*
  * List of sentences
  */
-.sentences_set {
-    margin: 8px 0;
-    background: #fff;
-}
+ .sentence-and-translations,
+ .sentences_set {
+     margin: 20px 10px;
+     background: #fff;
+ }

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -206,7 +206,7 @@
                         selectLang: vm.newTranslation.lang,
                         value: vm.newTranslation.text
                     };
-                    $http.post(rootUrl + '/sentences/save_translation/json', data).then(function(result) {
+                    $http.post(rootUrl + '/sentences/save_translation', data).then(function(result) {
                         result.data.editable = true;
                         result.data.parentId = sentenceId;
                         allDirectTranslations.unshift(result.data);
@@ -259,7 +259,7 @@
                 id: [lang, sentence.id].join('_'),
                 value: sentence.text
             };
-            return $http.post(rootUrl + '/sentences/edit_sentence/json', data);
+            return $http.post(rootUrl + '/sentences/edit_sentence', data);
         }
 
         function initSentence(data) {
@@ -279,7 +279,7 @@
         function adopt() {
             var action = vm.sentence.isOwnedByCurrentUser ? 'let_go' : 'adopt';
             
-            $http.get(rootUrl + '/sentences/' + action + '/' + vm.sentence.id + '/json').then(function(result) {
+            $http.get(rootUrl + '/sentences/' + action + '/' + vm.sentence.id).then(function(result) {
                 vm.sentence = result.data;
             });
         }

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -279,8 +279,8 @@
         function adopt() {
             var action = vm.sentence.isOwnedByCurrentUser ? 'let_go' : 'adopt';
             
-            $http.get(rootUrl + '/sentences/' + action + '/' + vm.sentence.id).then(function(result) {
-                vm.sentence.isOwnedByCurrentUser = !vm.sentence.isOwnedByCurrentUser;
+            $http.get(rootUrl + '/sentences/' + action + '/' + vm.sentence.id + '/json').then(function(result) {
+                vm.sentence = result.data;
             });
         }
     }

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -280,7 +280,8 @@
             var action = vm.sentence.isOwnedByCurrentUser ? 'let_go' : 'adopt';
             
             $http.get(rootUrl + '/sentences/' + action + '/' + vm.sentence.id).then(function(result) {
-                vm.sentence = result.data;
+                vm.sentence.user = result.data.user;
+                vm.sentence.isOwnedByCurrentUser = vm.sentence.user && vm.sentence.user.username;
             });
         }
     }

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -110,6 +110,7 @@
         vm.cancelEdit = cancelEdit;
         vm.editSentence = editSentence;
         vm.favorite = favorite;
+        vm.adopt = adopt;
 
         /////////////////////////////////////////////////////////////////////////
 
@@ -272,6 +273,14 @@
             
             $http.get(rootUrl + '/favorites/' + action + '/' + vm.sentence.id).then(function(result) {
                 vm.sentence.isFavorite = !vm.sentence.isFavorite;
+            });
+        }
+
+        function adopt() {
+            var action = vm.sentence.isOwnedByCurrentUser ? 'let_go' : 'adopt';
+            
+            $http.get(rootUrl + '/sentences/' + action + '/' + vm.sentence.id).then(function(result) {
+                vm.sentence.isOwnedByCurrentUser = !vm.sentence.isOwnedByCurrentUser;
             });
         }
     }

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -109,6 +109,7 @@
         vm.edit = edit;
         vm.cancelEdit = cancelEdit;
         vm.editSentence = editSentence;
+        vm.favorite = favorite;
 
         /////////////////////////////////////////////////////////////////////////
 
@@ -264,6 +265,14 @@
             data.lang = data.lang ? data.lang : 'unknown';
             oldSentence = data;
             vm.sentence = Object.assign({}, data);
+        }
+
+        function favorite() {
+            var action = vm.sentence.isFavorite ? 'remove_favorite' : 'add_favorite';
+            
+            $http.get(rootUrl + '/favorites/' + action + '/' + vm.sentence.id).then(function(result) {
+                vm.sentence.isFavorite = !vm.sentence.isFavorite;
+            });
         }
     }
 


### PR DESCRIPTION
This PR implements the favorite and adopt features in the new sentence design.

*Favorites**

This feature keeps pretty much the same behavior as in the old design:
- When the sentence is not favorited, an outlined "heart" icon is displayed with a tooltip "Add to favorites".
- When the sentence is favorited, a filled "heart" icon is displayed with a tooltip "Remove from favorites".

The differences:
- I did not add any progress animation. I think it's not really necessary here.
- The favorite button is not displayed by default so it takes more clicks to favorite sentences. This shouldn't have too much impact. The favorite feature is not heavily used.

**Adoption**

- The adopt/unadopt button is displayed at the end of the sentence menu whenever adoption or unadaoption is possible. It is hidden by default and is displayed after clicking on the expand (...) button.
- When the sentence can be unadopted (it belongs to the current user), a filled "person" icon is displayed with the tooltip "Click to unadopt".
- When the sentence can be adopted, an outlined "person" icon is displayed with the tooltip "Click to adopt". There are two cases for this:
	- The sentence has no owner.
	- The sentence is owned by an inactive member and the current user is advanced contributor or higher.
- The sentence header is updated upon adoption/unadoption to display the correct ownership.
- On the "Adopt sentences" page, the sentence menu is by default expanded in order to avoid extra clicks to adopt sentences. This hides the sentence ID but the sentence ID is not a useful information in the context of adopting sentences.