### PR TITLE
Split sentences_detailed.csv into single language files

### DIFF
--- a/config/app_local.php.template
+++ b/config/app_local.php.template
@@ -232,4 +232,12 @@ return [
     'Announcement' => [
         'enabled' => false,
     ],
+
+    /**
+     * Base path and base URL for the downloadable database exports.
+     */
+    'Downloads' => [
+        'path' => '/var/www-downloads/exports/',
+        'url' => 'https://downloads.tatoeba.org/exports/',
+    ],
 ];

--- a/docs/cron/export.sh
+++ b/docs/cron/export.sh
@@ -4,10 +4,11 @@ set -e
 PATH=$PATH:/usr/local/mysql/bin
 ROOT='/var/www-prod'
 
-mysql -u "$DB_USER" -p"$DB_PASS" "$DB" < /var/www-prod/docs/database/scripts/weekly_exports.sql
+mysql -u "$DB_USER" -p"$DB_PASS" "$DB" < $ROOT/docs/database/scripts/weekly_exports.sql
 
 DL_DIR="/var/www-downloads/exports"
-mv /var/tmp/* "$DL_DIR"
+mkdir -p "$DL_DIR/single_language"
+mv /var/tmp/*csv "$DL_DIR"
 
 cd "$DL_DIR"
 tar -cjf sentences_detailed.tar.bz2 sentences_detailed.csv
@@ -27,3 +28,8 @@ tar -cjf sentences_with_audio.tar.bz2 sentences_with_audio.csv
 tar -cjf user_languages.tar.bz2 user_languages.csv
 tar -cjf tags_detailed.tar.bz2 tags_detailed.csv
 tar -cjf sentences_CC0.tar.bz2 sentences_CC0.csv
+
+# Split sentences_detailed.csv into single language files
+cd "$DL_DIR/single_language"
+awk -F"\t" '{print >> ($2 == "\\N" ? "unknown_sentences_detailed.tsv" : $2 "_sentences_detailed.tsv")}' ../sentences_detailed.csv
+bzip2 -f *_sentences_detailed.tsv

--- a/docs/cron/export.sh
+++ b/docs/cron/export.sh
@@ -6,7 +6,6 @@ ROOT='/var/www-prod'
 
 mysql -u "$DB_USER" -p"$DB_PASS" "$DB" < $ROOT/docs/database/scripts/weekly_exports.sql
 
-DL_DIR="/var/www-downloads/exports"
 mv /var/tmp/*csv "$DL_DIR"
 
 cd "$DL_DIR"
@@ -49,5 +48,5 @@ split_file sentences_detailed.csv
 split_file sentences.csv
 split_file sentences_CC0.csv
 find $TEMP_DIR -path '*tsv' -exec bzip2 -qf '{}' +
-rm -rf $DL_DIR/per_language
+rm -rf ${DL_DIR}per_language
 mv -f $TEMP_DIR $DL_DIR

--- a/docs/cron/runner.sh
+++ b/docs/cron/runner.sh
@@ -6,5 +6,6 @@ shift 1
 DB_USER=$(php -r 'require "/var/www-prod/config/paths.php"; $config = include "/var/www-prod/config/app_local.php"; echo $config["Datasources"]["default"]["username"];')
 DB_PASS=$(php -r 'require "/var/www-prod/config/paths.php"; $config = include "/var/www-prod/config/app_local.php"; echo $config["Datasources"]["default"]["password"];')
 DB=$(php -r 'require "/var/www-prod/config/paths.php"; $config = include "/var/www-prod/config/app_local.php"; echo $config["Datasources"]["default"]["database"];')
+DL_DIR=$(php -r 'require "/var/www-prod/config/paths.php"; $config = include "/var/www-prod/config/app_local.php"; echo $config["Downloads"]["path"];')
 
-DB_PASS="$DB_PASS" DB_USER="$DB_USER" DB="$DB" "$cmd" "$@"
+DB_PASS="$DB_PASS" DB_USER="$DB_USER" DB="$DB" DL_DIR="$DL_DIR" "$cmd" "$@"

--- a/src/Template/Element/per_language_files.ctp
+++ b/src/Template/Element/per_language_files.ctp
@@ -17,8 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-if (empty($options)): ?>
-    <dd><?= __('There are no sentences available') ?></dd>
+if (count($options) == 1): ?>
+    <dd>
+        <a href="<?= $options[0]['url'] ?>">
+            <?= basename($options[0]['url']) ?>
+        </a>
+    </dd>
 <?php else: ?>
     <dd ng-init="<?= $model ?> = '<?= $options[0]['url'] ?>'" ng-cloak>
         <p>

--- a/src/Template/Element/per_language_files.ctp
+++ b/src/Template/Element/per_language_files.ctp
@@ -20,7 +20,7 @@
 if (empty($options)): ?>
     <dd><?= __('There are no sentences available') ?></dd>
 <?php else: ?>
-    <dd ng-init="<?= $model ?> = '<?= $options[0]['url'] ?>'">
+    <dd ng-init="<?= $model ?> = '<?= $options[0]['url'] ?>'" ng-cloak>
         <p>
             <a ng-href="{{<?= $model ?>}}">{{<?= $model ?> | filename}}</a>
         </p>

--- a/src/Template/Element/per_language_files.ctp
+++ b/src/Template/Element/per_language_files.ctp
@@ -46,6 +46,6 @@ if (count($options) == 1): ?>
                     <?php endforeach; ?>
                 </md-select>
             </div>
-        <md-radio-group>
+        </md-radio-group>
     </dd>
 <?php endif; ?>

--- a/src/Template/Element/per_language_files.ctp
+++ b/src/Template/Element/per_language_files.ctp
@@ -1,0 +1,47 @@
+<?php
+/*+
+ * Tatoeba Project, free collaborative creation of languages corpuses project
+ * Copyright (C) 2020  Tatoeba Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+if (empty($options)): ?>
+    <dd><?= __('There are no sentences available') ?></dd>
+<?php else: ?>
+    <dd ng-init="<?= $model ?> = '<?= $options[0]['url'] ?>'">
+        <p>
+            <a ng-href="{{<?= $model ?>}}">{{<?= $model ?> | filename}}</a>
+        </p>
+        <md-radio-group ng-model="<?= $model ?>"
+        ng-init="<?= $model ?>Select = '<?= $options[1]['url'] ?>'">
+            <md-radio-button class="file-selection" value="<?= $options[0]['url'] ?>">
+               <?= $options[0]['language'] ?>
+            </md-radio-button>
+            <div layout="row" layout-align="start center">
+                <md-radio-button class="file-selection" ng-value="<?= $model ?>Select" flex="none">
+                    Only sentences in
+                </md-radio-button>
+                <md-select class="file-selection" ng-model="<?= $model ?>Select"
+                ng-change="<?= $model ?> = <?= $model ?>Select" flex="initial">
+                    <?php foreach (array_slice($options, 1) as $option): ?>
+                        <md-option value="<?= $option['url'] ?>">
+                            <?= $option['language'] ?>
+                        </md-option>
+                    <?php endforeach; ?>
+                </md-select>
+            </div>
+        <md-radio-group>
+    </dd>
+<?php endif; ?>

--- a/src/Template/Pages/downloads.ctp
+++ b/src/Template/Pages/downloads.ctp
@@ -26,70 +26,99 @@
  */
 
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Download sentences')));
+
+// URLs
+$iso_code_url = "http://en.wikipedia.org/wiki/List_of_ISO_639-3_codes";
+$tanaka_url = "http://www.edrdg.org/wiki/index.php/Tanaka_Corpus#Current_Format_.28WWWJDIC.29";
+$tanaka_url2 = "http://www.edrdg.org/wiki/index.php/Tanaka_Corpus";
+$download_url = $this->Downloads::DOWNLOAD_URL . DS;
+
+// Section Headers
+$filename =  __('Filename');
+$format = __('Fields and structure');
+$description = __('File description');
+
+// Field names
+$sentence_id = __('Sentence id');
+$review = __('Review');
+$text = __('Text');
+$lang = __('Lang');
+$username = __('Username');
+$date_added = __('Date added');
+$date_created = __('Date created');
+$date_modified = __('Date last modified');
+$translation_id = __('Translation id');
+$tag_name = __('Tag name');
+$list_id = __('List id');
+$list_name = __('List name');
+$list_editable_by = __('Editable by');
+$meaning_id = __('Meaning id');
+$skill_level = __('Skill level');
+$details = __('Details');
+$license = __('License');
+$attribution_url = __('Attribution URL');
+
+// Examples in description
+$link_sample = $this->Downloads->fileFormat(['1', '77']);
+$link_sample_reversed = $this->Downloads->fileFormat(['77', '1']);
+$tag_sample = $this->Downloads->fileFormat(['381279', 'proverb']);
+$list_sample = $this->Downloads->fileFormat(['13', '381279']);
 ?>
 
 <div id="annexe_content">
     <div class="section md-whiteframe-1dp">
