### PR TITLE
Correct position of warning icon

### DIFF
--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -841,6 +841,7 @@ html[dir="rtl"] .comment-sentence .text {
 
 .sentence .copy.column {
     float: right;
+    height: 21px;
 }
 .sentence .copy-btn {
     width: 16px;

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1238,11 +1238,11 @@ input.sentenceId {
 }
 
 .mainSentence .correctnessNegative1 {
-    background-position: right top 5px;
+    background-position: right 5px;
 }
 
 .translations .correctnessNegative1 {
-    background-position: right top;
+    background-position: right 2px;
 }
 
 .correctness-info .ok,

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -629,12 +629,12 @@ html[dir="rtl"] .comment-sentence .text {
     background: none;
 }
 
-.paging li.prev md-icon, 
+.paging li.prev md-icon,
 .paging li.next md-icon {
     color: #4caf50;
 }
 
-.paging li.prev a:hover md-icon, 
+.paging li.prev a:hover md-icon,
 .paging li.next a:hover md-icon {
     color: #DD8800;
 }
@@ -652,7 +652,7 @@ html[dir="rtl"] .comment-sentence .text {
  * --------------------------------------------------------------------
  */
 
- #private-message-form { 
+ #private-message-form {
     background: #fafafa;
 }
 
@@ -841,7 +841,6 @@ html[dir="rtl"] .comment-sentence .text {
 
 .sentence .copy.column {
     float: right;
-    height: 16px;
 }
 .sentence .copy-btn {
     width: 16px;
@@ -873,11 +872,11 @@ html[dir="rtl"] .comment-sentence .text {
     color: gray;
     width: 24px;
     height: 24px;
-} 
+}
 
 .sentence .favorite-page.column svg:hover{
     color: black;
-} 
+}
 
 .translations .text {
     margin-top: 3px;
@@ -1234,14 +1233,15 @@ input.sentenceId {
     background: url("/img/warning-small.svg") no-repeat;
     padding-right: 25px;
     color: #EE0000;
+    overflow: hidden;
 }
 
 .mainSentence .correctnessNegative1 {
-    background-position: right 5px;
+    background-position: right top 5px;
 }
 
 .translations .correctnessNegative1 {
-    background-position: right 2px;
+    background-position: right top;
 }
 
 .correctness-info .ok,
@@ -1760,7 +1760,7 @@ div.hideLink {
 .loader-small {
     width: 11px;
     height: 11px;
-    border-width: 3px; 
+    border-width: 3px;
 }
 
 .sentence-loader {


### PR DESCRIPTION
This small PR is supposed to fix #1598. The result is the one given in my comment https://github.com/Tatoeba/tatoeba2/issues/1598#issuecomment-586194945 

It also modifies the height of `.copy.column` to its container height so the icon entirely fits inside the column, like the audio icon and the link icon. It shouldn't change anything visually. It's just to have correct values. 