### PR TITLE
Rework the Activity timeline page

### DIFF
--- a/docs/database/triggers/last_contributions_triggers.sql
+++ b/docs/database/triggers/last_contributions_triggers.sql
@@ -50,20 +50,36 @@ FOR EACH ROW BEGIN
       SELECT count FROM (SELECT count(*) as count from last_contributions) AS t
     )
     ORDER BY id LIMIT 1;
+  END IF;
 
-    -- Update contributions stats
-    IF NEW.action = "insert" THEN
-
-      SET @statId = (SELECT id FROM contributions_stats WHERE `date` = CURDATE());
+  -- Update contributions_stats
+  IF NEW.type != "license" AND NEW.action != "update" THEN
+    -- If the deleted sentence was added today, decrease today's "insert" counter
+    IF NEW.type = "sentence" AND NEW.action = "delete" THEN
+      SET @addedTodayId = (
+        SELECT id FROM contributions
+        WHERE sentence_id = NEW.sentence_id AND type = "sentence" AND action = "insert" AND DATE(datetime) = CURDATE()
+      );
+      IF @addedTodayId IS NOT NULL THEN
+        SET @toUpdateId = (
+          SELECT id FROM contributions_stats
+          WHERE `date` = CURDATE() AND `type` = NEW.type AND `action` = "insert"
+        );
+        UPDATE contributions_stats SET sentences = sentences - 1 WHERE id = @toUpdateId;
+      END IF;
+    END IF;
+    IF @addedTodayId IS NULL THEN
+      SET @statId = (
+        SELECT id FROM contributions_stats
+        WHERE `date` = CURDATE() AND `type` = NEW.type AND `action` = NEW.action
+      );
       IF @statId IS NULL THEN
         INSERT INTO contributions_stats(`date`, `sentences`, `action`, `type`)
         VALUES (CURDATE(), 1, NEW.action, NEW.type);
       ELSE
-        UPDATE contributions_stats SET sentences = sentences +1 WHERE id = @statId;
+        UPDATE contributions_stats SET sentences = sentences + 1 WHERE id = @statId;
       END IF;
-
     END IF;
-
   END IF;
 
 END;
@@ -78,11 +94,11 @@ FOR EACH ROW BEGIN
   IF NEW.type = "sentence" THEN
 
     -- The following code may cause problems in future if there are
-    -- columns, in the last_contributions table, that would 
+    -- columns, in the last_contributions table, that would
     -- be expected to be updated.
     --
-    -- The code below only updates the sentence_lang column, 
-    -- ignoring other columns. Worryingly, this behaviour may have to 
+    -- The code below only updates the sentence_lang column,
+    -- ignoring other columns. Worryingly, this behaviour may have to
     -- change according to future issues in the GitHub issue tracker.
     UPDATE last_contributions
       SET sentence_lang=NEW.sentence_lang

--- a/src/Command/FillContributionsStatsCommand.php
+++ b/src/Command/FillContributionsStatsCommand.php
@@ -1,0 +1,79 @@
+<?php
+namespace App\Command;
+
+use Cake\Console\Arguments;
+use Cake\Console\Command;
+use Cake\Console\ConsoleIo;
+use Cake\ORM\TableRegistry;
+use \Datetime;
+
+class FillContributionsStatsCommand extends Command
+{
+    public function initialize()
+    {
+        parent::initialize();
+        $this->loadModel('Contributions');
+        $this->loadModel('ContributionsStats');
+    }
+
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        // Initialize
+        $firstDay = new DateTime('2007-09-30');
+        $today = new DateTime('now');
+
+        for ($day = $firstDay; $day <= $today; $day->modify('+1 day')) {
+            $date = $day->format('Y-m-d');
+            $stats[$date] = [
+                ['sentence', 'insert', 0],
+                ['sentence', 'delete', 0],
+                ['link', 'insert', 0],
+                ['link', 'delete', 0]
+            ];
+
+            $inserted[$date] = [];
+        }
+
+        // Fetch
+        $contributions = $this->Contributions->find()
+                              ->where(["type !=" => "license", "action !=" => "update"])
+                              ->order(["datetime" => "ASC"]);
+        $contributions->disableBufferedResults();
+        foreach ($contributions as $contribution) {
+            if(!is_null($contribution->datetime)) {
+                $date = $contribution->datetime->format('Y-m-d');
+                if ($contribution->type === 'sentence' && $contribution->action === 'insert') {
+                    $stats[$date][0][2] += 1;
+                    array_push($inserted[$date], $contribution->sentence_id);
+                } elseif ($contribution->type === 'sentence' && $contribution->action === 'delete') {
+                    if (in_array($contribution->sentence_id, $inserted[$date])) {
+                        $stats[$date][0][2] -= 1;
+                    } else {
+                        $stats[$date][1][2] += 1;
+                    }
+                } elseif ($contribution->type === 'link' && $contribution->action === 'insert') {
+                        $stats[$date][2][2] += 1;
+                } elseif ($contribution->type === 'link' && $contribution->action === 'delete') {
+                        $stats[$date][3][2] += 1;
+                }
+            }
+        }
+
+        // Truncate table and Fill
+        $contributionsStats = TableRegistry::getTableLocator()->get('ContributionsStats');
+        $contributionsStats->deleteAll([]);
+        foreach ($stats as $date => $dailyStat) {
+            foreach ($dailyStat as $unitRecord) {
+                if ($unitRecord[2] != 0) {
+                    $record = $contributionsStats->newEntity([
+                        'date' => $date,
+                        'type' => $unitRecord[0],
+                        'action' => $unitRecord[1],
+                        'sentences' => $unitRecord[2]
+                    ]);
+                    $contributionsStats->save($record);
+                }
+            }
+        }
+    }
+}