-    <h2><?php echo __('Note'); ?></h2>
-    <p>
-    <?php
-    __(
-        'The data you will find here will NOT be useful unless you are coding a '.
-        'language tool or processing data.'
-    );
-    ?>
-    </p>
-    <p>
-    <?php
-    echo format(__(
-        'If you simply want sentences that you can use to learn a language, '.
-        'check out the <a href="{}">sentence lists</a>. '.
-        'You can build your own, or view the ones that others have created. '.
-        'The lists can be downloaded and printed.', true),
-        $this->Url->build(array("controller"=>"sentences_lists")
-    ));
-    ?>
-    </p>
+        <h2><?= __('Note') ?></h2>
+        <p>
+            <?= __(
+                'The data you will find here will NOT be useful unless you are coding a '.
+                'language tool or processing data.'
+            ) ?>
+        </p>
+        <p>
+            <?= format(
+                __(
+                    'If you simply want sentences that you can use to learn a language, '.
+                    'check out the <a href="{}">sentence lists</a>. '.
+                    'You can build your own, or view the ones that others have created. '.
+                    'The lists can be downloaded and printed.'
+                ),
+                $this->Url->build(array("controller"=>"sentences_lists"))
+            ) ?>
+        </p>
     </div>
 
     <div class="section md-whiteframe-1dp">
-        <h2><?php echo __('General information about the files'); ?></h2>
+        <h2><?= __('General information about the files') ?></h2>
         <p>
-            <?php
-            echo __(
+            <?= __(
                 'The files provided here are updated every <strong>Saturday at 6:30 a.m.</strong> '.
                 '(UTC).'
-            );
-            ?>
+            ) ?>
         </p>
-
         <p>
-            <?php $tanaka_url2 = "http://www.edrdg.org/wiki/index.php/Tanaka_Corpus";
-            echo format(
+            <?= format(
                 __(
                     'Many of the Japanese and English sentences are from the '.
-                    '<a href="{}">Tanaka Corpus</a>, which belongs to the public domain.', true
+                    '<a href="{}">Tanaka Corpus</a>, which belongs to the public domain.'
                 ),
                 $tanaka_url2
-            );
-            ?>
+            ); ?>
         </p>
     </div>
 
     <div class="section md-whiteframe-1dp">
-    <h2><?php echo __('Creative commons'); ?></h2>
-    <p><?php echo __('These files are released under CC BY 2.0 FR.'); ?></p>
-    <a rel="license" href="https://creativecommons.org/licenses/by/2.0/fr/">
-    <img alt="Creative Commons License CC-BY" style="border-width:0"
-        src="/img/cc-by-2.0-88x31.png" />
-    </a>
-    <p><?= __('A part of our sentences are also available under CC0 1.0.') ?></p>
-    <a rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/legalcode">
-    <img alt="Creative Commons License CC0" style="border-width:0"
-        src="/img/cc0-1.0-88x31.png" />
-    </a>
+        <h2><?= __('Creative commons') ?></h2>
+        <p><?= __('These files are released under CC BY 2.0 FR.') ?></p>
+        <a rel="license" href="https://creativecommons.org/licenses/by/2.0/fr/">
+            <img alt="Creative Commons License CC-BY" style="border-width:0"
+                src="/img/cc-by-2.0-88x31.png" />
+        </a>
+        <p><?= __('A part of our sentences are also available under CC0 1.0.') ?></p>
+        <a rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/legalcode">
+            <img alt="Creative Commons License CC0" style="border-width:0"
+                src="/img/cc0-1.0-88x31.png" />
+        </a>
     </div>
-
 
     <div class="section md-whiteframe-1dp">
         <h2><?= __('Licenses covering audio') ?></h2>
@@ -98,456 +127,301 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Download sentences'
                 'The license covering an audio file is chosen by the '.
                 'contributor, and is indicated on the page that lists '.
                 'the audio files that he or she has contributed.'
-            ); ?>
+            ) ?>
         </p>
     </div>
 
     <div class="section md-whiteframe-1dp">
-    <h2><?php echo __('Questions?'); ?></h2>
-    <p>
-    <?php
-        $firstSentence = format(__(
-           'If you have questions or requests, feel free to '.
-           '<a href="{}">contact us</a>.' , true),
-           $this->Url->build(array("controller"=>"pages", "action"=>"contact")
-       ));
-        $secondSentence = __('In general, we answer quickly.');
-        echo format(
-            __('{firstSentence} {secondSentence}'),
-            compact('firstSentence', 'secondSentence')
-        );
-    ?>
-    </p>
+        <h2><?= __('Questions?') ?></h2>
+        <p>
+            <?= format(
+                __(
+                   'If you have questions or requests, feel free to '.
+                   '<a href="{}">contact us</a>. In general, we answer quickly.'
+                ),
+                $this->Url->build(array("controller"=>"pages", "action"=>"contact"))
+            ) ?>
+        </p>
     </div>
 </div>
 
 <div id="main_content">
-    <?php
-        $download_str =  __('Download');
-        $downloads_str =  __('Downloads');
-        $field_struct_str = __('Fields and structure');
-        $file_desc_str = __('File description');
-        $sent_id_str = __('Sentence id');
-        $review_str = __('Review');
-        $text_str = __('Text');
-        $lang_str = __('Lang');
-        $username_str = __('Username');
-        $date_added_str = __('Date added');
-        $date_created_str = __('Date created');
-        $date_last_mod_str = __('Date last modified');
-        $trans_id_str = __('Translation id');
-        $tag_name_str = __('Tag name');
-        $list_id_str = __('List id');
-        $list_name_str = __('List name');
-        $list_editable_by = __('Editable by');
-        $meaning_id_str = __('Meaning id');
-        $skill_level_str = __('Skill level');
-        $details_str = __('Details');
-        $license_str = __('License');
-        $attribution_url_str = __('Attribution URL');
-        $tab_str = __('tab');
-        $per_language_str = __('Per-language files are available at <a ' .
-            'href="https://downloads.tatoeba.org/exports/per_language/">' .
-            'https://downloads.tatoeba.org/exports/per_language</a>.');
-    ?>
     <div>
