### PR TITLE
 Add pinyin tone marks to uppercase characters as well (fixes #2153) 

### DIFF
--- a/src/View/Helper/PinyinHelper.php
+++ b/src/View/Helper/PinyinHelper.php
@@ -192,6 +192,30 @@ class PinyinHelper extends AppHelper
     );
 
     /**
+     * Uppercase the first character in a UTF-8 string.
+     */
+    private function utf8_ucfirst($string) {
+        // Based on https://stackoverflow.com/a/2518021
+        // Licensed under CC BY-SA 4.0
+        $strlen = mb_strlen($string, 'UTF-8');
+        $firstChar = mb_substr($string, 0, 1, 'UTF-8');
+        $then = mb_substr($string, 1, $strlen - 1, 'UTF-8');
+        return mb_strtoupper($firstChar, 'UTF-8') . $then;
+    }
+
+    /**
+     * Wrapper for str_replace that optionally uppercases the first character
+     * of the search string, and also uppercases the first character of the
+     * replacement string in that case.
+     */
+    private function cased_str_replace($search, $replace, $subject) {
+        $utf8_ucfirst = function($string) { return $this->utf8_ucfirst($string); };
+        $search = array_merge($search, array_map($utf8_ucfirst, $search));
+        $replace = array_merge($replace, array_map($utf8_ucfirst, $replace));
+        return str_replace($search, $replace, $subject);
+    }
+
+    /**
      * Replace numeric pinyin by diacritical marks
      * Convert to php from a python script of Brian Vaughan
      * (http://brianvaughan.net)
@@ -203,26 +227,26 @@ class PinyinHelper extends AppHelper
 
     public function numeric2diacritic($text)
     {
-        $text = str_replace(
+        $text = $this->cased_str_replace(
             $this->_constTone2ToneConsti_search,
             $this->_constTone2ToneConsti_replace,
             $text
         );
 
-        $text = str_replace(
+        $text = $this->cased_str_replace(
             $this->_vowelVowelTone2VowelToneVowel_search,
             $this->_vowelVowelTone2VowelToneVowel_replace,
             $text
         );
 
-        $text = str_replace(
+        $text = $this->cased_str_replace(
             $this->_vowelTone2Unicode_search,
             $this->_vowelTone2Unicode_replace,
             $text
         );
 
 
-        $text = str_replace(
+        $text = $this->cased_str_replace(
             $this->_remove5thToneNumber_search,
             $this->_remove5thToneNumber_replace,
             $text

--- a/src/View/Helper/PinyinHelper.php
+++ b/src/View/Helper/PinyinHelper.php
@@ -89,7 +89,23 @@ class PinyinHelper extends AppHelper
         'ou1',
         'ou2',
         'ou3',
-        'ou4'
+        'ou4',
+        'Ai1',
+        'Ai2',
+        'Ai3',
+        'Ai4',
+        'Ao1',
+        'Ao2',
+        'Ao3',
+        'Ao4',
+        'Ei1',
+        'Ei2',
+        'Ei3',
+        'Ei4',
+        'Ou1',
+        'Ou2',
+        'Ou3',
+        'Ou4'
     );
 
     private $_vowelVowelTone2VowelToneVowel_replace = array(
@@ -108,7 +124,23 @@ class PinyinHelper extends AppHelper
         'o1u',
         'o2u',
         'o3u',
-        'o4u'
+        'o4u',
+        'A1i',
+        'A2i',
+        'A3i',
+        'A4i',
+        'A1o',
+        'A2o',
+        'A3o',
+        'A4o',
+        'E1i',
+        'E2i',
+        'E3i',
+        'E4i',
+        'O1u',
+        'O2u',
+        'O3u',
+        'O4u'
     );
 
     private $_vowelTone2Unicode_search = array(
@@ -135,7 +167,31 @@ class PinyinHelper extends AppHelper
         'v1',
         'v2',
         'v3',
-        'v4'
+        'v4',
+        'A1',
+        'A2',
+        'A3',
+        'A4',
+        'E1',
+        'E2',
+        'E3',
+        'E4',
+        'I1',
+        'I2',
+        'I3',
+        'I4',
+        'O1',
+        'O2',
+        'O3',
+        'O4',
+        'U1',
+        'U2',
+        'U3',
+        'U4',
+        'V1',
+        'V2',
+        'V3',
+        'V4'
     );
 
     private $_vowelTone2Unicode_replace = array(
@@ -162,7 +218,31 @@ class PinyinHelper extends AppHelper
         'ǖ',
         'ǘ',
         'ǚ',
-        'ǜ'
+        'ǜ',
+        'Ā',
+        'Á',
+        'Ǎ',
+        'À',
+        'Ē',
+        'É',
+        'Ě',
+        'È',
+        'Ī',
+        'Í',
+        'Ǐ',
+        'Ì',
+        'Ō',
+        'Ó',
+        'Ǒ',
+        'Ò',
+        'Ū',
+        'Ú',
+        'Ǔ',
+        'Ù',
+        'Ǖ',
+        'Ǘ',
+        'Ǚ',
+        'Ǜ'
     );
 
 
@@ -175,7 +255,16 @@ class PinyinHelper extends AppHelper
         'v5',
         'n5',
         'g5',
-        'r5'
+        'r5',
+        'A5',
+        'E5',
+        'I5',
+        'O5',
+        'U5',
+        'V5',
+        'N5',
+        'G5',
+        'R5'
     );
 
 
@@ -188,32 +277,17 @@ class PinyinHelper extends AppHelper
         'v',
         'n',
         'g',
-        'r'
+        'r',
+        'A',
+        'E',
+        'I',
+        'O',
+        'U',
+        'V',
+        'N',
+        'G',
+        'R'
     );
-
-    /**
-     * Uppercase the first character in a UTF-8 string.
-     */
-    private function utf8_ucfirst($string) {
-        // Based on https://stackoverflow.com/a/2518021
-        // Licensed under CC BY-SA 4.0
-        $strlen = mb_strlen($string, 'UTF-8');
-        $firstChar = mb_substr($string, 0, 1, 'UTF-8');
-        $then = mb_substr($string, 1, $strlen - 1, 'UTF-8');
-        return mb_strtoupper($firstChar, 'UTF-8') . $then;
-    }
-
-    /**
-     * Wrapper for str_replace that optionally uppercases the first character
-     * of the search string, and also uppercases the first character of the
-     * replacement string in that case.
-     */
-    private function cased_str_replace($search, $replace, $subject) {
-        $utf8_ucfirst = function($string) { return $this->utf8_ucfirst($string); };
-        $search = array_merge($search, array_map($utf8_ucfirst, $search));
-        $replace = array_merge($replace, array_map($utf8_ucfirst, $replace));
-        return str_replace($search, $replace, $subject);
-    }
 
     /**
      * Replace numeric pinyin by diacritical marks
@@ -227,26 +301,26 @@ class PinyinHelper extends AppHelper
 
     public function numeric2diacritic($text)
     {
-        $text = $this->cased_str_replace(
+        $text = str_replace(
             $this->_constTone2ToneConsti_search,
             $this->_constTone2ToneConsti_replace,
             $text
         );
 
-        $text = $this->cased_str_replace(
+        $text = str_replace(
             $this->_vowelVowelTone2VowelToneVowel_search,
             $this->_vowelVowelTone2VowelToneVowel_replace,
             $text
         );
 
-        $text = $this->cased_str_replace(
+        $text = str_replace(
             $this->_vowelTone2Unicode_search,
             $this->_vowelTone2Unicode_replace,
             $text
         );
 
 
-        $text = $this->cased_str_replace(
+        $text = str_replace(
             $this->_remove5thToneNumber_search,
             $this->_remove5thToneNumber_replace,
             $text

--- a/tests/TestCase/View/Helper/TranscriptionsHelperTest.php
+++ b/tests/TestCase/View/Helper/TranscriptionsHelperTest.php
@@ -31,7 +31,7 @@ class TranscriptionsHelperTest extends TestCase {
     function setUp() {
         parent::setUp();
         $View = new View();
-    	$this->T = new TranscriptionsHelper($View);
+        $this->T = new TranscriptionsHelper($View);
     }
 
     function assertFurigana($internal, $editable, $ruby) {
@@ -70,6 +70,33 @@ class TranscriptionsHelperTest extends TestCase {
             '[行|い|]',
             '行｛い｜｝',
             '<ruby>行<rp>（</rp><rt>い</rt><rp>）</rp></ruby>'
+        );
+    }
+
+    function assertPinyin($numeric, $diacritic) {
+        $transcription = array(
+            'text' => $numeric,
+            'script' => 'Latn',
+        );
+        $expected =
+            '<span style="display:none" class="markup">'.$numeric.'</span>'.
+            $diacritic;
+        $result = $this->T->transcriptionAsHTML('cmn', $transcription);
+        $this->assertEquals($expected, $result);
+    }
+
+    function testTranscriptionAsHTML_cmn() {
+        $this->assertPinyin(
+            'Ni3hao3.',
+            'Nǐhǎo.'
+        );
+        $this->assertPinyin(
+            'Ta1 zai4 zher4!',
+            'Tā zài zhèr!'
+        );
+        $this->assertPinyin(
+            'A1er3ji2li4ya4 shi4 E2luo2si1 he2 Zhong1guo2 de5 qin1mi4 meng2you3.',
+            'Āěrjílìyà shì Éluósī hé Zhōngguó de qīnmì méngyǒu.'
         );
     }
 }


### PR DESCRIPTION
I think the title is self-explanatory.

Aside: Since reporting #2153, I have learned that there *is* [a standard for pinyin orthography  that requires capitalization](http://www.moe.gov.cn/ewebeditor/uploadfile/2012/08/21/20120821100233165.pdf).