### PR TITLE
Correct time of exports given on the download page

### DIFF
--- a/src/Template/Pages/downloads.ctp
+++ b/src/Template/Pages/downloads.ctp
@@ -57,8 +57,8 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Download sentences'
         <p>
             <?php
             echo __(
-                'The files provided here are updated every <strong>Saturday at 9 a.m.</strong> '.
-                '(GMT).'
+                'The files provided here are updated every <strong>Saturday at 6:30 a.m.</strong> '.
+                '(UTC).'
             );
             ?>
         </p>


### PR DESCRIPTION
This small PR modifies the message giving the time of the exported files available on the download page, to fix #1920.