--- a/src/Model/Table/ContributionsStatsTable.php
+++ b/src/Model/Table/ContributionsStatsTable.php
@@ -96,7 +96,6 @@ class ContributionsStatsTable extends Table
             foreach ($stats as $date => $stat) {
                 $stats[$date]['total'] = array_sum($stats[$date]);
             }
-
             return $stats;
         }
     }

--- a/src/Model/Table/ContributionsStatsTable.php
+++ b/src/Model/Table/ContributionsStatsTable.php
@@ -90,10 +90,14 @@ class ContributionsStatsTable extends Table
             }
         }
 
-        foreach ($stats as $date => $stat) {
-            $stats[$date]['total'] = array_sum($stats[$date]);
-        }
+        if (!isset($stats)) {
+            return [];
+        } else {
+            foreach ($stats as $date => $stat) {
+                $stats[$date]['total'] = array_sum($stats[$date]);
+            }
 
-        return $stats;
+            return $stats;
+        }
     }
 }

--- a/src/Model/Table/ContributionsStatsTable.php
+++ b/src/Model/Table/ContributionsStatsTable.php
@@ -53,9 +53,7 @@ class ContributionsStatsTable extends Table
 
         $conditions = [
             'date >=' => $startDate,
-            'date <' => $endDate,
-            'type' => 'sentence',
-            'action' => 'insert'
+            'date <' => $endDate
         ];
 
         if ($lang) {
@@ -64,17 +62,38 @@ class ContributionsStatsTable extends Table
             $conditions['lang IS'] = null;
         }
 
-        return $this->find()
+        $contributionsStats = $this->find()
             ->where($conditions)
             ->select([
                 'lang',
                 'sentences',
+                'type',
+                'action',
                 'date',
             ])
             ->order([
-                'date' => 'ASC', 
-                'sentences' => 'DESC'
+                'date' => 'ASC',
+                'type' => 'ASC'
             ])
             ->toList();
+
+        // The number of "link" sentences is two times what we want
+        foreach ($contributionsStats as $contributionsStat) {
+            if ($contributionsStat->type === 'sentence' && $contributionsStat->action === 'insert') {
+                $stats[$contributionsStat->date]['added'] = $contributionsStat->sentences;
+            } elseif ($contributionsStat->type === 'sentence' && $contributionsStat->action === 'delete') {
+                    $stats[$contributionsStat->date]['deleted'] = $contributionsStat->sentences;
+            } elseif ($contributionsStat->type === 'link' && $contributionsStat->action === 'insert') {
+                    $stats[$contributionsStat->date]['linked'] = floor($contributionsStat->sentences / 2);
+            } elseif ($contributionsStat->type === 'link' && $contributionsStat->action === 'delete') {
+                    $stats[$contributionsStat->date]['unlinked'] = floor($contributionsStat->sentences / 2);
+            }
+        }
+
+        foreach ($stats as $date => $stat) {
+            $stats[$date]['total'] = array_sum($stats[$date]);
+        }
+
+        return $stats;
     }
 }

--- a/src/Model/Table/ContributionsTable.php
+++ b/src/Model/Table/ContributionsTable.php
@@ -208,7 +208,7 @@ class ContributionsTable extends Table
 
         $query = $this->excludeBots($query);
 