-        <h1><?php echo $downloads_str; ?></h1>
+        <h1><?= __('Downloads') ?></h1>
 
         <!-- Sentences -->
         <div  class="section md-whiteframe-1dp">
-        <h2><?php echo __('Sentences'); ?></h2>
-        <dl>
-            <dt><?php echo $download_str; ?></dt>
-            <dd>
-                1. <a href="http://downloads.tatoeba.org/exports/sentences.tar.bz2">
-                http://downloads.tatoeba.org/exports/sentences.tar.bz2
-                </a>
-            </dd>
-            <dd>
-                2. <a href="http://downloads.tatoeba.org/exports/sentences_detailed.tar.bz2">
-                http://downloads.tatoeba.org/exports/sentences_detailed.tar.bz2
-                </a>
-            </dd>
-            <dt><?php echo $field_struct_str; ?></dt>
-            <dd>
-                1. <span class="param"><?php echo $sent_id_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $lang_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $text_str; ?></span>
-            </dd>
-            <dd>
-                2. <span class="param"><?php echo $sent_id_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $lang_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $text_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $username_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $date_added_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $date_last_mod_str; ?></span>
-            </dd>
-
-
-        <dt><?php echo $file_desc_str; ?></dt>
-            <dd>
-            <?php
-                $iso_code_list = "http://en.wikipedia.org/wiki/List_of_ISO_639-3_codes";
-                echo format(
-                    __('Contains all the sentences. Each sentence is associated with a '.
-                       'unique id and an <a href="{}">ISO 639-3</a> language code. ',
-                       true), $iso_code_list);
-                __('The first file (sentences.tar.bz2) contains this information alone. '.
-                'The second file (sentences_detailed.tar.bz2) contains additional fields '.
-                'for those who would like to filter the sentences based on the contributor '.
-                'who owns the sentence, or the date when it was added or last modified.');
-            ?>
-            </dd>
-        </dl>
-        <?= $per_language_str; ?>
+            <h2><?= __('Sentences') ?></h2>
+            <dl>
+                <dt><?= $filename ?></dt>
+                <dd>
+                    <a href="<?= $download_url ?>sentences.tar.bz2">sentences.tar.bz2</a>
+                </dd>
+                <dt><?= $description ?></dt>
+                <dd>
+                    <?= format(
+                        __(
+                            'Contains all the sentences. Each sentence is associated with a '.
+                            'unique id and an <a href="{}">ISO 639-3</a> language code. '
+                        ),
+                        $iso_code_url
+                    ) ?>
+                </dd>
+                <dt><?= $format ?></dt>
+                <dd><?= $this->Downloads->fileFormat([$sentence_id, $lang, $text]) ?></dd>
+            </dl>
         </div>
 
-        <!-- Sentences -->
+        <!-- Sentences detailed-->
         <div  class="section md-whiteframe-1dp">
-        <h2><?php echo __('Sentences (CC0)'); ?></h2>
-        <dl>
-            <dt><?php echo $download_str; ?></dt>
-            <dd>
-                <a href="http://downloads.tatoeba.org/exports/sentences_CC0.tar.bz2">
-                http://downloads.tatoeba.org/exports/sentences_CC0.tar.bz2
-                </a>
-            </dd>
-            <dt><?php echo $field_struct_str; ?></dt>
-            <dd>
-                <span class="param"><?php echo $sent_id_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $lang_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $text_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $date_last_mod_str; ?></span>
-            </dd>
+            <h2><?= __('Detailed Sentences') ?></h2>
+            <dl>
+                <dt><?= $filename ?></dt>
+                <dd>
+                    <a href="<?= $download_url ?>sentences_detailed.tar.bz2">
+                        sentences_detailed.tar.bz2
+                    </a>
+                </dd>
+                <dt><?= $description ?></dt>
+                <dd>
+                    <?= format(
+                        __(
+                            'Contains additional fields for each sentence '.
+                            '(owner name, date created/modified).'
+                        )
+                    ) ?>
+                </dd>
+                <dt><?= $format ?></dt>
+                <dd>
+                    <?= $this->Downloads->fileFormat(
+                        [$sentence_id, $lang, $text, $username, $date_added, $date_modified]
+                    ) ?>
+                </dd>
+            </dl>
+        </div>
 
-            <dt><?php echo $file_desc_str; ?></dt>
-            <dd>
-            <?= __('Contains all the sentences available under CC0.') ?>
-            </dd>
-        </dl>
-        <?= $per_language_str; ?>
+        <!-- Sentences CC0 -->
+        <div  class="section md-whiteframe-1dp">
+            <h2><?= __('Sentences (CC0)') ?></h2>
+            <dl>
+                <dt><?= $filename ?></dt>
+                <dd>
+                    <a href="<?= $download_url ?>sentences_CC0.tar.bz2">sentences_CC0.tar.bz2</a>
+                </dd>
+                <dt><?= $description ?></dt>
+                <dd>
+                <?= __('Contains all the sentences available under CC0.') ?>
+                </dd>
+                <dt><?= $format ?></dt>
+                <dd>
+                    <?= $this->Downloads->fileFormat([$sentence_id, $lang, $text, $date_modified]) ?>
+                </dd>
+            </dl>
         </div>
 
         <!-- Links -->
         <div  class="section md-whiteframe-1dp">
-        <h2><?php echo __('Links'); ?></h2>
-        <dl>
-            <dt><?php echo $download_str; ?></dt>
-            <dd>
-                <a href="http://downloads.tatoeba.org/exports/links.tar.bz2">
-                http://downloads.tatoeba.org/exports/links.tar.bz2
-                </a>
-            </dd>
-
-            <dt><?php echo $field_struct_str; ?></dt>
-            <dd>
-            <span class="param"><?php echo $sent_id_str; ?></span>
-            <span class="symbol">[<?php echo $tab_str; ?>]</span>
-            <span class="param"><?php echo $trans_id_str; ?></span>
-            </dd>
-
-            <dt><?php echo $file_desc_str; ?></dt>
-            <dd>
-                <?php
-                $sample_line = sprintf(
-                    '<span class="param">1</span>'.
-                    '<span class="symbol"> [%s] </span>'.
-                    '<span class="param">77</span> ',
-                    $tab_str
-                );
-                $sample_line_rev = sprintf(
-                    '<span class="param">77</span>'.
-                    '<span class="symbol"> [%s] </span>'.
-                    '<span class="param">1</span> ',
-                    $tab_str
-                );
-
-                echo format(
-                    __('Contains the links between the sentences. {sampleLinkLine} '.
-                    'means that sentence #77 is the translation of sentence #1. '.
-                    'The reciprocal link is also present, so the file will '.
-                    'also contain a line that says {sampleLinkLineReversed}.', true),
-                    array(
-                        'sampleLinkLine' => $sample_line,
-                        'sampleLinkLineReversed' => $sample_line_rev
-                    )
-                );
-                ?>
-            </dd>
-        </dl>
+            <h2><?= __('Links') ?></h2>
+            <dl>
+                <dt><?= $filename ?></dt>
+                <dd>
+                    <a href="<?= $download_url ?>links.tar.bz2">links.tar.bz2</a>
+                </dd>
+                <dt><?= $description ?></dt>
+                <dd>
+                    <?= format(
+                        __('Contains the links between the sentences. {sampleLinkLine} '.
+                        'means that sentence #77 is the translation of sentence #1. '.
+                        'The reciprocal link is also present, so the file will '.
+                        'also contain a line that says {sampleLinkLineReversed}.'),
+                        [
+                            'sampleLinkLine' => $link_sample,
+                            'sampleLinkLineReversed' => $link_sample_reversed
+                        ]
+                    ) ?>
+                </dd>
+                <dt><?= $format ?></dt>
+                <dd><?= $this->Downloads->fileFormat([$sentence_id, $translation_id]) ?></dd>
+            </dl>
         </div>
 
         <!-- Tags -->
         <div  class="section md-whiteframe-1dp">
