### PR TITLE
Remove obsolete 'time' option for cache

### DIFF
--- a/src/Template/Audio/index.ctp
+++ b/src/Template/Audio/index.ctp
@@ -32,10 +32,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
 <div id="annexe_content">
     <?= $this->element('audio_stats',
             [ 'stats' => $stats ],
-            [ 'cache' => [
-                'time' => '+6 hours',
-                'key'  => 'audio_stats_'.Configure::read('Config.language')
-            ]]
+            [ 'cache' => [ 'key'  => 'audio_stats_'.Configure::read('Config.language') ]]
     ); ?>
 </div>
 

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -84,10 +84,7 @@ use Cake\Core\Configure;
             && $selectedLanguageTo == 'und'
             && empty($query)
             && !$this->Languages->preferredLanguageFilter()) {
-            $cache = [
-                'time' => '+1 day',
-                'key' => 'search_bar_'.Configure::read('Config.language'),
-            ];
+            $cache = [ 'key' => 'search_bar_'.Configure::read('Config.language') ];
         } else {
             $cache = null;
         }
@@ -97,10 +94,7 @@ use Cake\Core\Configure;
         );
     } else {
         echo $this->element('short_description', [], [
-            'cache' => [
-                'time' => '+1 day',
-                'key' => 'short_description_'.Configure::read('Config.language')
-            ]
+            'cache' => [ 'key' => 'short_description_'.Configure::read('Config.language') ]
         ]);
     }
     ?>

--- a/src/Template/Pages/index.ctp
+++ b/src/Template/Pages/index.ctp
@@ -47,10 +47,7 @@ $moreCommentsUrl = $this->Url->build([
                   'numberOfLanguages' => $numberOfLanguages,
                   'numSentences,' => $numSentences,
                 ],
-                [ 'cache' => [
-                    'time' => '+15 minutes',
-                    'key' => 'homepage_stats_'.Configure::read('Config.language')
-                ]]
+                [ 'cache' => [ 'key' => 'homepage_stats_'.Configure::read('Config.language') ]]
         ); ?>
     </div>
         

--- a/src/Template/Pages/index_for_guests.ctp
+++ b/src/Template/Pages/index_for_guests.ctp
@@ -100,10 +100,7 @@ $registerUrl = $this->Url->build(
                   'numberOfLanguages' => $numberOfLanguages,
                   'numSentences' => $numSentences,
                 ],
-                [ 'cache' => [
-                    'time' => '+15 minutes',
-                    'key' => 'homepage_stats_'.Configure::read('Config.language')
-                ]]
+                [ 'cache' => [ 'key' => 'homepage_stats_'.Configure::read('Config.language') ]]
         ); ?>
     </div>
 </div>

--- a/src/Template/Stats/sentences_by_language.ctp
+++ b/src/Template/Stats/sentences_by_language.ctp
@@ -33,10 +33,7 @@ $max = $stats[0]['sentences'];
 <div id="annexe_content">
     <?= $this->element('audio_stats',
         [ 'stats' => $audioStats ],
-        [ 'cache' => [
-            'time'=> '+6 hours',
-            'key'=> Configure::read('Config.language')
-        ]]
+        [ 'cache' => [ 'key' => Configure::read('Config.language') ]]
     ); ?>
 </div>
 


### PR DESCRIPTION
CakePHP 3 doesn't use the `time` option for caching view elements anymore.