-        if ($lang == 'und'|| empty($lang)) {
+        if ($lang == 'und' || empty($lang)) {
             $this->setTable('last_contributions');
         } else {
             $query = $query->where(['sentence_lang' => $lang]);

--- a/src/Template/Contributions/activity_timeline.ctp
+++ b/src/Template/Contributions/activity_timeline.ctp
@@ -134,8 +134,6 @@ if (!empty($stats)) {
         echo $this->Html->tag('td', $formattedDate, array('class' => 'date'));
         echo $this->Html->tag('td', $bar, array('class' => 'bar'));
         echo '</tr>';
-
-
     }
     echo '</table>';
 

--- a/src/Template/Contributions/activity_timeline.ctp
+++ b/src/Template/Contributions/activity_timeline.ctp
@@ -45,7 +45,9 @@ $selectedMonth = format(
 );
 
 $maxWidth = 400;
-$maxTotal = max(array_column($stats, 'total'));
+if (!empty($stats)) {
+    $maxTotal = max(array_column($stats, 'total'));
+}
 ?>
 
 <div id="annexe_content">

--- a/src/Template/Contributions/activity_timeline.ctp
+++ b/src/Template/Contributions/activity_timeline.ctp
@@ -61,8 +61,7 @@ if (!empty($stats)) {
 <div id="main_content">
     <div class="section md-whiteframe-1dp">
     <h2><?php
-        echo __('Activity timeline') . ' &#8212; ' .
-            format(__('{month} {year}'), array('month' => $monthName, 'year' => $year));
+        echo format(__('Activity timeline — {month} {year}'), array('month' => $monthName, 'year' => $year));
     ?></h2>
     <p>
     <?php

--- a/src/Template/Contributions/activity_timeline.ctp
+++ b/src/Template/Contributions/activity_timeline.ctp
@@ -43,32 +43,32 @@ $selectedMonth = format(
     __('{month} {year}'),
     array('month' => $monthName, 'year' => $year)
 );
- 
-$maxWidth = 400;
-$maxTotal = 0;
 
-foreach ($stats as $stat) {
-    if ($stat->sentences > $maxTotal) {
-        $maxTotal = $stat->sentences;
-    }
-}
+$maxWidth = 400;
+$maxTotal = max(array_column($stats, 'total'));
 ?>
 
 <div id="annexe_content">
-    <?php 
+    <?php
     echo $this->element(
-        'calendar', 
+        'calendar',
         array(
             'currentYear' => $year,
             'currentMonth' => $month
         )
-    ); 
+    );
     ?>
 </div>
 
 <div id="main_content">
     <div class="section md-whiteframe-1dp">
     <h2><?php echo $selectedMonth; ?></h2>
+    <div id="timeline_legend" layout="row" layout-xs="column" layout-align="space-around">
+        <div class="added">Number of added sentences</div>
+        <div class="linked">Number of linked sentences</div>
+        <div class="unlinked">Number of unlinked sentences</div>
+        <div class="deleted">Number of deleted sentences</div>
+    </div>
 
     <?php
     echo '<table id="timeline">';
@@ -77,15 +77,33 @@ foreach ($stats as $stat) {
     $totalSentences = 0;
     $numberOfDays = 0;
 
-    foreach ($stats as $stat) {
-        
-        $numSentences = $stat->sentences;
-        $date = $stat->date;
-
-        $width = ($numSentences / $maxTotal) * 100;
-        $bar = $this->Html->div('logs_stats', null,
-            array('style' => 'width:'.$width.'%')
-        );
+    foreach ($stats as $date => $stat) {
+        $numSentences = $stat['total'];
+        $bar = '';
+        if(isset($stat['added'])){
+            $width = ($stat['added'] / $maxTotal) * 100;
+            $bar .= $this->Html->div('logs_stats added', $stat['added'],
+                array('style' => 'width:'.$width.'%')
+            );
+        }
+        if(isset($stat['linked'])){
+            $width = ($stat['linked'] / $maxTotal) * 100;
+            $bar .= $this->Html->div('logs_stats linked', $stat['linked'],
+                array('style' => 'width:'.$width.'%')
+            );
+        }
+        if(isset($stat['unlinked'])){
+            $width = ($stat['unlinked'] / $maxTotal) * 100;
+            $bar .= $this->Html->div('logs_stats unlinked', $stat['unlinked'],
+                array('style' => 'width:'.$width.'%')
+            );
+        }
+        if(isset($stat['deleted'])){
+            $width = ($stat['deleted'] / $maxTotal) * 100;
+            $bar .= $this->Html->div('logs_stats deleted', $stat['deleted'],
+                array('style' => 'width:'.$width.'%')
+            );
+        }
 
         $formattedDate = $this->Time->i18nFormat($date, [IntlDateFormatter::SHORT, IntlDateFormatter::NONE]);
         echo '<tr>';
@@ -97,13 +115,13 @@ foreach ($stats as $stat) {
         $totalSentences += $numSentences;
     }
     echo '</table>';
-    
+
     if( $month == date('m') && $year == date('Y')) {
         $numberOfDays = date('d');
     } else if (($year < date('Y')) || ($year == date('Y') && $month < date('m'))){
         $numberOfDays = cal_days_in_month(CAL_GREGORIAN, $month, $year);
     }
-    
+
     if($numberOfDays > 0){
         $dailyAverage = round($totalSentences / $numberOfDays,1);
         $averageString = format(
@@ -117,7 +135,7 @@ foreach ($stats as $stat) {
         );
         echo $this->Html->div("daily-average", $averageString);
     }
-    
+
     ?>
     </div>
 </div>

--- a/src/Template/Contributions/activity_timeline.ctp
+++ b/src/Template/Contributions/activity_timeline.ctp
@@ -102,27 +102,27 @@ if (!empty($stats)) {
     <?php
     foreach ($stats as $date => $stat) {
         $bar = '';
-        if(isset($stat['added'])){
+        if(isset($stat['added']) && $stat['added'] > 0){
             $width = ($stat['added'] / $maxTotal) * 100;
             $bar .= $this->Html->div('logs_stats added', '+' . $stat['added'],
                 array('style' => 'width:'.$width.'%')
             );
             $totalSentences += $stat['added'];
         }
-        if(isset($stat['linked'])){
+        if(isset($stat['linked']) && $stat['linked'] > 0){
             $width = ($stat['linked'] / $maxTotal) * 100;
             $bar .= $this->Html->div('logs_stats linked', '+' . $stat['linked'],
                 array('style' => 'width:'.$width.'%')
             );
             $totalLinks += $stat['linked'];
         }
-        if(isset($stat['unlinked'])){
+        if(isset($stat['unlinked']) && $stat['unlinked'] > 0){
             $width = ($stat['unlinked'] / $maxTotal) * 100;
             $bar .= $this->Html->div('logs_stats unlinked', '-' . $stat['unlinked'],
                 array('style' => 'width:'.$width.'%')
             );
         }
-        if(isset($stat['deleted'])){
+        if(isset($stat['deleted']) && $stat['deleted'] > 0){
             $width = ($stat['deleted'] / $maxTotal) * 100;
             $bar .= $this->Html->div('logs_stats deleted', '-' . $stat['deleted'],
                 array('style' => 'width:'.$width.'%')

--- a/src/Template/Contributions/activity_timeline.ctp
+++ b/src/Template/Contributions/activity_timeline.ctp
@@ -62,45 +62,67 @@ $maxTotal = max(array_column($stats, 'total'));
 
 <div id="main_content">
     <div class="section md-whiteframe-1dp">
-    <h2><?php echo $selectedMonth; ?></h2>
-    <div id="timeline_legend" layout="row" layout-xs="column" layout-align="space-around">
-        <div class="added">Number of added sentences</div>
-        <div class="linked">Number of linked sentences</div>
-        <div class="unlinked">Number of unlinked sentences</div>
-        <div class="deleted">Number of deleted sentences</div>
-    </div>
+    <h2><?php echo __('Activity timeline') . ' - ' . $selectedMonth; ?></h2>
+    <p>
+    <?php
+        if ($month == date('m') && $year == date('Y')) {
+            echo __('Statistics about the number of contributions over this month.');
+        } else {
+            echo format(__('Statistics about the number of contributions over {$selectedMonth}.'),
+                        array('$selectedMonth' => $selectedMonth));
+        }
+    ?>
+    </p>
 
     <?php
     echo '<table id="timeline">';
 
     $currentDate = null;
     $totalSentences = 0;
+    $totalLinks = 0;
     $numberOfDays = 0;
+    ?>
 
+    <thead>
+        <tr>
+            <td class="date"><?= __('Day'); ?></td>
+            <td>
+                <div layout="row">
+                    <div flex="25" class="added"><?= __('Sentences added'); ?></div>
+                    <div flex="25" class="linked"><?= __('Links added'); ?></div>
+                    <div flex="25" class="unlinked"><?= __('Links removed'); ?></div>
+                    <div flex="25" class="deleted"><?= __('Sentences removed'); ?></div>
+                </div>
+            </td>
+        </tr>
+    </thead>
+
+    <?php
     foreach ($stats as $date => $stat) {
-        $numSentences = $stat['total'];
         $bar = '';
         if(isset($stat['added'])){
             $width = ($stat['added'] / $maxTotal) * 100;
-            $bar .= $this->Html->div('logs_stats added', $stat['added'],
+            $bar .= $this->Html->div('logs_stats added', '+' . $stat['added'],
                 array('style' => 'width:'.$width.'%')
             );
+            $totalSentences += $stat['added'];
         }
         if(isset($stat['linked'])){
             $width = ($stat['linked'] / $maxTotal) * 100;
-            $bar .= $this->Html->div('logs_stats linked', $stat['linked'],
+            $bar .= $this->Html->div('logs_stats linked', '+' . $stat['linked'],
                 array('style' => 'width:'.$width.'%')
             );
+            $totalLinks += $stat['linked'];
         }
         if(isset($stat['unlinked'])){
             $width = ($stat['unlinked'] / $maxTotal) * 100;
-            $bar .= $this->Html->div('logs_stats unlinked', $stat['unlinked'],
+            $bar .= $this->Html->div('logs_stats unlinked', '-' . $stat['unlinked'],
                 array('style' => 'width:'.$width.'%')
             );
         }
         if(isset($stat['deleted'])){
             $width = ($stat['deleted'] / $maxTotal) * 100;
-            $bar .= $this->Html->div('logs_stats deleted', $stat['deleted'],
+            $bar .= $this->Html->div('logs_stats deleted', '-' . $stat['deleted'],
                 array('style' => 'width:'.$width.'%')
             );
         }
@@ -108,11 +130,10 @@ $maxTotal = max(array_column($stats, 'total'));
         $formattedDate = $this->Time->i18nFormat($date, [IntlDateFormatter::SHORT, IntlDateFormatter::NONE]);
         echo '<tr>';
         echo $this->Html->tag('td', $formattedDate, array('class' => 'date'));
-        echo $this->Html->tag('td', $this->Number->format($numSentences), array('class' => 'number'));
         echo $this->Html->tag('td', $bar, array('class' => 'bar'));
         echo '</tr>';
 
-        $totalSentences += $numSentences;
+
     }
     echo '</table>';
 
@@ -123,17 +144,27 @@ $maxTotal = max(array_column($stats, 'total'));
     }
 
     if($numberOfDays > 0){
-        $dailyAverage = round($totalSentences / $numberOfDays,1);
-        $averageString = format(
+        $dailyAverageSentences = round($totalSentences / $numberOfDays,1);
+        $averageSentencesString = format(
             __n(
-                'Daily Average: {n} sentence',
-                'Daily Average: {n} sentences',
-                $dailyAverage,
+                'Daily Average: {n} sentence added',
+                'Daily Average: {n} sentences added',
+                $dailyAverageSentences,
                 true
             ),
-            array('n' => $this->Number->format($dailyAverage))
+            array('n' => $this->Number->format($dailyAverageSentences))
         );
-        echo $this->Html->div("daily-average", $averageString);
+        $dailyAverageLinks = round($totalLinks / $numberOfDays,1);
+        $averageLinksString = format(
+            __n(
+                ', {n} link added',
+                ', {n} links added',
+                $dailyAverageLinks,
+                true
+            ),
+            array('n' => $this->Number->format($dailyAverageLinks))
+        );
+        echo $this->Html->div("daily-average", $averageSentencesString . $averageLinksString);
     }
 
     ?>

--- a/src/Template/Contributions/activity_timeline.ctp
+++ b/src/Template/Contributions/activity_timeline.ctp
@@ -132,7 +132,8 @@ if (!empty($stats)) {
         $formattedDate = $this->Time->i18nFormat($date, [IntlDateFormatter::SHORT, IntlDateFormatter::NONE]);
         echo '<tr>';
         echo $this->Html->tag('td', $formattedDate, array('class' => 'date'));
-        echo $this->Html->tag('td', $bar, array('class' => 'bar'));
+        $contents = '<div layout="row">' . $bar . '</div>';
+        echo $this->Html->tag('td', $contents, array('class' => 'bar'));
         echo '</tr>';
     }
     echo '</table>';

--- a/src/Template/Contributions/activity_timeline.ctp
+++ b/src/Template/Contributions/activity_timeline.ctp
@@ -39,10 +39,6 @@
 $this->set('title_for_layout', $this->Pages->formatTitle(__("Activity timeline")));
 
 $monthName = $this->Date->monthName($month);
-$selectedMonth = format(
-    __('{month} {year}'),
-    array('month' => $monthName, 'year' => $year)
-);
 
 $maxWidth = 400;
 if (!empty($stats)) {
@@ -64,7 +60,10 @@ if (!empty($stats)) {
 
 <div id="main_content">
     <div class="section md-whiteframe-1dp">
-    <h2><?php echo __('Activity timeline') . ' - ' . $selectedMonth; ?></h2>
+    <h2><?php
+        echo __('Activity timeline') . ' &#8212; ' .
+            format(__('{month} {year}'), array('month' => $monthName, 'year' => $year));
+    ?></h2>
     <p>
     <?php
         if ($month == date('m') && $year == date('Y')) {

--- a/src/Template/Contributions/activity_timeline.ctp
+++ b/src/Template/Contributions/activity_timeline.ctp
@@ -70,8 +70,8 @@ if (!empty($stats)) {
         if ($month == date('m') && $year == date('Y')) {
             echo __('Statistics about the number of contributions over this month.');
         } else {
-            echo format(__('Statistics about the number of contributions over {$selectedMonth}.'),
-                        array('$selectedMonth' => $selectedMonth));
+            echo format(__('Statistics about the number of contributions over {month} {year}.'),
+                        array('month' => $monthName, 'year' => $year));
         }
     ?>
     </p>

--- a/tests/Fixture/ContributionsFixture.php
+++ b/tests/Fixture/ContributionsFixture.php
@@ -1768,5 +1768,61 @@ class ContributionsFixture extends TestFixture {
 			'type' => 'link',
 			'id' => '123'
 		),
+		array(
+			'sentence_id' => '55',
+			'sentence_lang' => NULL,
+			'translation_id' => '57',
+			'translation_lang' => NULL,
+			'script' => NULL,
+			'text' => '',
+			'action' => 'delete',
+			'user_id' => '7',
+			'datetime' => '2018-04-12 12:13:19',
+			'ip' => '127.0.0.1',
+			'type' => 'link',
+			'id' => '124'
+		),
+		array(
+			'sentence_id' => '57',
+			'sentence_lang' => 'jpn',
+			'translation_id' => '55',
+			'translation_lang' => NULL,
+			'script' => NULL,
+			'text' => '',
+			'action' => 'delete',
+			'user_id' => '7',
+			'datetime' => '2018-04-12 12:13:19',
+			'ip' => '127.0.0.1',
+			'type' => 'link',
+			'id' => '125'
+		),
+		array(
+			'sentence_id' => '56',
+			'sentence_lang' => 'jpn',
+			'translation_id' => NULL,
+			'translation_lang' => NULL,
+			'script' => NULL,
+			'text' => '電話借りてもいい？',
+			'action' => 'delete',
+			'user_id' => '4',
+			'datetime' => '2018-04-12 12:23:19',
+			'ip' => '127.0.0.1',
+			'type' => 'sentence',
+			'id' => '126'
+		),
+		array(
+			'sentence_id' => '29',
+			'sentence_lang' => 'eng',
+			'translation_id' => NULL,
+			'translation_lang' => NULL,
+			'script' => NULL,
+			'text' => 'The log of this sentence shows two creation records.',
+			'action' => 'delete',
+			'user_id' => '4',
+			'datetime' => '2018-04-12 12:23:19',
+			'ip' => '127.0.0.1',
+			'type' => 'sentence',
+			'id' => '127'
+		),
 	);
 }

--- a/tests/Fixture/ContributionsStatsFixture.php
+++ b/tests/Fixture/ContributionsStatsFixture.php
@@ -521,6 +521,38 @@ class ContributionsStatsFixture extends TestFixture
                 'action' => 'insert',
                 'type' => 'sentence'
             ],
+            [
+                'id' => 3121,
+                'date' => '2016-11-01 00:00:00',
+                'lang' => null,
+                'sentences' => 5000,
+                'action' => 'insert',
+                'type' => 'link'
+            ],
+            [
+                'id' => 3122,
+                'date' => '2016-11-01 00:00:00',
+                'lang' => null,
+                'sentences' => 200,
+                'action' => 'delete',
+                'type' => 'link'
+            ],
+            [
+                'id' => 3123,
+                'date' => '2016-11-01 00:00:00',
+                'lang' => null,
+                'sentences' => 15,
+                'action' => 'delete',
+                'type' => 'sentence'
+            ],
+            [
+                'id' => 3124,
+                'date' => '2016-11-30 00:00:00',
+                'lang' => null,
+                'sentences' => 3000,
+                'action' => 'insert',
+                'type' => 'link'
+            ]
         ];
         parent::init();
     }

--- a/tests/TestCase/Command/FillContributionsStatsTest.php
+++ b/tests/TestCase/Command/FillContributionsStatsTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace App\Test\TestCase\Command;
+
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+use Cake\Console\Command;
+use Cake\ORM\TableRegistry;
+use App\Model\Table\ContributionsStats;
+
+class FillContributionsStatsCommand extends TestCase {
+    use ConsoleIntegrationTestTrait;
+
+    public $fixtures = array(
+        'app.contributions',
+        'app.contributions_stats'
+    );
+
+    function setUp() {
+        parent::setUp();
+        $this->UseCommandRunner();
+        $this->ContributionsStats = TableRegistry::getTableLocator()->get('ContributionsStats');
+    }
+
+    function tearDown() {
+        unset($this->ContributionsStats);
+        parent::tearDown();
+    }
+
+    function testExecute_oldestDateIsCorrect() {
+        $this->exec("fill_contributions_stats");
+
+        $contributionStats = $this->ContributionsStats->find('all')->toList();
+        $this->assertEquals('2014-04-09', $contributionStats[0]->date);
+    }
+
+    function testExecute_numberOfInsertedSentencesIsCorrect() {
+        $this->exec("fill_contributions_stats");
+
+        $insertedSentences = $this->ContributionsStats->find()
+                                   ->where(['date' => '2018-04-12', 'action' => 'insert', 'type' => 'sentence'])
+                                   ->first();
+        // 3 in contributions but 1 delete as well
+        $this->assertEquals(2, $insertedSentences->sentences);
+    }
+
+    function testExecute_numberOfDeletedSentencesIsCorrect() {
+        $this->exec("fill_contributions_stats");
+
+        $deletedSentences = $this->ContributionsStats->find()
+                                   ->where(['date' => '2018-04-12', 'action' => 'delete', 'type' => 'sentence'])
+                                   ->first();
+        // 2 in contributions but 1 was inserted the same day
+        $this->assertEquals(1, $deletedSentences->sentences);
+    }
+
+    function testExecute_numberOfInsertedLinksIsCorrect() {
+        $this->exec("fill_contributions_stats");
+
+        $insertedLinks = $this->ContributionsStats->find()
+                                   ->where(['date' => '2018-04-12', 'action' => 'insert', 'type' => 'link'])
+                                   ->first();
+        $this->assertEquals(4, $insertedLinks->sentences);
+    }
+
+    function testExecute_numberOfDeletedLinksIsCorrect() {
+        $this->exec("fill_contributions_stats");
+
+        $deletedLinks = $this->ContributionsStats->find()
+                                   ->where(['date' => '2018-04-12', 'action' => 'delete', 'type' => 'link'])
+                                   ->first();
+        $this->assertEquals(2, $deletedLinks->sentences);
+    }
+
+    function testExecute_noDeletedLinksWhenNotInContributions() {
+        $this->exec("fill_contributions_stats");
+
+        $deletedLinks = $this->ContributionsStats->find()
+                                   ->where(['date' => '2017-04-13', 'action' => 'delete', 'type' => 'link']);
+        $this->assertEquals(0, $deletedLinks->count());
+    }
+
+    function testExecute_oneInsertDeleted_noInsertAndNoDelete() {
+        $this->exec("fill_contributions_stats");
+
+        $insertedSentences = $this->ContributionsStats->find()
+                                   ->where(['date' => '2014-09-02', 'action' => 'insert', 'type' => 'sentence']);
+        $deletedSentences = $this->ContributionsStats->find()
+                                  ->where(['date' => '2014-09-02', 'action' => 'delete', 'type' => 'sentence']);
+        $this->assertEquals(0, $insertedSentences->count());
+        $this->assertEquals(0, $deletedSentences->count());
+    }
+}

--- a/tests/TestCase/Command/FillContributionsStatsTest.php
+++ b/tests/TestCase/Command/FillContributionsStatsTest.php
@@ -43,7 +43,21 @@ class FillContributionsStatsCommand extends TestCase {
         $this->assertEquals('2014-04-09', $contributionStats[0]->date);
     }
 
-    function testExecute_paramsGiven_ContributionsAreRewritten() {
+    function testExecute_paramsGiven_OneDayContributionsAreRewritten() {
+        $this->exec("fill_contributions_stats -f 2016-06-19 -t 2016-06-19");
+
+        $firstContributionStats = $this->ContributionsStats->find()->order(['id' => 'DESC'])->first();
+        $this->assertEquals('2016-06-19', $firstContributionStats->date);
+    }
+
+    function testExecute_paramsGiven_LastDayOfRewrittenContributionsIsCorrect() {
+        $this->exec("fill_contributions_stats -f 2016-06-19 -t 2016-12-26");
+
+        $firstContributionStats = $this->ContributionsStats->find()->order(['id' => 'DESC'])->first();
+        $this->assertEquals('2016-12-26', $firstContributionStats->date);
+    }
+
+    function testExecute_paramsGiven_FirstDayOfRewrittenContributionsIsCorrect() {
         $this->exec("fill_contributions_stats -f 2016-06-19 -t 2016-12-16");
 
         $firstContributionStats = $this->ContributionsStats->find()->order(['id' => 'DESC'])->first();

--- a/tests/TestCase/Model/Table/ContributionsStatsTableTest.php
+++ b/tests/TestCase/Model/Table/ContributionsStatsTableTest.php
@@ -29,6 +29,18 @@ class ContributionsStatsTableTest extends TestCase {
     public function testGetActivityTimelineStatistics() {
         $result = $this->ContributionsStats->getActivityTimelineStatistics(2016, 11);
         $this->assertEquals(30, count($result));
-        $this->assertEquals('2016-11-01', $result[0]->date);
+        $this->assertEquals(2614, $result['2016-11-01']['added']);
+        $this->assertEquals(2500, $result['2016-11-01']['linked']);
+        $this->assertEquals(100, $result['2016-11-01']['unlinked']);
+        $this->assertEquals(15, $result['2016-11-01']['deleted']);
+        $this->assertEquals(5229, $result['2016-11-01']['total']);
+
+        $this->assertArrayNotHasKey('unlinked', $result['2016-11-30']);
+        $this->assertArrayNotHasKey('deleted', $result['2016-11-30']);
+    }
+
+    public function testGetActivityTimelineStatistics_emptyResult() {
+        $result = $this->ContributionsStats->getActivityTimelineStatistics(2017, 01);
+        $this->assertEquals(0, count($result));
     }
 }

--- a/webroot/css/contributions/activity_timeline.css
+++ b/webroot/css/contributions/activity_timeline.css
@@ -6,7 +6,7 @@
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -49,10 +49,35 @@
 }
 
 #timeline .logs_stats {
-    height: 10px;
+    height: auto;
     border-left: none;
-    background: #4caf50;
-    opacity: 0.4;
+    display: inline-block;
+    text-align: center;
+}
+
+#timeline .added,
+#timeline_legend .added {
+    background: #4caf5066;
+}
+
+#timeline .deleted,
+#timeline_legend .deleted {
+    background: #F4433666;
+}
+
+#timeline .linked,
+#timeline_legend .linked {
+    background: #03a9f466;
+}
+
+#timeline .unlinked,
+#timeline_legend .unlinked {
+    background: #ff980066;
+}
+
+#timeline_legend {
+    text-align: center;
+    margin-bottom:30px;
 }
 
 .daily-average {

--- a/webroot/css/contributions/activity_timeline.css
+++ b/webroot/css/contributions/activity_timeline.css
@@ -33,15 +33,8 @@
 #timeline .date {
     text-align: right;
     color: #545454;
-    padding: 0 10px;
-}
-
-#timeline .number {
-    text-align: center;
-    padding: 0 10px;
-    color: #111;
     border-right: 1px solid #767676;
-    font-weight: bold;
+    padding: 0 10px;
 }
 
 #timeline .bar {
@@ -55,29 +48,30 @@
     text-align: center;
 }
 
-#timeline .added,
-#timeline_legend .added {
+#timeline .added {
     background: #4caf5066;
 }
 
-#timeline .deleted,
-#timeline_legend .deleted {
+#timeline .deleted {
     background: #F4433666;
 }
 
-#timeline .linked,
-#timeline_legend .linked {
+#timeline .linked {
     background: #03a9f466;
 }
 
-#timeline .unlinked,
-#timeline_legend .unlinked {
+#timeline .unlinked {
     background: #ff980066;
 }
 
-#timeline_legend {
+thead {
     text-align: center;
-    margin-bottom:30px;
+    border-bottom: 30px solid white;
+}
+
+thead .added, thead .deleted,
+thead .linked, thead .unlinked {
+    height: 33px;
 }
 
 .daily-average {

--- a/webroot/css/contributions/activity_timeline.css
+++ b/webroot/css/contributions/activity_timeline.css
@@ -26,7 +26,7 @@
 }
 
 #timeline td {
-    padding: 0;
+    padding-bottom: 2px;
     border: 1px solid #FFF;
 }
 
@@ -42,10 +42,10 @@
 }
 
 #timeline .logs_stats {
-    height: auto;
     border-left: none;
     display: inline-block;
     text-align: center;
+    min-width: 30px;
 }
 
 #timeline .added {
@@ -71,7 +71,7 @@ thead {
 
 thead .added, thead .deleted,
 thead .linked, thead .unlinked {
-    height: 33px;
+    min-height: 33px;
 }
 
 .daily-average {


### PR DESCRIPTION
This PR addresses #2144. It should also solves #1882. The page looks like the following 

![image](https://user-images.githubusercontent.com/42261966/76140641-0c8fb580-60a0-11ea-8bab-414b72f11072.png)

I took a screenshot of the Japanese page because the default font is bigger, thus things are displayed a little bit more differently. The original English is "Sentences added".
 
I have the following concerns:

- I wonder if we should to vertically center the text inside the div of the first line (legend). However, I cannot I cannot find satisfying CSS rules. If someone could give a hand here, that'd be nice. Although I'm not sure it would look better if the text is vertically aligned.
- I'm not sure of the English sentence "Statistics about the number of contributions over this month." For month other than the current one, the sentence looks like "Statistics about the number of contributions over February 2020" Maybe @alanfgh could tell me if that's correct English or if I should use something else.   
- Maybe CakePHP (or raw PHP) has a better way to build the stats array than what I did. 

Some technical notes:
- Until version 10.2.3, MariaDB does not support multiple triggers on the same event. I updated the part of the trigger on `last_contributions` that used to take care of filling `contributions_stats`.
- The trigger records `sentence + insert`, `sentence + delete`, `link + insert`, `link + delete`. It ignores the other contributions. For links, the number displayed is half the one recorded in the table.
- The + and - before the numbers seemed strange at first, but once the eye gets used to it, I think that gives a good feeling. The colors are similar to the ones used through Tatoeba. 
- I modified some `height` attributes because of the difference of heights between the default fonts of different languages (i.e. Japanese).
- I set a min-width attribute to be able to distinguish small numbers (like the last line of the screenshot).