-        <h2><?php echo __('Tags'); ?></h2>
-        <dl>
-            <dt><?php echo $download_str; ?></dt>
-            <dd>
-                <a href="http://downloads.tatoeba.org/exports/tags.tar.bz2">
-                http://downloads.tatoeba.org/exports/tags.tar.bz2
-                </a>
-            </dd>
-
-            <dt><?php echo $field_struct_str; ?></dt>
-            <dd>
-                <span class="param"><?php echo $sent_id_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $tag_name_str; ?></span>
-            </dd>
-
-            <dt><?php echo $file_desc_str; ?></dt>
-            <dd>
-                <?php
-                $tag_url = $this->Url->build(array(
-                    'controller' => 'tags',
-                    'action' => 'view_all'
-                ));
-                $sample_line = sprintf(
-                    '<span class="param">381279</span>'.
-                    '<span class="symbol"> [%s] </span>'.
-                    '<span class="param">proverb</span>',
-                    $tab_str
-                );
-                echo format(
-                    __('Contains the list of <a href="{url}">tags</a> associated with '.
-                       'each sentence. {sampleTagLine} means that sentence #381279 has '.
-                       'been assigned the "proverb" tag.', true),
-                    array('url' => $tag_url, 'sampleTagLine' => $sample_line)
-                );
-                ?>
-            </dd>
-        </dl>
+            <h2><?= __('Tags') ?></h2>
+            <dl>
+                <dt><?= $filename ?></dt>
+                <dd>
+                    <a href="<?= $download_url ?>tags.tar.bz2">tags.tar.bz2</a>
+                </dd>
+                <dt><?= $description ?></dt>
+                <dd>
+                    <?= format(
+                        __('Contains the list of <a href="{url}">tags</a> associated with '.
+                           'each sentence. {sampleTagLine} means that sentence #381279 has '.
+                           'been assigned the "proverb" tag.'),
+                        [
+                            'url' => $this->Url->build(['controller' => 'tags', 'action' => 'view_all']),
+                            'sampleTagLine' => $tag_sample
+                        ]
+                    ) ?>
+                </dd>
+                <dt><?= $format ?></dt>
+                <dd><?= $this->Downloads->fileFormat([$sentence_id, $tag_name]) ?></dd>
+            </dl>
         </div>
 
         <!-- Lists -->
         <div  class="section md-whiteframe-1dp">
-        <h2><?php echo __('Lists'); ?></h2>
-        <dl>
-            <dt><?php echo $download_str; ?></dt>
-            <dd>
-                <a href="http://downloads.tatoeba.org/exports/user_lists.tar.bz2">
-                http://downloads.tatoeba.org/exports/user_lists.tar.bz2
-                </a>
-            </dd>
-            <dt><?php echo $field_struct_str; ?></dt>
-            <dd>
-                <span class="param"><?php echo $list_id_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $username_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $date_created_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $date_last_mod_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $list_name_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $list_editable_by; ?></span>
-            </dd>
-
-            <dt><?php echo $file_desc_str; ?></dt>
-            <dd>
-                <?php
-                $list_url = $this->Url->build(array(
-                    'controller' => 'sentences_lists',
-                    'action' => 'index'
-                ));
-                echo format(__('Contains the list of <a href="{}">sentence lists</a>.'),
-                            $list_url);
-                ?>
-            </dd>
-        </dl>
+            <h2><?= __('Lists') ?></h2>
+            <dl>
+                <dt><?= $filename ?></dt>
+                <dd>
+                    <a href="<?= $download_url ?>user_lists.tar.bz2">user_lists.tar.bz2</a>
+                </dd>
+                <dt><?= $description ?></dt>
+                <dd>
+                    <?= format(
+                        __('Contains the list of <a href="{}">sentence lists</a>.'),
+                        $this->Url->build(['controller' => 'sentences_lists', 'action' => 'index'])
+                    ) ?>
+                </dd>
+                <dt><?= $format ?></dt>
+                <dd>
+                    <?= $this->Downloads->fileFormat(
+                        [$list_id, $username, $date_created, $date_modified, $list_name, $list_editable_by]
+                    ) ?>
+                </dd>
+            </dl>
         </div>
 
         <div  class="section md-whiteframe-1dp">
-        <h2><?php echo __('Sentences in lists'); ?></h2>
-        <dl>
-            <dt><?php echo $download_str; ?></dt>
-            <dd>
-                <a href="http://downloads.tatoeba.org/exports/sentences_in_lists.tar.bz2">
-                http://downloads.tatoeba.org/exports/sentences_in_lists.tar.bz2
-                </a>
-            </dd>
-
-            <dt><?php echo $field_struct_str; ?></dt>
-            <dd>
-                <span class="param"><?php echo $list_id_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $sent_id_str; ?></span>
-            </dd>
-
-            <dt><?php echo $file_desc_str; ?></dt>
-            <dd>
-                <?php
-                    $sample_line = sprintf(
-                        '<span class="param">13</span>'.
-                        '<span class="symbol"> [%s] </span>'.
-                        '<span class="param">381279</span> ',
-                        $tab_str
-                    );
-                    echo format(__('Indicates the sentences that are contained by '.
-                                   'any lists. {sampleListLine} means that sentence #381279 is contained '.
-                                   'by the list that has an id of 13.', true),
-                                array('sampleListLine' => $sample_line));
-                ?>
-            </dd>
-        </dl>
+            <h2><?= __('Sentences in lists') ?></h2>
+            <dl>
+                <dt><?= $filename ?></dt>
+                <dd>
+                    <a href="<?= $download_url ?>sentences_in_lists.tar.bz2">
+                            sentences_in_lists.tar.bz2
+                    </a>
+                </dd>
+                <dt><?= $description ?></dt>
+                <dd>
+                    <?= format(
+                        __(
+                            'Indicates the sentences that are contained by '.
+                            'any lists. {sampleListLine} means that sentence #381279 is contained '.
+                            'by the list that has an id of 13.'
+                        ),
+                        ['sampleListLine' => $list_sample]
+                    ) ?>
+                </dd>
+                <dt><?= $format ?></dt>
+                <dd>
+                    <?= $this->Downloads->fileFormat([$list_id, $sentence_id]) ?>
+                </dd>
+            </dl>
         </div>
 
         <!-- Indices -->
         <div  class="section md-whiteframe-1dp">
