### PR TITLE
Add sentences to lists in new sentence design

### DIFF
--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -51,3 +51,6 @@ files[] = sentences.change_language.js
 files[] = sentences.link.js
 files[] = links.add_and_delete.js
 files[] = reviews.add_remove.js
+
+[sentence-component.js]
+files[] = directives/sentence-and-translations.dir.js

--- a/src/Controller/SentencesListsController.php
+++ b/src/Controller/SentencesListsController.php
@@ -488,4 +488,15 @@ class SentencesListsController extends AppController
         $this->set("translationsLang", $translationsLang);
         $this->set("sentencesWithTranslation", $results);
     }
+
+    public function choices() {
+        $lists = $this->SentencesLists->getUserChoices(
+            CurrentUser::get('id'), 1, true
+        );
+
+        $this->set('lists', $lists);
+        $this->loadComponent('RequestHandler');
+        $this->set('_serialize', ['lists']);
+        $this->RequestHandler->renderAs($this, 'json');
+    }
 }

--- a/src/Controller/SentencesListsController.php
+++ b/src/Controller/SentencesListsController.php
@@ -68,7 +68,8 @@ class SentencesListsController extends AppController
         $noCsrfActions = [
             'set_option',
             'save_name',
-            'add_new_sentence_to_list'
+            'add_new_sentence_to_list',
+            'add_sentence_to_new_list'
         ];
         if (in_array($params['action'], $noCsrfActions)) {
             $this->components()->unload('Csrf');
@@ -86,7 +87,8 @@ class SentencesListsController extends AppController
         $this->Security->config('unlockedActions', [
             'set_option',
             'save_name',
-            'add_new_sentence_to_list'
+            'add_new_sentence_to_list',
+            'add_sentence_to_new_list'
         ]);
 
         return parent::beforeFilter($event);
@@ -363,6 +365,28 @@ class SentencesListsController extends AppController
         }
 
         $this->set('sentence', $result);
+    }
+
+    public function add_sentence_to_new_list() {
+        $userId = $this->Auth->user('id');
+        $sentenceId = $this->request->getData('sentenceId');
+        $list = $this->SentencesLists->createList(
+            $this->request->getData('name'), 
+            $this->Auth->user('id')
+        );
+
+        if ($this->SentencesLists->addSentenceToList($sentenceId, $list->id, $userId)) {
+            $list->hasSentence = true;
+            $this->set('result', $list);
+            $this->Cookie->write('most_recent_list', $list->id, false, '+1 month');
+        } else {
+            $this->set('result', 'error');
+        }
+        
+        $this->loadComponent('RequestHandler');
+        $this->set('result', $list);
+        $this->set('_serialize', ['result']);
+        $this->RequestHandler->renderAs($this, 'json');
     }
 
     /**

--- a/src/Controller/SentencesListsController.php
+++ b/src/Controller/SentencesListsController.php
@@ -384,7 +384,6 @@ class SentencesListsController extends AppController
         }
         
         $this->loadComponent('RequestHandler');
-        $this->set('result', $list);
         $this->set('_serialize', ['result']);
         $this->RequestHandler->renderAs($this, 'json');
     }

--- a/src/Controller/SentencesListsController.php
+++ b/src/Controller/SentencesListsController.php
@@ -369,20 +369,20 @@ class SentencesListsController extends AppController
 
     public function add_sentence_to_new_list() {
         $userId = $this->Auth->user('id');
+        $listName = $this->request->getData('name');
         $sentenceId = $this->request->getData('sentenceId');
-        $list = $this->SentencesLists->createList(
-            $this->request->getData('name'), 
-            $this->Auth->user('id')
-        );
+        $list = $this->SentencesLists->createList($listName, $userId);
 
-        if ($this->SentencesLists->addSentenceToList($sentenceId, $list->id, $userId)) {
-            $list->hasSentence = true;
-            $this->set('result', $list);
-            $this->Cookie->write('most_recent_list', $list->id, false, '+1 month');
-        } else {
-            $this->set('result', 'error');
+        $result = 'error';
+        if ($list) {
+            if ($this->SentencesLists->addSentenceToList($sentenceId, $list->id, $userId)) {
+                $list->hasSentence = true;
+                $result = $list;
+                $this->Cookie->write('most_recent_list', $list->id, false, '+1 month');
+            }
         }
-        
+
+        $this->set('result', $result);
         $this->loadComponent('RequestHandler');
         $this->set('_serialize', ['result']);
         $this->RequestHandler->renderAs($this, 'json');

--- a/src/Model/Table/SentencesListsTable.php
+++ b/src/Model/Table/SentencesListsTable.php
@@ -152,9 +152,6 @@ class SentencesListsTable extends Table
                     'editable_by' => 'no_one'
                 ]
             ])
-            ->notMatching('SentencesSentencesLists', function ($q) use ($sentenceId) {
-                return $q->where(['SentencesSentencesLists.sentence_id' => $sentenceId]);
-            })
             ->select([
                 'id',
                 'name',
@@ -168,6 +165,9 @@ class SentencesListsTable extends Table
             return $results->toList();
         } else {
             $results->order(['name']);
+            $results->notMatching('SentencesSentencesLists', function ($q) use ($sentenceId) {
+                return $q->where(['SentencesSentencesLists.sentence_id' => $sentenceId]);
+            });
             $listsOfUser = array();
             $collaborativeLists = array();
     

--- a/src/Model/Table/SentencesListsTable.php
+++ b/src/Model/Table/SentencesListsTable.php
@@ -140,7 +140,7 @@ class SentencesListsTable extends Table
      *
      * @return array
      */
