### PR TITLE
Don't try to change clipboard data in IE (fixes #2142)

### DIFF
--- a/webroot/js/generic_functions.js
+++ b/webroot/js/generic_functions.js
@@ -156,9 +156,12 @@ $(document).on('copy', function (e) {
 
     var sel = window.getSelection();
     if (sel.rangeCount > 0) {
-        e.preventDefault();
         $('rt').css('visibility', 'hidden');
-        e.originalEvent.clipboardData.setData('text', sel.toString());
+        var clipboardData = e.originalEvent.clipboardData;
+        if (clipboardData) { // not available in IE
+            e.preventDefault();
+            clipboardData.setData('text', sel.toString());
+        }
         $('rt').css('visibility', 'visible');
     }
 });

--- a/webroot/js/generic_functions.js
+++ b/webroot/js/generic_functions.js
@@ -155,13 +155,11 @@ $(document).on('copy', function (e) {
     if(e.target.tagName == 'TEXTAREA') return;
 
     var sel = window.getSelection();
-    if (sel.rangeCount > 0) {
+    var clipboardData = e.originalEvent.clipboardData; // not available in IE
+    if (sel.rangeCount > 0 && clipboardData) {
         $('rt').css('visibility', 'hidden');
-        var clipboardData = e.originalEvent.clipboardData;
-        if (clipboardData) { // not available in IE
-            e.preventDefault();
-            clipboardData.setData('text', sel.toString());
-        }
+        clipboardData.setData('text', sel.toString());
         $('rt').css('visibility', 'visible');
+        e.preventDefault();
     }
 });


### PR DESCRIPTION
IE doesn't support the `clipboardData` property and there doesn't seem to be another way to modify the clipboard contents while copying. So this PR just does nothing when a copy event fires.

Tested with IE 11.