-        <h2><?php echo __('Japanese indices'); ?></h2>
-        <dl>
-            <dt><?php echo $download_str; ?></dt>
-            <dd>
-                <a href="http://downloads.tatoeba.org/exports/jpn_indices.tar.bz2">
-                http://downloads.tatoeba.org/exports/jpn_indices.tar.bz2
-                </a>
-            </dd>
-
-
-            <dt><?php echo $field_struct_str; ?></dt>
-            <dd>
-                <span class="param"><?php echo $sent_id_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $meaning_id_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $text_str; ?></span>
-            </dd>
-
-            <dt><?php echo $file_desc_str; ?></dt>
-            <dd>
-                <?php
-                $tanaka_url = "http://www.edrdg.org/wiki/index.php/Tanaka_Corpus#Current_Format_.28WWWJDIC.29";
-                echo format(
-                    __('Contains the equivalent of the "B lines" in the Tanaka Corpus '.
-                       'file distributed by Jim Breen. See <a href="{url}">this page</a> '.
-                       'for the format. Each entry is associated with a pair of '.
-                       'Japanese/English sentences. {sentenceId} refers to the id of the '.
-                       'Japanese sentence. {meaningId} refers to the id of the English '.
-                       'sentence.', true),
-                    array(
-                        'url' => $tanaka_url,
-                        'sentenceId' => '<span class="param">'.$sent_id_str.'</span>',
-                        'meaningId'  => '<span class="param">'.$meaning_id_str.'</span>')
-                );
-                ?>
-            </dd>
-        </dl>
+            <h2><?= __('Japanese indices') ?></h2>
+            <dl>
+                <dt><?= $filename ?></dt>
+                <dd>
+                    <a href="<?= $download_url ?>jpn_indices.tar.bz2">jpn_indices.tar.bz2</a>
+                </dd>
+                <dt><?= $description ?></dt>
+                <dd>
+                    <?= format(
+                        __(
+                            'Contains the equivalent of the "B lines" in the Tanaka Corpus '.
+                            'file distributed by Jim Breen. See <a href="{url}">this page</a> '.
+                            'for the format. Each entry is associated with a pair of '.
+                            'Japanese/English sentences. {sentenceId} refers to the id of the '.
+                            'Japanese sentence. {meaningId} refers to the id of the English sentence.'
+                        ),
+                        [
+                            'url' => $tanaka_url,
+                            'sentenceId' => '<span class="param">'.$sentence_id.'</span>',
+                            'meaningId'  => '<span class="param">'.$meaning_id.'</span>'
+                        ]
+                    ) ?>
+                </dd>
+                <dt><?= $format ?></dt>
+                <dd><?= $this->Downloads->fileFormat([$sentence_id, $meaning_id, $text]) ?></dd>
+            </dl>
         </div>
 
         <!-- Sentences with audio -->
         <div  class="section md-whiteframe-1dp">
-        <h2><?php echo __('Sentences with audio'); ?></h2>
-        <dl>
-            <dt><?php echo $download_str; ?></dt>
-            <dd>
-            <a href="http://downloads.tatoeba.org/exports/sentences_with_audio.tar.bz2">
-             http://downloads.tatoeba.org/exports/sentences_with_audio.tar.bz2
-            </a>
-            </dd>
-
-            <dt><?php echo $field_struct_str; ?></dt>
-            <dd>
-            <span class="param"><?php echo $sent_id_str; ?></span>
-            <span class="symbol">[<?php echo $tab_str; ?>]</span>
-            <span class="param"><?php echo $username_str; ?></span>
-            <span class="symbol">[<?php echo $tab_str; ?>]</span>
-            <span class="param"><?php echo $license_str; ?></span>
-            <span class="symbol">[<?php echo $tab_str; ?>]</span>
-            <span class="param"><?php echo $attribution_url_str; ?></span>
-            </dd>
-
-            <dt><?php echo $file_desc_str; ?></dt>
-            <dd>
-            <?php
-            echo __(
-                'Contains the ids of the sentences, in all languages, for '.
-                'which audio is available. Other fields indicate who recorded '.
-                'the audio, its license and a URL to attribute the author. If '.
-                'the license field is empty, you may not reuse the audio '.
-                'outside the Tatoeba project.'
-            );
-            ?>
-            </dd>
-        </dl>
+            <h2><?= __('Sentences with audio') ?></h2>
+            <dl>
+                <dt><?= $filename ?></dt>
+                <dd>
+                    <a href="<?= $download_url ?>sentences_with_audio.tar.bz2">
+                        sentences_with_audio.tar.bz2
+                    </a>
+                </dd>
+                <dt><?= $description ?></dt>
+                <dd>
+                    <?= __(
+                        'Contains the ids of the sentences, in all languages, for '.
+                        'which audio is available. Other fields indicate who recorded '.
+                        'the audio, its license and a URL to attribute the author. If '.
+                        'the license field is empty, you may not reuse the audio '.
+                        'outside the Tatoeba project.'
+                    ) ?>
+                </dd>
+                <dt><?= $format ?></dt>
+                <dd>
+                    <?= $this->Downloads->fileFormat(
+                        [$sentence_id, $username, $license, $attribution_url]
+                    ) ?>
+                </dd>
+            </dl>
         </div>
 
         <!-- User skill level per language -->
         <div  class="section md-whiteframe-1dp">
-        <h2><?php echo __('User skill level per language'); ?></h2>
-        <dl>
-            <dt><?php echo $download_str; ?></dt>
-            <dd>
-            <a href="http://downloads.tatoeba.org/exports/user_languages.tar.bz2">
-             http://downloads.tatoeba.org/exports/user_languages.tar.bz2
-            </a>
-            </dd>
-
-            <dt><?php echo $field_struct_str; ?></dt>
-            <dd>
-                <span class="param"><?php echo $lang_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $skill_level_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $username_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $details_str; ?></span>
-            </dd>
-
-            <dt><?php echo $file_desc_str; ?></dt>
-            <dd>
-            <?php echo __('Indicates the self-reported skill levels of members in individual languages.'); ?>
-            </dd>
-        </dl>
+            <h2><?= __('User skill level per language') ?></h2>
+            <dl>
+                <dt><?= $filename ?></dt>
+                <dd>
+                    <a href="<?= $download_url ?>user_languages.tar.bz2">user_languages.tar.bz2</a>
+                </dd>
+                <dt><?= $description ?></dt>
+                <dd>
+                    <?= __('Indicates the self-reported skill levels of members in individual languages.') ?>
+                </dd>
+                <dt><?= $format ?></dt>
+                <dd>
+                    <?= $this->Downloads->fileFormat([$lang, $skill_level, $username, $details]) ?>
+                </dd>
+            </dl>
         </div>
 
         <!-- Users' reviews -->
         <div  class="section md-whiteframe-1dp">
-        <h2><?php echo __('Users\' sentence reviews'); ?></h2>
-        <dl>
-            <dt><?php echo $download_str; ?></dt>
-            <dd>
-            <a href="http://downloads.tatoeba.org/exports/users_sentences.csv">
-             http://downloads.tatoeba.org/exports/users_sentences.csv
-            </a>
-            </dd>
-
-            <dt><?php echo $field_struct_str; ?></dt>
-            <dd>
-                <span class="param"><?php echo $username_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $lang_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $sent_id_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $review_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $date_added_str; ?></span>
-                <span class="symbol">[<?php echo $tab_str; ?>]</span>
-                <span class="param"><?php echo $date_last_mod_str; ?></span>
-            </dd>
-
-            <dt><?php echo $file_desc_str; ?></dt>
-            <dd>
-            <?php
-            echo __(
-                'Contains sentences reviewed by users. The value of the review ' .
-                'can be -1 (sentence not OK), 0 (undecided or unsure), ' .
-                'or 1 (sentence OK). Warning: this data is still experimental.'
-            );
-            ?>
-            </dd>
-        </dl>
+            <h2><?= __('Users\' sentence reviews') ?></h2>
+            <dl>
+                <dt><?= $filename ?></dt>
+                <dd>
+                    <a href="<?= $download_url ?>users_sentences.csv">users_sentences.csv</a>
+                </dd>
+                <dt><?= $description ?></dt>
+                <dd>
+                    <?= __(
+                        'Contains sentences reviewed by users. The value of the review ' .
+                        'can be -1 (sentence not OK), 0 (undecided or unsure), ' .
+                        'or 1 (sentence OK). Warning: this data is still experimental.'
+                    ) ?>
+                </dd>
+                <dt><?= $format ?></dt>
+                <dd>
+                    <?= $this->Downloads->fileFormat(
+                        [$username, $lang, $sentence_id, $review, $date_added, $date_modified]
+                    ) ?>
+                </dd>
+            </dl>
         </div>
     </div>
 </div>

