### PR TITLE
Add charset declaration at the beginning of layout.css

### DIFF
--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -19,6 +19,7 @@ cachePath = WEBROOT/cache_css/
 filters[] = CssMinFilter
 
 [layout.css]
+files[] = charset.css
 files[] = angular-material.min.css
 files[] = layouts/default.css
 files[] = layouts/elements.css

--- a/webroot/css/charset.css
+++ b/webroot/css/charset.css
@@ -1,0 +1,1 @@
+@charset "utf-8";


### PR DESCRIPTION
This PR addresses #2039 

`layout.css` contains Unicode characters so we need to declare the encoding of that file to ensure that all clients will interpret these characters correctly.