### PR TITLE
Base i18n locale on the language tag, not the 3-letter ISO code

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -186,7 +186,7 @@ class AppController extends Controller
             $this->Cookie->write('CakeCookie.interfaceLanguage', $lang, false, "+1 month");
         }
         Configure::write('Config.language', $lang);
-        $locale = Locale::parseLocale($lang);
+        $locale = Locale::parseLocale(LanguagesLib::languageTag($lang));
         I18N::setLocale($locale['language']);
 
         // If the Router did not parse the URL, we don't know if the URL


### PR DESCRIPTION
Second attempt after #2150. The `languageTag` function is currently mainly used to mark the language of sentences in the HTML to select appropriate fonts (well, I think that's what it's for). So it should be suitable for selecting the i18n locale as well. At the very least making this change displays dates in Chinese as well as selecting the `zh` translations when the UI language is set to `cmn`. The only other language where this changes the strings on the homepage is Malaysian (`zsm`), which is also currently broken, because its translations are stored as `ms`.

We'd run into trouble if we ever wanted to have `zh_TW` or `zh_HK` locales, but for those we'd have to rethink the current system of indicating the language by its ISO 639 three-letter code in the URL anyway.