--- a/src/Template/Pages/downloads.ctp
+++ b/src/Template/Pages/downloads.ctp
@@ -146,6 +146,9 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Download sentences'
         $license_str = __('License');
         $attribution_url_str = __('Attribution URL');
         $tab_str = __('tab');
+        $per_language_str = __('Per-language files are available at <a ' .
+            'href="https://downloads.tatoeba.org/exports/per_language/">' .
+            'https://downloads.tatoeba.org/exports/per_language</a>.');
     ?>
     <div>
         <h1><?php echo $downloads_str; ?></h1>
@@ -203,6 +206,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Download sentences'
             ?>
             </dd>
         </dl>
+        <?= $per_language_str; ?>
         </div>
 
         <!-- Sentences -->
@@ -231,6 +235,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Download sentences'
             <?= __('Contains all the sentences available under CC0.') ?>
             </dd>
         </dl>
+        <?= $per_language_str; ?>
         </div>
 
         <!-- Links -->

--- a/src/Template/Pages/downloads.ctp
+++ b/src/Template/Pages/downloads.ctp
@@ -25,13 +25,15 @@
  * @link     https://tatoeba.org
  */
 
+use Cake\Core\Configure;
+
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Download sentences')));
 
 // URLs
 $iso_code_url = "http://en.wikipedia.org/wiki/List_of_ISO_639-3_codes";
 $tanaka_url = "http://www.edrdg.org/wiki/index.php/Tanaka_Corpus#Current_Format_.28WWWJDIC.29";
 $tanaka_url2 = "http://www.edrdg.org/wiki/index.php/Tanaka_Corpus";
-$download_url = $this->Downloads::DOWNLOAD_URL . DS;
+$download_url = Configure::read('Downloads.url');
 
 // Section Headers
 $filename =  __('Filename');

--- a/src/Template/Pages/downloads.ctp
+++ b/src/Template/Pages/downloads.ctp
@@ -63,6 +63,11 @@ $link_sample = $this->Downloads->fileFormat(['1', '77']);
 $link_sample_reversed = $this->Downloads->fileFormat(['77', '1']);
 $tag_sample = $this->Downloads->fileFormat(['381279', 'proverb']);
 $list_sample = $this->Downloads->fileFormat(['13', '381279']);
+
+// Dropdown for selections
+$sentencesOptions = $this->Downloads->createOptions('sentences');
+$sentencesDetailedOptions = $this->Downloads->createOptions('sentences_detailed');
+$sentencesCC0Options = $this->Downloads->createOptions('sentences_CC0');
 ?>
 
 <div id="annexe_content">
@@ -154,15 +159,20 @@ $list_sample = $this->Downloads->fileFormat(['13', '381279']);
             <h2><?= __('Sentences') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
-                <dd>
-                    <a href="<?= $download_url ?>sentences.tar.bz2">sentences.tar.bz2</a>
-                </dd>
+                <?= $this->element(
+                    'per_language_files',
+                    [
+                        'model' => 'sentences',
+                        'options' => $sentencesOptions
+                    ]
+                ) ?>
                 <dt><?= $description ?></dt>
                 <dd>
                     <?= format(
                         __(
-                            'Contains all the sentences. Each sentence is associated with a '.
-                            'unique id and an <a href="{}">ISO 639-3</a> language code. '
+                            'Contains all the sentences in the selected language. '.
+                            'Each sentence is associated with a unique id and an '.
+                            '<a href="{}">ISO 639-3</a> language code.'
                         ),
                         $iso_code_url
                     ) ?>
@@ -177,11 +187,13 @@ $list_sample = $this->Downloads->fileFormat(['13', '381279']);
             <h2><?= __('Detailed Sentences') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
-                <dd>
-                    <a href="<?= $download_url ?>sentences_detailed.tar.bz2">
-                        sentences_detailed.tar.bz2
-                    </a>
-                </dd>
+                <?= $this->element(
+                    'per_language_files',
+                    [
+                        'model' => 'sentencesDetailed',
+                        'options' => $sentencesDetailedOptions
+                    ]
+                ) ?>
                 <dt><?= $description ?></dt>
                 <dd>
                     <?= format(
@@ -205,9 +217,13 @@ $list_sample = $this->Downloads->fileFormat(['13', '381279']);
             <h2><?= __('Sentences (CC0)') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
-                <dd>
-                    <a href="<?= $download_url ?>sentences_CC0.tar.bz2">sentences_CC0.tar.bz2</a>
-                </dd>
+                <?= $this->element(
+                    'per_language_files',
+                    [
+                        'model' => 'sentencesCC0',
+                        'options' => $sentencesCC0Options
+                    ]
+                ) ?>
                 <dt><?= $description ?></dt>
                 <dd>
                 <?= __('Contains all the sentences available under CC0.') ?>

--- a/src/View/Helper/DownloadsHelper.php
+++ b/src/View/Helper/DownloadsHelper.php
@@ -79,8 +79,7 @@ class DownloadsHelper extends AppHelper
         $urls = $this->availableFiles($basename);
         if (!empty($urls)) {
             $languages = array_intersect_key(
-                $this->Languages->onlyLanguagesArray(false) +
-                ['unknown' => __x('dropdown-list', 'Unknown language')],
+                $this->Languages->unknownLanguagesArray(false),
                 $urls
             );
 

--- a/src/View/Helper/DownloadsHelper.php
+++ b/src/View/Helper/DownloadsHelper.php
@@ -25,7 +25,7 @@ class DownloadsHelper extends AppHelper
 {
     use LanguageNameTrait;
 
-    public $helpers = ['Languages'];
+    public $helpers = ['Html', 'Languages'];
 
     const PER_LANGUAGE_DIR = '/var/www-downloads/exports/per_language';
     const DOWNLOAD_URL = 'https://downloads.tatoeba.org/exports';
@@ -84,5 +84,28 @@ class DownloadsHelper extends AppHelper
         };
 
         return $options;
+    }
+
+    /**
+     * Create HTML for file format
+     *
+     * @param array $fields Array of field names
+     *
+     * @return string
+     **/
+    public function fileFormat($fields) {
+        if (empty($fields)) {
+            return '';
+        }
+        $tab = $this->Html->tag(
+            'span',
+            format('[{}]', __('tab')),
+            ['class' => 'symbol']
+        );
+        $fieldSpan = function ($field) {
+            return $this->Html->tag('span', $field, ['class' => 'param']);
+        };
+
+        return implode($tab, array_map($fieldSpan, $fields));
     }
 }

--- a/src/View/Helper/DownloadsHelper.php
+++ b/src/View/Helper/DownloadsHelper.php
@@ -20,15 +20,13 @@ namespace App\View\Helper;
 
 use App\View\Helper\AppHelper;
 use App\Model\Entity\LanguageNameTrait;