-    public function getUserChoices($userId, $sentenceId)
+    public function getUserChoices($userId, $sentenceId, $forNewDesign = false)
     {
         $results = $this->find()
             ->where([
@@ -158,30 +158,34 @@ class SentencesListsTable extends Table
             ->select(['id', 'name', 'user_id'])
             ->order(['name']);
 
-        $listsOfUser = array();
-        $collaborativeLists = array();
-
-        $currentUserId = CurrentUser::get('id');
-        foreach ($results as $result) {
-            $listId = $result['id'];
-            $listName = $result['name'];
-            $userId = $result['user_id'];
-
-            if (empty($listName)) {
-                $listName = __('unnamed list');
+        if ($forNewDesign) {
+            return $results->toList();
+        } else {
+            $listsOfUser = array();
+            $collaborativeLists = array();
+    
+            $currentUserId = CurrentUser::get('id');
+            foreach ($results as $result) {
+                $listId = $result['id'];
+                $listName = $result['name'];
+                $userId = $result['user_id'];
+    
+                if (empty($listName)) {
+                    $listName = __('unnamed list');
+                }
+    
+                if ($currentUserId == $userId) {
+                    $listsOfUser[$listId] = $listName;
+                } else {
+                    $collaborativeLists[$listId] = $listName;
+                }
             }
+    
+            $lists['OfUser'] = $listsOfUser;
+            $lists['Collaborative'] = $collaborativeLists;
 
-            if ($currentUserId == $userId) {
-                $listsOfUser[$listId] = $listName;
-            } else {
-                $collaborativeLists[$listId] = $listName;
-            }
+            return $lists;
         }
-
-        $lists['OfUser'] = $listsOfUser;
-        $lists['Collaborative'] = $collaborativeLists;
-
-        return $lists;
     }
 
 

--- a/src/Model/Table/SentencesListsTable.php
+++ b/src/Model/Table/SentencesListsTable.php
@@ -155,8 +155,14 @@ class SentencesListsTable extends Table
             ->notMatching('SentencesSentencesLists', function ($q) use ($sentenceId) {
                 return $q->where(['SentencesSentencesLists.sentence_id' => $sentenceId]);
             })
-            ->select(['id', 'name', 'user_id'])
-            ->order(['name']);
+            ->select([
+                'id',
+                'name',
+                'user_id',
+                'is_mine' => 'IF(SentencesLists.user_id = '.$userId.', TRUE, FALSE)',
+                'is_collaborative' => 'IF(SentencesLists.editable_by = "anyone", TRUE, FALSE)',
+            ])
+            ->order(['is_mine DESC', 'name']);
 
         if ($forNewDesign) {
             return $results->toList();

--- a/src/Model/Table/SentencesListsTable.php
+++ b/src/Model/Table/SentencesListsTable.php
@@ -161,12 +161,13 @@ class SentencesListsTable extends Table
                 'user_id',
                 'is_mine' => 'IF(SentencesLists.user_id = '.$userId.', TRUE, FALSE)',
                 'is_collaborative' => 'IF(SentencesLists.editable_by = "anyone", TRUE, FALSE)',
-            ])
-            ->order(['is_mine DESC', 'name']);
+            ]);
 
         if ($forNewDesign) {
+            $results->order(['is_mine DESC', 'modified DESC']);
             return $results->toList();
         } else {
+            $results->order(['name']);
             $listsOfUser = array();
             $collaborativeLists = array();
     

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -1,8 +1,3 @@
-<?php
-use App\Model\CurrentUser;
-use Cake\ORM\TableRegistry;
-?>
-
 <form layout="column" class="list-form" ng-if="vm.visibility.list_form">
     <div layout="row" layout-margin>
         <md-input-container flex>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -37,7 +37,7 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
             </md-icon>
         </md-list-item>
         <md-list-item ng-if="vm.lists.length === 0 && vm.listType === 'search'"><em><?= __('No list found.') ?></em></md-list-item>
-        <md-list-item ng-if="vm.lists.length === 0 && vm.listType === 'of_user'"><em><?= __('You have no lists yet.') ?></em></md-list-item>
+        <md-list-item ng-if="vm.lists.length === 0 && vm.listType === 'of_user'"><em><?= __('You have no lists which this sentence can be added to.') ?></em></md-list-item>
     </md-list>
     <md-button ng-click="vm.hide('list_form')"><?= __('Close') ?></md-button>
 </form>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -3,7 +3,7 @@ use App\Model\CurrentUser;
 use Cake\ORM\TableRegistry;
 ?>
 
-<form layout="column" style="border-top: 1px solid #f1f1f1; padding-top: 10px;" ng-if="vm.visibility.list_form">
+<form layout="column" class="list-form" ng-if="vm.visibility.list_form">
     <div layout="row" layout-margin>
         <md-input-container flex>
             <label><?= __('Search list or enter new list name') ?></label>
@@ -13,7 +13,7 @@ use Cake\ORM\TableRegistry;
         <md-button class="md-raised md-primary" ng-click="vm.addToNewList()" ng-disabled="!vm.listSearch"><?= __('Create') ?></md-button>
     </div>
 
-    <md-list style="height: 310px; overflow-y: scroll; border-top: 1px solid #f1f1f1">
+    <md-list>
         <md-subheader ng-if="vm.listType === 'of_user'"><?= __('Your last selected list (if any) and last updated lists') ?></md-subheader>
         <md-subheader ng-if="vm.listType === 'search'"><?= __('Search results') ?></md-subheader>
         <md-list-item class="list" ng-repeat="list in vm.lists">
@@ -22,7 +22,7 @@ use Cake\ORM\TableRegistry;
                 ng-model="list.hasSentence"
                 class="md-primary"></md-checkbox> 
             <p flex>{{list.name}}</p>
-            <em ng-if="list.isLastSelected" style="color: grey; padding: 0 5px"><?= __('(last selected)') ?></em>
+            <em class="last-selected" ng-if="list.isLastSelected"><?= __('(last selected)') ?></em>
             <md-icon ng-if="list.is_collaborative === '1'">
                 group
                 <md-tooltip><?= __('Collaborative list') ?></md-tooltip>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -11,7 +11,7 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
 ?>
 
 <form layout="column" style="border-top: 1px solid #f1f1f1; padding-top: 10px;"
-      ng-init="vm.initLists(<?= $listsJSON ?>)" ng-if="vm.isListFormVisible">
+      ng-init="vm.initLists(<?= $listsJSON ?>)" ng-show="vm.isListFormVisible">
     <div layout="column" layout-margin>
         <md-input-container>
             <label><?= __('Search list or enter new list name') ?></label>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -15,7 +15,7 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
     <div layout="row" layout-margin>
         <md-input-container flex>
             <label><?= __('Search list or enter new list name') ?></label>
-            <input id="list-form-<?= $sentenceId ?>" ng-model="vm.listSearch" ng-enter="vm.addToNewList()">
+            <input id="list-form-<?= $sentenceId ?>" ng-model="vm.listSearch" ng-enter="vm.addToNewList()" ng-escape="vm.hide('list_form')">
         </md-input-container>
         <md-button class="md-raised md-primary" ng-click="vm.addToNewList()"><?= __('Create') ?></md-button>
     </div>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -15,25 +15,29 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
     <div layout="row" layout-margin>
         <md-input-container flex>
             <label><?= __('Search list or enter new list name') ?></label>
-            <input id="list-form-<?= $sentenceId ?>" ng-model="vm.listSearch" ng-enter="vm.addToNewList()" ng-escape="vm.hide('list_form')">
+            <input id="list-form-<?= $sentenceId ?>" ng-model="vm.listSearch"
+                   ng-change="vm.searchList()" ng-enter="vm.addToNewList()" ng-escape="vm.hide('list_form')">
         </md-input-container>
         <md-button class="md-raised md-primary" ng-click="vm.addToNewList()"><?= __('Create') ?></md-button>
     </div>
 
     <md-list style="height: 200px; overflow-y: scroll; border-top: 1px solid #f1f1f1">
-        <md-subheader><?= __('Select list') ?></md-subheader>
-        <md-list-item class="list" ng-repeat="list in vm.lists | filter: { name: vm.listSearch }">
+        <md-subheader ng-if="vm.listType === 'of_user'"><?= __('Your most recent lists') ?></md-subheader>
+        <md-subheader ng-if="vm.listType === 'search'"><?= __('Search results') ?></md-subheader>
+        <md-list-item class="list" ng-repeat="list in vm.lists">
             <md-checkbox
                 ng-change="vm.toggleList(list)"
                 ng-model="list.hasSentence"
                 class="md-primary"></md-checkbox> 
             <p flex ng-class="{'is-mine': list.is_mine === '1'}">{{list.name}}</p>
-            <em ng-if="list.isLastSelected" style="color: grey"><?= __('(last selected)') ?></em>
+            <em ng-if="list.isLastSelected" style="color: grey; padding: 0 5px"><?= __('(last selected)') ?></em>
             <md-icon ng-if="list.is_collaborative === '1'">
                 group
                 <md-tooltip><?= __('Collaborative list') ?></md-tooltip>
             </md-icon>
         </md-list-item>
+        <md-list-item ng-if="vm.lists.length === 0 && vm.listType === 'search'"><em><?= __('No list found.') ?></em></md-list-item>
+        <md-list-item ng-if="vm.lists.length === 0 && vm.listType === 'of_user'"><em><?= __('You have no lists yet.') ?></em></md-list-item>
     </md-list>
     <md-button ng-click="vm.hide('list_form')"><?= __('Close') ?></md-button>
 </form>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -11,7 +11,7 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
 ?>
 
 <form layout="column" style="border-top: 1px solid #f1f1f1; padding-top: 10px;"
-      ng-init="vm.initLists(<?= $listsJSON ?>)" ng-show="vm.visibility.list_form">
+      ng-init="vm.initLists(<?= $listsJSON ?>, <?= CurrentUser::get('id') ?>)" ng-show="vm.visibility.list_form">
     <div layout="row" layout-margin>
         <md-input-container flex>
             <label><?= __('Search list or enter new list name') ?></label>
@@ -22,13 +22,17 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
 
     <md-list style="height: 200px; overflow-y: scroll; border-top: 1px solid #f1f1f1">
         <md-subheader><?= __('Select list') ?></md-subheader>
-        <md-list-item ng-repeat="list in vm.lists | filter: { name: vm.listSearch }">
+        <md-list-item class="list" ng-repeat="list in vm.lists | filter: { name: vm.listSearch }">
             <md-checkbox
                 ng-change="vm.toggleList(list)"
                 ng-model="list.hasSentence"
                 class="md-primary"></md-checkbox> 
-            <p flex>{{list.name}}</p>
+            <p flex ng-class="{'is-mine': list.is_mine === '1'}">{{list.name}}</p>
             <em ng-if="list.isLastSelected" style="color: grey"><?= __('(last selected)') ?></em>
+            <md-icon ng-if="list.is_collaborative === '1'">
+                group
+                <md-tooltip><?= __('Collaborative list') ?></md-tooltip>
+            </md-icon>
         </md-list-item>
     </md-list>
     <md-button ng-click="vm.hide('list_form')"><?= __('Close') ?></md-button>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -16,7 +16,7 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
         <md-input-container flex>
             <label><?= __('Search list or enter new list name') ?></label>
             <input id="list-form-<?= $sentenceId ?>" ng-model="vm.listSearch"
-                   ng-change="vm.searchList()" ng-enter="vm.addToNewList()" ng-escape="vm.hide('list_form')">
+                   ng-change="vm.searchList()" ng-enter="vm.addToNewList()" ng-escape="vm.closeList()">
         </md-input-container>
         <md-button class="md-raised md-primary" ng-click="vm.addToNewList()"><?= __('Create') ?></md-button>
     </div>
@@ -39,5 +39,5 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
         <md-list-item ng-if="vm.lists.length === 0 && vm.listType === 'search'"><em><?= __('No list found.') ?></em></md-list-item>
         <md-list-item ng-if="vm.lists.length === 0 && vm.listType === 'of_user'"><em><?= __('You have no lists which this sentence can be added to.') ?></em></md-list-item>
     </md-list>
-    <md-button ng-click="vm.hide('list_form')"><?= __('Close') ?></md-button>
+    <md-button ng-click="vm.closeList()"><?= __('Close') ?></md-button>
 </form>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -22,8 +22,9 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
 
     <md-list style="height: 200px; overflow-y: scroll; border-top: 1px solid #f1f1f1">
         <md-subheader><?= __('Select list') ?></md-subheader>
-        <md-list-item ng-repeat="list in vm.lists | filter: { name: vm.listSearch }" ng-click="vm.toggleList(list)">
+        <md-list-item ng-repeat="list in vm.lists | filter: { name: vm.listSearch }">
             <md-checkbox
+                ng-change="vm.toggleList(list)"
                 ng-model="list.hasSentence"
                 class="md-primary"></md-checkbox> 
             <p flex>{{list.name}}</p>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -26,7 +26,8 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
             <md-checkbox
                 ng-model="list.hasSentence"
                 class="md-primary"></md-checkbox> 
-            <p>{{list.name}}</p>
+            <p flex>{{list.name}}</p>
+            <em ng-if="list.isLastSelected" style="color: grey"><?= __('(last selected)') ?></em>
         </md-list-item>
     </md-list>
     <md-button ng-click="vm.isListFormVisible = false"><?= __('Close') ?></md-button>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -21,7 +21,7 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
         <md-button class="md-raised md-primary" ng-click="vm.addToNewList()"><?= __('Create') ?></md-button>
     </div>
 
-    <md-list style="height: 200px; overflow-y: scroll; border-top: 1px solid #f1f1f1">
+    <md-list style="height: 310px; overflow-y: scroll; border-top: 1px solid #f1f1f1">
         <md-subheader ng-if="vm.listType === 'of_user'"><?= __('Your most recent lists') ?></md-subheader>
         <md-subheader ng-if="vm.listType === 'search'"><?= __('Search results') ?></md-subheader>
         <md-list-item class="list" ng-repeat="list in vm.lists">

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -11,7 +11,7 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
 ?>
 
 <form layout="column" style="border-top: 1px solid #f1f1f1; padding-top: 10px;"
-      ng-init="vm.initLists(<?= $listsJSON ?>)" ng-show="vm.isListFormVisible">
+      ng-init="vm.initLists(<?= $listsJSON ?>)" ng-show="vm.visibility.list_form">
     <div layout="row" layout-margin>
         <md-input-container flex>
             <label><?= __('Search list or enter new list name') ?></label>
@@ -30,5 +30,5 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
             <em ng-if="list.isLastSelected" style="color: grey"><?= __('(last selected)') ?></em>
         </md-list-item>
     </md-list>
-    <md-button ng-click="vm.isListFormVisible = false"><?= __('Close') ?></md-button>
+    <md-button ng-click="vm.hide('list_form')"><?= __('Close') ?></md-button>
 </form>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -1,0 +1,35 @@
+<?php
+use App\Model\CurrentUser;
+use Cake\ORM\TableRegistry;
+
+$SentencesLists = TableRegistry::getTableLocator()->get('SentencesLists');
+$lists = $SentencesLists->getUserChoices(
+    CurrentUser::get('id'), $sentenceId, true
+);
+$mostRecentList = $this->request->getSession()->read('most_recent_list');
+$listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
+?>
+
+<form layout="column" style="border-top: 1px solid #f1f1f1; padding-top: 10px;"
+      ng-init="vm.initLists(<?= $listsJSON ?>)" ng-if="vm.isListFormVisible">
+    <div layout="column" layout-margin>
+        <md-input-container>
+            <label><?= __('Search list or enter new list name') ?></label>
+            <input id="list-form-<?= $sentenceId ?>" ng-model="vm.listSearch">
+        </md-input-container>
+        <div layout="row" layout-align="end">
+            <md-button class="md-raised" ng-click="vm.isListFormVisible = false"><?= __('Close') ?></md-button>
+            <md-button class="md-raised md-primary"><?= __('Add to new list') ?></md-button>
+        </div>
+    </div>
+
+    <md-list style="height: 200px; overflow-y: scroll; border-top: 1px solid #f1f1f1">
+        <md-subheader><?= __('Add to existing list') ?></md-subheader>
+        <md-list-item ng-repeat="list in vm.lists | filter: { name: vm.listSearch }" ng-click="vm.toggleList(list)">
+            <md-checkbox
+                ng-model="list.hasSentence"
+                class="md-primary"></md-checkbox> 
+            <p>{{list.name}}</p>
+        </md-list-item>
+    </md-list>
+</form>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -15,9 +15,9 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
     <div layout="row" layout-margin>
         <md-input-container flex>
             <label><?= __('Search list or enter new list name') ?></label>
-            <input id="list-form-<?= $sentenceId ?>" ng-model="vm.listSearch">
+            <input id="list-form-<?= $sentenceId ?>" ng-model="vm.listSearch" ng-enter="vm.addToNewList()">
         </md-input-container>
-        <md-button class="md-raised md-primary"><?= __('Create') ?></md-button>
+        <md-button class="md-raised md-primary" ng-click="vm.addToNewList()"><?= __('Create') ?></md-button>
     </div>
 
     <md-list style="height: 200px; overflow-y: scroll; border-top: 1px solid #f1f1f1">

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -1,17 +1,9 @@
 <?php
 use App\Model\CurrentUser;
 use Cake\ORM\TableRegistry;
-
-$SentencesLists = TableRegistry::getTableLocator()->get('SentencesLists');
-$lists = $SentencesLists->getUserChoices(
-    CurrentUser::get('id'), $sentenceId, true
-);
-$mostRecentList = $this->request->getSession()->read('most_recent_list');
-$listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
 ?>
 
-<form layout="column" style="border-top: 1px solid #f1f1f1; padding-top: 10px;"
-      ng-init="vm.initLists(<?= $listsJSON ?>, <?= CurrentUser::get('id') ?>)" ng-show="vm.visibility.list_form">
+<form layout="column" style="border-top: 1px solid #f1f1f1; padding-top: 10px;" ng-if="vm.visibility.list_form">
     <div layout="row" layout-margin>
         <md-input-container flex>
             <label><?= __('Search list or enter new list name') ?></label>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -12,19 +12,16 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
 
 <form layout="column" style="border-top: 1px solid #f1f1f1; padding-top: 10px;"
       ng-init="vm.initLists(<?= $listsJSON ?>)" ng-show="vm.isListFormVisible">
-    <div layout="column" layout-margin>
-        <md-input-container>
+    <div layout="row" layout-margin>
+        <md-input-container flex>
             <label><?= __('Search list or enter new list name') ?></label>
             <input id="list-form-<?= $sentenceId ?>" ng-model="vm.listSearch">
         </md-input-container>
-        <div layout="row" layout-align="end">
-            <md-button class="md-raised" ng-click="vm.isListFormVisible = false"><?= __('Close') ?></md-button>
-            <md-button class="md-raised md-primary"><?= __('Add to new list') ?></md-button>
-        </div>
+        <md-button class="md-raised md-primary"><?= __('Create') ?></md-button>
     </div>
 
     <md-list style="height: 200px; overflow-y: scroll; border-top: 1px solid #f1f1f1">
-        <md-subheader><?= __('Add to existing list') ?></md-subheader>
+        <md-subheader><?= __('Select list') ?></md-subheader>
         <md-list-item ng-repeat="list in vm.lists | filter: { name: vm.listSearch }" ng-click="vm.toggleList(list)">
             <md-checkbox
                 ng-model="list.hasSentence"
@@ -32,4 +29,5 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
             <p>{{list.name}}</p>
         </md-list-item>
     </md-list>
+    <md-button ng-click="vm.isListFormVisible = false"><?= __('Close') ?></md-button>
 </form>

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -22,7 +22,7 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
     </div>
 
     <md-list style="height: 310px; overflow-y: scroll; border-top: 1px solid #f1f1f1">
-        <md-subheader ng-if="vm.listType === 'of_user'"><?= __('Your most recent lists') ?></md-subheader>
+        <md-subheader ng-if="vm.listType === 'of_user'"><?= __('Your last selected list (if any) and last updated lists') ?></md-subheader>
         <md-subheader ng-if="vm.listType === 'search'"><?= __('Search results') ?></md-subheader>
         <md-list-item class="list" ng-repeat="list in vm.lists">
             <md-checkbox

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -10,7 +10,7 @@ use Cake\ORM\TableRegistry;
             <input id="list-form-<?= $sentenceId ?>" ng-model="vm.listSearch"
                    ng-change="vm.searchList()" ng-enter="vm.addToNewList()" ng-escape="vm.closeList()">
         </md-input-container>
-        <md-button class="md-raised md-primary" ng-click="vm.addToNewList()"><?= __('Create') ?></md-button>
+        <md-button class="md-raised md-primary" ng-click="vm.addToNewList()" ng-disabled="!vm.listSearch"><?= __('Create') ?></md-button>
     </div>
 
     <md-list style="height: 310px; overflow-y: scroll; border-top: 1px solid #f1f1f1">

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -29,7 +29,7 @@ $listsJSON = htmlspecialchars(json_encode($lists), ENT_QUOTES, 'UTF-8');
                 ng-change="vm.toggleList(list)"
                 ng-model="list.hasSentence"
                 class="md-primary"></md-checkbox> 
-            <p flex ng-class="{'is-mine': list.is_mine === '1'}">{{list.name}}</p>
+            <p flex>{{list.name}}</p>
             <em ng-if="list.isLastSelected" style="color: grey; padding: 0 5px"><?= __('(last selected)') ?></em>
             <md-icon ng-if="list.is_collaborative === '1'">
                 group

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -124,6 +124,10 @@ $sentenceUrl = $this->Url->build([
             'sentenceId' => $sentence->id,
             'langs' => $langs
         ]);
+
+        echo $this->element('sentences/list_form', [
+            'sentenceId' => $sentence->id
+        ]);
     }
 
     if ($sentenceMenu['canEdit']) {

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -2,7 +2,7 @@
 use App\Lib\LanguagesLib;
 use App\Model\CurrentUser;
 
-$this->Html->script('/js/directives/sentence-and-translations.dir.js', array('block' => 'scriptBottom'));
+$this->AssetCompress->script('sentence-component.js', ['block' => 'scriptBottom']);
 if (CurrentUser::isMember()) {
     $this->Html->script('/js/services/list-data.srv.js', array('block' => 'scriptBottom'));
 }

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -3,6 +3,9 @@ use App\Lib\LanguagesLib;
 use App\Model\CurrentUser;
 
 $this->Html->script('/js/directives/sentence-and-translations.dir.js', array('block' => 'scriptBottom'));
+if (CurrentUser::isMember()) {
+    $this->Html->script('/js/services/list-data.srv.js', array('block' => 'scriptBottom'));
+}
 
 if (!isset($menuExpanded)) {
     $menuExpanded = false;

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -117,7 +117,6 @@ $sentenceUrl = $this->Url->build([
         </div>
     </div>
 
-    <md-progress-linear ng-if="vm.inProgress"></md-progress-linear>
     <?php
     if (CurrentUser::isMember()) {
         echo $this->element('sentences/translation_form', [
@@ -136,6 +135,8 @@ $sentenceUrl = $this->Url->build([
         ]);
     }
     ?>
+
+    <md-progress-linear ng-if="vm.inProgress"></md-progress-linear>
 
     <div layout="column" class="direct translations" ng-if="vm.visibility.translations && vm.directTranslations.length > 0">
         <md-divider></md-divider>

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -85,7 +85,7 @@ $sentenceUrl = $this->Url->build([
         </div>
 
         <div class="sentence <?= $notReliable ? 'not-reliable' : '' ?>"
-             layout="row" layout-align="start center" ng-if="!vm.isSentenceFormVisible">
+             layout="row" layout-align="start center" ng-if="!vm.visibility.sentence_form">
             <div class="lang">
                 <language-icon lang="vm.sentence.lang" title="vm.sentence.langName"></language-icon>
             </div>
@@ -137,7 +137,7 @@ $sentenceUrl = $this->Url->build([
     }
     ?>
 
-    <div layout="column" class="direct translations" ng-if="!vm.isTranslationFormVisible && vm.directTranslations.length > 0">
+    <div layout="column" class="direct translations" ng-if="vm.visibility.translations && vm.directTranslations.length > 0">
         <md-divider></md-divider>
         <md-subheader><?= __('Translations') ?></md-subheader>
 
@@ -148,7 +148,7 @@ $sentenceUrl = $this->Url->build([
         ?>
     </div>
 
-    <div layout="column" <?= $showExtra ?> class="indirect translations" ng-if="!vm.isTranslationFormVisible && vm.indirectTranslations.length > 0"
+    <div layout="column" <?= $showExtra ?> class="indirect translations" ng-if="vm.visibility.translations && vm.indirectTranslations.length > 0"
             ng-init="vm.initIndirectTranslations(<?= $this->Sentences->translationsForAngular($indirectTranslations) ?>)">
         <md-subheader><?= __('Translations of translations') ?></md-subheader>
 
@@ -161,7 +161,7 @@ $sentenceUrl = $this->Url->build([
 
 
     <?php if ($numExtra > 1) { ?>
-        <div layout="column" ng-if="!vm.isTranslationFormVisible">
+        <div layout="column" ng-if="vm.visibility.translations">
             <md-button ng-click="vm.expandOrCollapse()">
                 <md-icon>{{vm.expandableIcon}}</md-icon>
                 <span ng-if="!vm.isExpanded">

--- a/src/Template/Element/sentences/sentence_form.ctp
+++ b/src/Template/Element/sentences/sentence_form.ctp
@@ -1,13 +1,13 @@
 <?php 
 $hasAudio = count($sentence->audios) > 0;
 ?>
-<form layout="column" layout-margin style="padding-top: 10px" ng-if="vm.isSentenceFormVisible">
+<form layout="column" layout-margin style="padding-top: 10px" ng-if="vm.visibility.sentence_form">
 <?php if ($hasAudio) { ?>
 
     <p><?= __('You cannot edit this sentence because it has audio.'); ?>
 
     <div layout="row" layout-align="end center">
-        <md-button class="md-raised" ng-click="vm.isSentenceFormVisible = false">
+        <md-button class="md-raised" ng-click="vm.cancelEdit()">
             <?= __('Close') ?>
         </md-button>
     </div>

--- a/src/Template/Element/sentences/sentence_menu.ctp
+++ b/src/Template/Element/sentences/sentence_menu.ctp
@@ -20,8 +20,9 @@ $isUnapproved = $sentence->correctness == -1;
             </md-button>
             <?php } ?>
 
-            <md-button class="md-icon-button" ng-disabled="true">
+            <md-button class="md-icon-button" ng-click="vm.list()">
                 <md-icon>list</md-icon>
+                <md-tooltip><?= __('Add sentence to list') ?></md-tooltip>
             </md-button>
 
             <md-button class="md-icon-button" ng-if="vm.isMenuExpanded" ng-click="vm.favorite()">

--- a/src/Template/Element/sentences/translation_form.ctp
+++ b/src/Template/Element/sentences/translation_form.ctp
@@ -1,4 +1,4 @@
-<div ng-if="vm.isTranslationFormVisible" style="background: #fafafa; border-top: 1px solid #f1f1f1">
+<div ng-if="vm.visibility.translation_form" style="background: #fafafa; border-top: 1px solid #f1f1f1">
 
 <?php if (!empty($langs)) { ?>
     <form layout="column" layout-margin style="padding-top: 10px">
@@ -26,7 +26,7 @@
         </div>
 
         <div layout="row" layout-align="end center">
-            <md-button class="md-raised" ng-click="vm.isTranslationFormVisible = false">
+            <md-button class="md-raised" ng-click="vm.hide('translation_form')">
                 <?= __('Cancel') ?>
             </md-button>
             <md-button class="md-raised md-primary" ng-click="vm.saveTranslation(<?= $sentenceId ?>)">

--- a/src/Template/SentencesLists/show.ctp
+++ b/src/Template/SentencesLists/show.ctp
@@ -162,27 +162,12 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
          data-list-id="<?php echo $listId; ?>">
     <?php
     $this->Pagination->display();
-    if (!CurrentUser::isMember() || CurrentUser::getSetting('use_new_design')) {
-        foreach ($sentencesInList as $item) {
-            $sentence = $item->sentence;
-            $translations = $sentence->translations;
-            echo $this->element(
-                'sentences/sentence_and_translations',
-                array(
-                    'sentence' => $sentence,
-                    'translations' => $translations,
-                    'user' => $sentence->user
-                )
-            );
-        }
-    } else {
-        $this->Sentences->javascriptForAJAXSentencesGroup();
-        foreach ($sentencesInList as $item) {
-            $sentence = $item->sentence;
-            $this->Lists->displaySentence(
-                $sentence, $permissions['canRemoveSentences']
-            );
-        }
+    $this->Sentences->javascriptForAJAXSentencesGroup();
+    foreach ($sentencesInList as $item) {
+        $sentence = $item->sentence;
+        $this->Lists->displaySentence(
+            $sentence, $permissions['canRemoveSentences']
+        );
     }
     ?>
     </div>

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -884,7 +884,8 @@ class SentencesHelper extends AppHelper
             'correctness' => $sentence->correctness,
             'isFavorite' => CurrentUser::hasFavorited($sentence->id),
             'isOwnedByCurrentUser' => $sentence->user && $sentence->user->username === CurrentUser::get('username'),
-            'user' => $sentence->user
+            'user' => $sentence->user,
+            'sentences_lists' => $sentence->sentences_lists
         ];
     }
 }

--- a/tests/TestCase/Model/Table/SentencesListsTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesListsTableTest.php
@@ -374,6 +374,7 @@ class SentencesListsTableTest extends TestCase {
         $result = Hash::combine($lists, '{n}.id', '{n}.is_collaborative', '{n}.is_mine');
         $expected = [
             1 => [
+                '1' => 0,
                 '2' => 0,
                 '3' => 0,
             ],

--- a/tests/TestCase/Model/Table/SentencesListsTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesListsTableTest.php
@@ -351,6 +351,39 @@ class SentencesListsTableTest extends TestCase {
         $this->assertEquals($expected, $result);
     }
 
+    function testGetUserChoices_withNewDesignAndSentenceNotInLists() {
+        CurrentUser::store(['id' => 7]);
+        $lists = $this->SentencesList->getUserChoices(7, 1, true);
+        $result = Hash::combine($lists, '{n}.id', '{n}.is_collaborative', '{n}.is_mine');
+        $expected = [
+            1 => [
+                '1' => 0, 
+                '2' => 0, 
+                '3' => 0,
+            ],
+            0 => [
+                '5' => 1
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    function testGetUserChoices_withNewDesignAndSentenceInOneList() {
+        CurrentUser::store(['id' => 7]);
+        $lists = $this->SentencesList->getUserChoices(7, 4, true);
+        $result = Hash::combine($lists, '{n}.id', '{n}.is_collaborative', '{n}.is_mine');
+        $expected = [
+            1 => [
+                '2' => 0,
+                '3' => 0,
+            ],
+            0 => [
+                '5' => 1
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
     function testGetSearchableLists_asGuests() {
         CurrentUser::store(['id' => null]);
         $lists = $this->SentencesList->getSearchableLists();

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1365,6 +1365,10 @@ div.hideLink {
     background: #f1f1f1;
 }
 
+.sentence-and-translations .list .is-mine {
+    font-weight: bold;
+}
+
 
 /*
  * --------------------------------------------------------------------

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1365,6 +1365,21 @@ div.hideLink {
     background: #f1f1f1;
 }
 
+.sentence-and-translations .list-form {
+    border-top: 1px solid #f1f1f1;
+    padding-top: 10px;
+}
+
+.sentence-and-translations .list-form md-list {
+    height: 310px;
+    overflow-y: scroll;
+    border-top: 1px solid #f1f1f1;
+}
+
+.sentence-and-translations .list-form .last-selected {
+    color: grey;
+    padding: 0 5px;
+}
 
 /*
  * --------------------------------------------------------------------

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1361,6 +1361,10 @@ div.hideLink {
     display: none;
 }
 
+.sentence-and-translations md-list-item.md-clickable:hover {
+    background: #f1f1f1;
+}
+
 
 /*
  * --------------------------------------------------------------------

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1365,10 +1365,6 @@ div.hideLink {
     background: #f1f1f1;
 }
 
-.sentence-and-translations .list .is-mine {
-    font-weight: bold;
-}
-
 
 /*
  * --------------------------------------------------------------------

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -134,6 +134,10 @@
         /////////////////////////////////////////////////////////////////////////
 
         $scope.$on('newListCreated', function(event, data, sentenceId) {
+            if (data === 'error') {
+                resetLists();
+                return;
+            }
             var list = angular.copy(data);
             $cookies.put('most_recent_list', list.id);
             list.hasSentence = vm.sentence.id === parseInt(sentenceId);

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -327,19 +327,23 @@
         }
 
         function toggleList(list) {
+            vm.inProgress = true;
             var action = list.hasSentence ? 'add_sentence_to_list' : 'remove_sentence_from_list';
 
             $http.get(rootUrl + '/sentences_lists/' + action + '/' + vm.sentence.id + '/' + list.id).then(function(result) {
+                vm.inProgress = false;
                 $cookies.put('most_recent_list', list.id);
             });
         }
 
         function addToNewList() {
+            vm.inProgress = true;
             var data = { 
                 name: vm.listSearch,
                 sentenceId: vm.sentence.id
             };
             $http.post(rootUrl + '/sentences_lists/add_sentence_to_new_list', data).then(function(result) {
+                vm.inProgress = false;
                 vm.listSearch = '';
                 $rootScope.$broadcast('newListCreated', result.data.result, vm.sentence.id);
             });

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -66,10 +66,6 @@
                       'ng-attr-title="{{title ? title : lang}}"' +
                       'ng-src="/img/flags/{{lang}}.svg" />'
             }
-        })
-        .factory('listsDataService', listsDataService)
-        .run(function(listsDataService) {
-            listsDataService.init();
         });
 
     function sentenceAndTranslations() {
@@ -80,7 +76,7 @@
         };
     }
 
-    function SentenceAndTranslationsController($rootScope, $scope, $http, $cookies, $timeout, listsDataService) {
+    function SentenceAndTranslationsController($rootScope, $scope, $http, $cookies, $timeout, $injector) {
         const MAX_TRANSLATIONS = 5;
         const rootUrl = get_tatoeba_root_url();
 
@@ -91,6 +87,7 @@
         var allLists = [];
         var lastSelectedList = null;
         var timeout;
+        var listsDataService;
 
         vm.inProgress = false;
         vm.isExpanded = false;
@@ -154,7 +151,12 @@
             showFewerTranslations();
         }
 
-        function initLists(selectableLists, selectedLists) {
+        function initLists(selectedLists) {
+            if (!listsDataService) {
+                listsDataService = $injector.get('listsDataService');
+            }
+            var selectableLists = listsDataService.getLists();
+
             if (selectableLists) {
                 if (selectedLists) {
                     allLists = selectableLists.map(function(selectableList) {
@@ -335,7 +337,7 @@
         }
 
         function list() {
-            initLists(listsDataService.getLists(), vm.sentence.sentences_lists);
+            initLists(vm.sentence.sentences_lists);
 
             if (vm.visibility['list_form']) {
                 closeList();
@@ -428,31 +430,6 @@
                 return item.is_mine === '1' || item.isLastSelected;
             }).slice(0, 10);
             vm.listType = 'of_user';
-        }
-    }
-    
-    function listsDataService($http) {
-        const rootUrl = get_tatoeba_root_url();
-        
-        var lists;
-
-        return {
-            init: init,
-            getLists: getLists
-        };
-
-        /////////////////////////////////////////////////////////////////////////
-
-        function init() {
-            if (!lists) {
-                $http.get(rootUrl + '/sentences_lists/choices').then(function(result) {
-                    lists = result.data.lists;
-                });
-            }
-        }
-
-        function getLists() {
-            return lists;
         }
     }
 

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -300,8 +300,11 @@
         }
 
         function toggleList(list) {
-            list.hasSentence = !list.hasSentence;
-            console.log(vm.sentence.id, list.id);
+            var action = list.hasSentence ? 'remove_sentence_from_list' : 'add_sentence_to_list';
+
+            $http.get(rootUrl + '/sentences_lists/' + action + '/' + vm.sentence.id + '/' + list.id).then(function(result) {
+                list.hasSentence = !list.hasSentence;
+            });
         }
     }
 

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -99,6 +99,7 @@
         vm.newTranslation = {};
         vm.lists = [];
         vm.listSearch = '';
+        vm.lastSelectedList = null;
 
         vm.init = init;
         vm.initLists = initLists;
@@ -299,7 +300,8 @@
             vm.isListFormVisible = !vm.isListFormVisible;
             if (vm.isListFormVisible) {
                 focusInput('#list-form-' + vm.sentence.id);
-            }            
+                moveRecentListToTop();
+            }
         }
 
         function toggleList(list) {
@@ -307,6 +309,7 @@
 
             $http.get(rootUrl + '/sentences_lists/' + action + '/' + vm.sentence.id + '/' + list.id).then(function(result) {
                 list.hasSentence = !list.hasSentence;
+                $cookies.put('most_recent_list', list.id);
             });
         }
 
@@ -319,6 +322,21 @@
                 vm.listSearch = '';
                 vm.lists.unshift(result.data.result);
             });
+        }
+
+        function moveRecentListToTop() {
+            var i = vm.lists.findIndex(function(item) {
+                return item.id === parseInt($cookies.get('most_recent_list'));
+            });
+            if (vm.lastSelectedList) {
+                vm.lastSelectedList.isLastSelected = false;
+            }
+            if (i > -1) {
+                vm.lastSelectedList = vm.lists[i];
+                vm.lastSelectedList.isLastSelected = true;
+                vm.lists.splice(i, 1);
+                vm.lists.unshift(vm.lastSelectedList);
+            }
         }
     }
 

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -90,14 +90,18 @@
         vm.isMenuExpanded = false;
         vm.isTranslationFormVisible = false;
         vm.isSentenceFormVisible = false;
+        vm.isListFormVisible = false;
         vm.expandableIcon = 'expand_more';
         vm.userLanguages = [];
         vm.sentence = null;
         vm.directTranslations = [];
         vm.indirectTranslations = [];
         vm.newTranslation = {};
+        vm.lists = [];
+        vm.listSearch = '';
 
         vm.init = init;
+        vm.initLists = initLists;
         vm.expandOrCollapse = expandOrCollapse;
         vm.toggleMenu = toggleMenu;
         vm.playAudio = playAudio;
@@ -110,6 +114,8 @@
         vm.editSentence = editSentence;
         vm.favorite = favorite;
         vm.adopt = adopt;
+        vm.list = list;
+        vm.toggleList = toggleList;
 
         /////////////////////////////////////////////////////////////////////////
 
@@ -119,6 +125,10 @@
             allDirectTranslations = directTranslations;
             allIndirectTranslations = indirectTranslations;
             showFewerTranslations();
+        }
+
+        function initLists(lists) {
+            vm.lists = lists;
         }
 
         function expandOrCollapse() {
@@ -282,6 +292,16 @@
                 vm.sentence.user = result.data.user;
                 vm.sentence.isOwnedByCurrentUser = vm.sentence.user && vm.sentence.user.username;
             });
+        }
+
+        function list() {
+            vm.isListFormVisible = true;
+            focusInput('#list-form-' + vm.sentence.id);
+        }
+
+        function toggleList(list) {
+            list.hasSentence = !list.hasSentence;
+            console.log(vm.sentence.id, list.id);
         }
     }
 

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -88,9 +88,6 @@
         vm.inProgress = false;
         vm.isExpanded = false;
         vm.isMenuExpanded = false;
-        vm.isTranslationFormVisible = false;
-        vm.isSentenceFormVisible = false;
-        vm.isListFormVisible = false;
         vm.expandableIcon = 'expand_more';
         vm.userLanguages = [];
         vm.sentence = null;
@@ -100,6 +97,12 @@
         vm.lists = [];
         vm.listSearch = '';
         vm.lastSelectedList = null;
+        vm.visibility = {
+            'translations': true,
+            'translate_form': false,
+            'sentence_form': false,
+            'list_form': false
+        };
 
         vm.init = init;
         vm.initLists = initLists;
@@ -118,6 +121,8 @@
         vm.list = list;
         vm.toggleList = toggleList;
         vm.addToNewList = addToNewList;
+        vm.show = show;
+        vm.hide = hide;
 
         /////////////////////////////////////////////////////////////////////////
 
@@ -195,8 +200,7 @@
         }
 
         function translate(id) {
-            vm.isTranslationFormVisible = true;
-            vm.isSentenceFormVisible = false;
+            show('translation_form');
             
             if (vm.newTranslation.editable) {
                 vm.newTranslation = {};
@@ -217,7 +221,7 @@
                 vm.inProgress = true;
                 if (vm.newTranslation.editable) {
                     saveSentence(vm.newTranslation).then(function(result) {
-                        vm.isTranslationFormVisible = false;
+                        show('translations');
                         vm.inProgress = false;
                         vm.newTranslation = {};
                     });
@@ -232,7 +236,7 @@
                         result.data.parentId = sentenceId;
                         allDirectTranslations.unshift(result.data);
                         vm.newTranslation = {};
-                        vm.isTranslationFormVisible = false;
+                        show('translations');
                         vm.inProgress = false;
                         showFewerTranslations();
                     });
@@ -241,7 +245,7 @@
         }
 
         function editTranslation(translation) {
-            vm.isTranslationFormVisible = true;
+            show('translation_form');
             vm.newTranslation = translation;
             focusInput('#translation-form-' + translation.parentId);
         }
@@ -254,13 +258,12 @@
         }
 
         function edit() {
-            vm.isSentenceFormVisible = true;
-            vm.isTranslationFormVisible = false;
+            show('sentence_form');
             focusInput('#sentence-form-' + vm.sentence.id);
         }
         
         function cancelEdit() {
-            vm.isSentenceFormVisible = false;
+            hide('sentence_form');
             initSentence(oldSentence);
         }
 
@@ -268,7 +271,7 @@
             vm.inProgress = true;
 
             saveSentence(vm.sentence).then(function(result) {
-                vm.isSentenceFormVisible = false;
+                hide('sentence_form');
                 vm.inProgress = false;
                 initSentence(result.data);
             });
@@ -307,8 +310,10 @@
         }
 
         function list() {
-            vm.isListFormVisible = !vm.isListFormVisible;
-            if (vm.isListFormVisible) {
+            if (vm.visibility['list_form']) {
+                hide('list_form');
+            } else {
+                show('list_form');
                 focusInput('#list-form-' + vm.sentence.id);
                 moveRecentListToTop();
             }
@@ -347,6 +352,18 @@
                 vm.lists.splice(i, 1);
                 vm.lists.unshift(vm.lastSelectedList);
             }
+        }
+
+        function show(name) {
+            for (var i in vm.visibility) {
+                vm.visibility[i] = false;
+            }
+            vm.visibility[name] = true;
+        }
+
+        function hide(name) {
+            vm.visibility[name] = false;
+            vm.visibility['translations'] = true;
         }
     }
 

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -116,6 +116,7 @@
         vm.adopt = adopt;
         vm.list = list;
         vm.toggleList = toggleList;
+        vm.addToNewList = addToNewList;
 
         /////////////////////////////////////////////////////////////////////////
 
@@ -306,6 +307,17 @@
 
             $http.get(rootUrl + '/sentences_lists/' + action + '/' + vm.sentence.id + '/' + list.id).then(function(result) {
                 list.hasSentence = !list.hasSentence;
+            });
+        }
+
+        function addToNewList() {
+            var data = { 
+                name: vm.listSearch,
+                sentenceId: vm.sentence.id
+            };
+            $http.post(rootUrl + '/sentences_lists/add_sentence_to_new_list', data).then(function(result) {
+                vm.listSearch = '';
+                vm.lists.unshift(result.data.result);
             });
         }
     }

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -295,8 +295,10 @@
         }
 
         function list() {
-            vm.isListFormVisible = true;
-            focusInput('#list-form-' + vm.sentence.id);
+            vm.isListFormVisible = !vm.isListFormVisible;
+            if (vm.isListFormVisible) {
+                focusInput('#list-form-' + vm.sentence.id);
+            }            
         }
 
         function toggleList(list) {

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -121,6 +121,7 @@
         vm.favorite = favorite;
         vm.adopt = adopt;
         vm.list = list;
+        vm.closeList = closeList;
         vm.toggleList = toggleList;
         vm.addToNewList = addToNewList;
         vm.searchList = searchList;
@@ -318,12 +319,17 @@
 
         function list() {
             if (vm.visibility['list_form']) {
-                hide('list_form');
+                closeList();
             } else {
                 show('list_form');
                 focusInput('#list-form-' + vm.sentence.id);
                 resetLists();
             }
+        }
+
+        function closeList() {
+            vm.hide('list_form');
+            vm.listSearch = '';
         }
 
         function toggleList(list) {

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -76,7 +76,7 @@
         };
     }
 
-    function SentenceAndTranslationsController($http, $cookies) {
+    function SentenceAndTranslationsController($rootScope, $scope, $http, $cookies) {
         const MAX_TRANSLATIONS = 5;
         const rootUrl = get_tatoeba_root_url();
 
@@ -118,6 +118,16 @@
         vm.list = list;
         vm.toggleList = toggleList;
         vm.addToNewList = addToNewList;
+
+        /////////////////////////////////////////////////////////////////////////
+
+        $scope.$on('newListCreated', function(event, data, sentenceId) {
+            var list = angular.copy(data);
+            $cookies.put('most_recent_list', list.id);
+            list.hasSentence = vm.sentence.id === parseInt(sentenceId);
+            vm.lists.unshift(list);
+            moveRecentListToTop();
+        });
 
         /////////////////////////////////////////////////////////////////////////
 
@@ -320,7 +330,7 @@
             };
             $http.post(rootUrl + '/sentences_lists/add_sentence_to_new_list', data).then(function(result) {
                 vm.listSearch = '';
-                vm.lists.unshift(result.data.result);
+                $rootScope.$broadcast('newListCreated', result.data.result, vm.sentence.id);
             });
         }
 

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -75,7 +75,8 @@
             controllerAs: 'vm'
         };
     }
-
+    
+    SentenceAndTranslationsController.$inject = ['$rootScope', '$scope', '$http', '$cookies', '$timeout', '$injector'];
     function SentenceAndTranslationsController($rootScope, $scope, $http, $cookies, $timeout, $injector) {
         const MAX_TRANSLATIONS = 5;
         const rootUrl = get_tatoeba_root_url();

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -320,10 +320,9 @@
         }
 
         function toggleList(list) {
-            var action = list.hasSentence ? 'remove_sentence_from_list' : 'add_sentence_to_list';
+            var action = list.hasSentence ? 'add_sentence_to_list' : 'remove_sentence_from_list';
 
             $http.get(rootUrl + '/sentences_lists/' + action + '/' + vm.sentence.id + '/' + list.id).then(function(result) {
-                list.hasSentence = !list.hasSentence;
                 $cookies.put('most_recent_list', list.id);
             });
         }

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -142,7 +142,6 @@
             list.is_mine = '1';
             allLists.unshift(list);
             resetLists();
-            moveRecentListToTop();
         });
 
         /////////////////////////////////////////////////////////////////////////
@@ -425,7 +424,6 @@
 
         function resetLists() {
             moveRecentListToTop();
-            console.log(allLists);
             vm.lists = allLists.filter(function(item) {
                 return item.is_mine === '1' || item.isLastSelected;
             }).slice(0, 10);

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -363,6 +363,10 @@
         }
 
         function addToNewList() {
+            if (!vm.listSearch) {
+                return;
+            }
+            
             vm.inProgress = true;
             var data = { 
                 name: vm.listSearch,

--- a/webroot/js/services/list-data.srv.js
+++ b/webroot/js/services/list-data.srv.js
@@ -1,0 +1,35 @@
+(function() {
+    'use strict';
+
+    angular
+        .module('app')
+        .factory('listsDataService', listsDataService)
+        .run(function(listsDataService) {
+            listsDataService.init();
+        })
+
+    function listsDataService($http) {
+        const rootUrl = get_tatoeba_root_url();
+        
+        var lists;
+
+        return {
+            init: init,
+            getLists: getLists
+        };
+
+        /////////////////////////////////////////////////////////////////////////
+
+        function init() {
+            if (!lists) {
+                $http.get(rootUrl + '/sentences_lists/choices').then(function(result) {
+                    lists = result.data.lists;
+                });
+            }
+        }
+
+        function getLists() {
+            return lists;
+        }
+    }
+})();


### PR DESCRIPTION
This PR implements the list feature in the new sentence design. This is probably the toughest feature to migrate from all the sentence features and it won't be 100% perfect in this first iteration but I hope it brings enough improvement to make people want to switch to the new design.

Related Wall thread: https://tatoeba.org/eng/wall/show_message/34213#message_34213

## Current implementation

**List form**

* The list form contains a text input that fulfills two functionalities:
	* Searching a list. After entering at least one character, all the selectable lists that have this character in their name will be displayed.
    * Creating a new list. The sentence from which the new list is created is automatically added to that list. This addresses #161 and perhaps #1394 as well.
* The list of lists is no longer displayed in a dropdown but in a what looks like a multi-selection box.
	* Each row has a checkbox, the name of the list and a `group` icon if it's a collaborative list.
* The initial list of lists contains the current user's 10 most recently updated lists (only lists to which the sentence can be added).
* On top of that, the first list will be the last selected list (regardless if it belongs to the current user or not). It will have an indicator `(last selected)`.
	* The last selected list is saved in a cookie so it will not appear if the user clears their cookies.
* If the user has no list to select from, the message `You have no lists which this sentence can be added to.` is displayed.
* The list form can be closed by:
	* Clicking again on the list button.
	* Clicking on the "Close" button at the bottom.
	* Pressing escape while the search input is on focus.
* Closing the list form will reset the search.

**Adding/removing a sentence to a new list**

* The sentence is added to the list upon checking the checkbox.
	* The progress bar is displayed while the sentence is being added to the list, even though the response time is very short. Users otherwise don't intuitively understand that checking the checkbox triggers the sentence to be saved in the list right away.
	* The progress bar is also displayed while a new list is being created and the sentence being added.
* The sentence can be removed from a list by unchecking the checkbox.
	* This only applies to lists that have been added without reloading the page. This allows the user to easily revert their action if they added a sentence to a list by mistake.
	* Refreshing the page will lose this possibility because the multi-selection box is initialized with only the lists in which the sentence can be added.

## Improvements for another iteration

1) Instead of displaying only the lists to which the sentence can be added, it will be more intuitive to display the all the available lists.
	* If the sentence already belongs to the list, then the checkbox is checked.
	* Otherwise it is left unchecked.
2) The initial list of lists could display the 10 last selected lists from the user instead of the user's last updated lists.
3) There can be duplicate list names so we would need to find a way to distinguish these lists from one another. We could show the username of the owner, plus the list ID in case the user has two lists with the same name.
4) The user might want to browse the list to see what kind of sentences are already in the list. There should be a button or something to open the list in a new tab.