+use Cake\Core\Configure;
 
 class DownloadsHelper extends AppHelper
 {
     use LanguageNameTrait;
 
     public $helpers = ['Html', 'Languages'];
-
-    const PER_LANGUAGE_DIR = '/var/www-downloads/exports/per_language';
-    const DOWNLOAD_URL = 'https://downloads.tatoeba.org/exports';
 
     /**
      * Get all available per-language files for the given file
@@ -39,7 +37,9 @@ class DownloadsHelper extends AppHelper
      * @return array           A mapping of language code => URL for file
      **/
     private function availableFiles($basename) {
-        $command = 'find ' . self::PER_LANGUAGE_DIR . ' -type f ' .
+        $perLanguageDir = Configure::read('Downloads.path') . 'per_language';
+        $perLanguageURL = Configure::read('Downloads.url') . 'per_language/';
+        $command = "find $perLanguageDir -type f " .
                    "-name '*$basename.tsv.bz2' -printf '%P\\n' " .
                    '2> /dev/null';
         $stdout = trim(shell_exec($command));
@@ -51,7 +51,7 @@ class DownloadsHelper extends AppHelper
         $map = [];
         foreach ($paths as $path) {
             list($code, ) = preg_split('#/#', $path);
-            $url = self::DOWNLOAD_URL . DS . 'per_language' . DS . $path;
+            $url = $perLanguageURL . $path;
             $map[$code] = $url;
         }
         return $map;
@@ -70,7 +70,7 @@ class DownloadsHelper extends AppHelper
      *                         (for the all-languages file).
      **/
     public function createOptions($basename) {
-        $urlForAll = self::DOWNLOAD_URL . DS . $basename . '.tar.bz2';
+        $urlForAll = Configure::read('Downloads.url') . $basename . '.tar.bz2';
         $options[0] = [
             'language' => __('All languages'),
             'url' => $urlForAll

--- a/src/View/Helper/DownloadsHelper.php
+++ b/src/View/Helper/DownloadsHelper.php
@@ -65,31 +65,33 @@ class DownloadsHelper extends AppHelper
      *                         (without extension)
      *
      * @return array           Each item is an array with keys 'language'
-     *                         and 'url'
+     *                         and 'url'.
+     *                         The array will always contain at least one item
+     *                         (for the all-languages file).
      **/
     public function createOptions($basename) {
-        $urls = $this->availableFiles($basename);
-        if (empty($urls)) {
-            return [];
-        }
-        $languages = array_intersect_key(
-            $this->Languages->onlyLanguagesArray(false) +
-            ['unknown' => __x('dropdown-list', 'Unknown language')],
-            $urls
-        );
-
         $urlForAll = self::DOWNLOAD_URL . DS . $basename . '.tar.bz2';
         $options[0] = [
             'language' => __('All languages'),
             'url' => $urlForAll
         ];
 
-        foreach($languages as $code => $name) {
-            $options[] = [
-                'language' => $name,
-                'url' => $urls[$code]
-            ];
-        };
+        $urls = $this->availableFiles($basename);
+        if (!empty($urls)) {
+            $languages = array_intersect_key(
+                $this->Languages->onlyLanguagesArray(false) +
+                ['unknown' => __x('dropdown-list', 'Unknown language')],
+                $urls
+            );
+
+
+            foreach($languages as $code => $name) {
+                $options[] = [
+                    'language' => $name,
+                    'url' => $urls[$code]
+                ];
+            };
+        }
 
         return $options;
     }

--- a/src/View/Helper/DownloadsHelper.php
+++ b/src/View/Helper/DownloadsHelper.php
@@ -40,7 +40,8 @@ class DownloadsHelper extends AppHelper
      **/
     private function availableFiles($basename) {
         $command = 'find ' . self::PER_LANGUAGE_DIR . ' -type f ' .
-                   "-name '*$basename.tsv.bz2' -printf '%P\\n'";
+                   "-name '*$basename.tsv.bz2' -printf '%P\\n' " .
+                   '2> /dev/null';
         $stdout = trim(shell_exec($command));
         if (empty($stdout)) {
             return [];

--- a/src/View/Helper/DownloadsHelper.php
+++ b/src/View/Helper/DownloadsHelper.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2020 Tatoeba Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace App\View\Helper;
+
+use App\View\Helper\AppHelper;
+use App\Model\Entity\LanguageNameTrait;
+
+class DownloadsHelper extends AppHelper
+{
+    use LanguageNameTrait;
+
+    public $helpers = ['Languages'];
+
+    const PER_LANGUAGE_DIR = '/var/www-downloads/exports/per_language';
+    const DOWNLOAD_URL = 'https://downloads.tatoeba.org/exports';
+
+    /**
+     * Get all available per-language files for the given file
+     *
+     * @param string $basename Name of the file containing all languages
+     *                         (without extension)
+     *
+     * @return array           A mapping of language code => URL for file
+     **/
+    private function availableFiles($basename) {
+        $command = 'find ' . self::PER_LANGUAGE_DIR . ' -type f ' .
+                   "-name '*$basename.tsv.bz2' -printf '%P\\n'";
+        $stdout = shell_exec($command);
+        $paths = explode("\n", $stdout, -1);
+
+        $map = [];
+        foreach ($paths as $path) {
+            list($code, ) = preg_split('#/#', $path);
+            $url = self::DOWNLOAD_URL . DS . 'per_language' . DS . $path;
+            $map[$code] = $url;
+        }
+        return $map;
+    }
+
+    /**
+     * Create the options for the per-language file selection on the
+     * Downloads page
+     *
+     * @param string $basename Name of the file containing all languages
+     *                         (without extension)
+     *
+     * @return array           Each item is an array with keys 'language'
+     *                         and 'url'
+     **/
+    public function createOptions($basename) {
+        $urls = $this->availableFiles($basename);
+        $languages = array_intersect_key(
+            $this->Languages->unknownLanguagesArray(),
+            $urls
+        );
+
+        $urlForAll = self::DOWNLOAD_URL . DS . $basename . '.tar.bz2';
+        $options[0] = [
+            'language' => __('All languages'),
+            'url' => $urlForAll
+        ];
+
+        foreach($languages as $code => $name) {
+            $options[] = [
+                'language' => $name,
+                'url' => $urls[$code]
+            ];
+        };
+
+        return $options;
+    }
+}

--- a/src/View/Helper/DownloadsHelper.php
+++ b/src/View/Helper/DownloadsHelper.php
@@ -41,8 +41,11 @@ class DownloadsHelper extends AppHelper
     private function availableFiles($basename) {
         $command = 'find ' . self::PER_LANGUAGE_DIR . ' -type f ' .
                    "-name '*$basename.tsv.bz2' -printf '%P\\n'";
-        $stdout = shell_exec($command);
-        $paths = explode("\n", $stdout, -1);
+        $stdout = trim(shell_exec($command));
+        if (empty($stdout)) {
+            return [];
+        }
+        $paths = explode("\n", $stdout);
 
         $map = [];
         foreach ($paths as $path) {
@@ -65,8 +68,12 @@ class DownloadsHelper extends AppHelper
      **/
     public function createOptions($basename) {
         $urls = $this->availableFiles($basename);
+        if (empty($urls)) {
+            return [];
+        }
         $languages = array_intersect_key(
-            $this->Languages->unknownLanguagesArray(),
+            $this->Languages->onlyLanguagesArray(false) +
+            ['unknown' => __x('dropdown-list', 'Unknown language')],
             $urls
         );
 

--- a/src/View/Helper/LanguagesHelper.php
+++ b/src/View/Helper/LanguagesHelper.php
@@ -189,16 +189,18 @@ class LanguagesHelper extends AppHelper
     }
 
     /**
-     * Return array of languages in Tatoeba. + 'unknown language'
+     * Return array of languages in Tatoeba + 'Unknown language'
      *
+     * @param Boolean $split Whether the languages should be split into
+     *                       'Profile languages' and 'Other languages'.
      * @return array
      */
-    public function unknownLanguagesArray()
+    public function unknownLanguagesArray($split = true)
     {
-        $languages = $this->onlyLanguagesArray();
+        $languages = $this->onlyLanguagesArray($split);
         $options = ['unknown' => __x('dropdown-list', 'Unknown language')];
 
-        return $options + $languages;
+        return $languages + $options;
     }
 
 

--- a/tests/TestCase/View/Helper/DownloadsHelperTest.php
+++ b/tests/TestCase/View/Helper/DownloadsHelperTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * If the static property $files in the test class is set, we return its
+ * value instead of calling shell_exec() in the private method
+ * DownloadsHelper\availableFiles().
+ **/
+namespace App\View\Helper {
+
+    function shell_exec($command) {
+        return \App\Test\TestCase\View\Helper\DownloadsHelperTest::$files ?: \shell_exec($command);
+    }
+}
+
+namespace App\Test\TestCase\View\Helper {
+
+    use App\View\Helper\DownloadsHelper;
+    use Cake\TestSuite\TestCase;
+    use Cake\View\View;
+
+    class DownloadsHelperTest extends TestCase {
+
+        public $DownloadsHelper;
+
+        public static $files = null;
+
+        public function setUp() {
+            parent::setUp();
+            $View = new View();
+            $this->DownloadsHelper = new DownloadsHelper($View);
+        }
+
+        public function tearDown() {
+            self::$files = null;
+            unset($this->DownloadsHelper);
+            parent::tearDown();
+        }
+
+        public function testCreateOptions_InvalidBasename() {
+            $options = $this->DownloadsHelper->createOptions('foobar');
+
+            $this->assertEquals(1, count($options));
+            $this->assertEquals('All languages', $options[0]['language']);
+        }
+
+        public function filenameProvider () {
+            return [
+                ['sentences'],
+                ['sentences_detailed'],
+                ['sentences_CC0']
+            ];
+        }
+
+        /**
+         * @dataProvider filenameProvider
+         **/
+        public function testCreateOptions_ValidBasename($basename) {
+            self::$files = "eng/eng_$basename.tar.bz2\n" .
+                           "fra/fra_$basename.tar.bz2\n" .
+                           "jpn/jpn_$basename.tar.bz2\n";
+
+            $options = $this->DownloadsHelper->createOptions($basename);
+
+            $this->assertEquals(4, count($options));
+            $this->assertEquals(
+                $this->DownloadsHelper::DOWNLOAD_URL . "/$basename.tar.bz2",
+                $options[0]['url']
+            );
+            $this->assertEquals(
+                $this->DownloadsHelper::DOWNLOAD_URL . "/per_language/eng/eng_$basename.tar.bz2",
+                $options[1]['url']
+            );
+            $this->assertEquals('Japanese', $options[3]['language']);
+        }
+
+        /**
+         * @dataProvider filenameProvider
+         **/
+        public function testCreateOptions_NoPerLanguageFilesAvailable($basename) {
+            self::$files = "\n";
+
+            $options = $this->DownloadsHelper->createOptions($basename);
+
+            $this->assertEquals(1, count($options));
+            $this->assertEquals('All languages', $options[0]['language']);
+        }
+    }
+}

--- a/tests/TestCase/View/Helper/DownloadsHelperTest.php
+++ b/tests/TestCase/View/Helper/DownloadsHelperTest.php
@@ -38,8 +38,7 @@ namespace App\Test\TestCase\View\Helper {
         public function testCreateOptions_InvalidBasename() {
             $options = $this->DownloadsHelper->createOptions('foobar');
 
-            $this->assertEquals(1, count($options));
-            $this->assertEquals('All languages', $options[0]['language']);
+            $this->assertTrue(empty($options));
         }
 
         public function filenameProvider () {
@@ -80,8 +79,7 @@ namespace App\Test\TestCase\View\Helper {
 
             $options = $this->DownloadsHelper->createOptions($basename);
 
-            $this->assertEquals(1, count($options));
-            $this->assertEquals('All languages', $options[0]['language']);
+            $this->assertTrue(empty($options));
         }
 
         public function fileFormatProvider () {

--- a/tests/TestCase/View/Helper/DownloadsHelperTest.php
+++ b/tests/TestCase/View/Helper/DownloadsHelperTest.php
@@ -38,7 +38,11 @@ namespace App\Test\TestCase\View\Helper {
         public function testCreateOptions_InvalidBasename() {
             $options = $this->DownloadsHelper->createOptions('foobar');
 
-            $this->assertTrue(empty($options));
+            $this->assertEquals(1, count($options));
+            $this->assertEquals(
+                $this->DownloadsHelper::DOWNLOAD_URL . "/foobar.tar.bz2",
+                $options[0]['url']
+            );
         }
 
         public function filenameProvider () {
@@ -79,7 +83,11 @@ namespace App\Test\TestCase\View\Helper {
 
             $options = $this->DownloadsHelper->createOptions($basename);
 
-            $this->assertTrue(empty($options));
+            $this->assertEquals(1, count($options));
+            $this->assertEquals(
+                $this->DownloadsHelper::DOWNLOAD_URL . "/$basename.tar.bz2",
+                $options[0]['url']
+            );
         }
 
         public function fileFormatProvider () {

--- a/tests/TestCase/View/Helper/DownloadsHelperTest.php
+++ b/tests/TestCase/View/Helper/DownloadsHelperTest.php
@@ -83,5 +83,26 @@ namespace App\Test\TestCase\View\Helper {
             $this->assertEquals(1, count($options));
             $this->assertEquals('All languages', $options[0]['language']);
         }
+
+        public function fileFormatProvider () {
+            return [
+                'empty fields' => [[], ''],
+                'one field' => [['id'], '<span class="param">id</span>'],
+                'two fields' => [
+                    ['id', 'lang'],
+                    '<span class="param">id</span>' .
+                    '<span class="symbol">[tab]</span>' .
+                    '<span class="param">lang</span>'
+                ]
+            ];
+        }
+
+        /**
+         * @dataProvider fileFormatProvider
+         **/
+        public function testFileFormat($fields, $expected) {
+            $result = $this->DownloadsHelper->fileFormat($fields);
+            $this->assertEquals($expected, $result);
+        }
     }
 }

--- a/webroot/css/pages/downloads.css
+++ b/webroot/css/pages/downloads.css
@@ -35,5 +35,6 @@ dt {
 
 .symbol {
     color: #97BC5C;
+    padding: 0 0.5ch;
 }
 

--- a/webroot/css/pages/downloads.css
+++ b/webroot/css/pages/downloads.css
@@ -35,6 +35,14 @@ dt {
 
 .symbol {
     color: #97BC5C;
-    padding: 0 0.5ch;
+    padding: 0 0.5em;
 }
 
+.file-selection {
+    margin: 0;
+}
+
+.file-selection md-select-value {
+    min-width: 200px;
+    margin-left: 0.5em;
+}

--- a/webroot/js/responsive/app.module.js
+++ b/webroot/js/responsive/app.module.js
@@ -35,6 +35,11 @@
                 return "";
             };
         })
+        .filter('filename', function() {
+            return function(input) {
+                return input.substring(input.lastIndexOf('/') + 1);
+            };
+        })
         // https://stackoverflow.com/questions/28851893/angularjs-textaera-enter-key-submit-form-with-autocomplete
         .directive('ngEnter', function() {
             return function(scope, element, attrs) {


### PR DESCRIPTION
As discussed on #1729 here's one possible way to serve single language exports.

I don't think it's necessary to split both `sentences.csv` and `sentences_detailed.csv` so I've chosen the latter because it is a superset of the former.

Even if we decide to not use this implementation we should still change line 7 and line 10:
- `ROOT` is defined on line 5 so we should use it on line 7
- `var/tmp` is also used by `systemd` so we should just move the `csv` files we've created