### PR TITLE
Allow edition of simplified/traditional scripts in Chinese sentences

### DIFF
--- a/src/Model/Entity/Transcription.php
+++ b/src/Model/Entity/Transcription.php
@@ -37,7 +37,6 @@ class Transcription extends Entity
         'cmn-Hans' => array(
             'Hant' => array(
                 'type' => 'altscript',
-                'readonly' => true,
             ),
             'Latn' => array(
             ),
@@ -45,7 +44,6 @@ class Transcription extends Entity
         'cmn-Hant' => array(
             'Hans' => array(
                 'type' => 'altscript',
-                'readonly' => true,
             ),
             'Latn' => array(
             ),

--- a/src/Model/Table/TranscriptionsTable.php
+++ b/src/Model/Table/TranscriptionsTable.php
@@ -47,7 +47,6 @@ class TranscriptionsTable extends Table
         'cmn-Hans' => array(
             'Hant' => array(
                 'type' => 'altscript',
-                'readonly' => true,
             ),
             'Latn' => array(
             ),
@@ -55,7 +54,6 @@ class TranscriptionsTable extends Table
         'cmn-Hant' => array(
             'Hans' => array(
                 'type' => 'altscript',
-                'readonly' => true,
             ),
             'Latn' => array(
             ),

--- a/tests/Fixture/SentencesFixture.php
+++ b/tests/Fixture/SentencesFixture.php
@@ -765,5 +765,18 @@ class SentencesFixture extends TestFixture {
 			'license' => 'CC BY 2.0 FR',
 			'based_on_id' => '55',
 		),
+		array(
+			'id' => '58',
+			'lang' => 'uzb',
+			'text' => 'Ишингни қил!',
+			'correctness' => '0',
+			'user_id' => '7',
+			'created' => '2020-01-22 22:22:22',
+			'modified' => '2020-01-22 22:22:22',
+			'script' => 'Cyrl',
+			'hash' => "rjskda\0\0\0\0\0\0\0\0\0\0",
+			'license' => 'CC BY 2.0 FR',
+			'based_on_id' => '0',
+		),
 	);
 }

--- a/tests/Fixture/TranscriptionsFixture.php
+++ b/tests/Fixture/TranscriptionsFixture.php
@@ -51,5 +51,15 @@ class TranscriptionsFixture extends TestFixture {
 			'created' => '2014-10-18 17:43:32',
 			'modified' => '2014-10-18 17:43:32'
 		),
+		array(
+			'id' => 4,
+			'sentence_id' => 58,
+			'script' => 'Latn',
+			'text' => 'Ishingni qil!',
+			'user_id' => null,
+			'needsReview' => 0,
+			'created' => '2020-01-22 22:22:22',
+			'modified' => '2020-01-22 22:22:22'
+		),
 	);
 }

--- a/tests/TestCase/Lib/AutotranscriptionTest.php
+++ b/tests/TestCase/Lib/AutotranscriptionTest.php
@@ -109,6 +109,28 @@ class AutotranscriptionTest extends TestCase {
         $this->assertInvalidTranscriptions('cmn', 'Hant', 'Latn', $testBad);
     }
 
+    function testHansHantValidation() {
+        $testGood = array(
+            '門開著嗎？' => array(
+                '门开着吗？',
+                '門開著嗎？',
+            ),
+        );
+        $testBad = array(
+            '門開著嗎？' => array(
+                '门开着',
+                '门开着吗',
+                '门开着吗吗',
+                '门开着吗?',
+                '门开着吗？啊',
+            ),
+        );
+        foreach (array('Hans' => 'Hant', 'Hant' => 'Hans') as $script => $oppositeScript) {
+            $this->assertValidTranscriptions('cmn', $script, $oppositeScript, $testGood);
+            $this->assertInvalidTranscriptions('cmn', $script, $oppositeScript, $testBad);
+        }
+    }
+
     function _mockHttpClient($body) {
         $response = $this->getMockBuilder(Cake\Http\Response::class)
                        ->setMethods(['isOk', 'getStringBody'])

--- a/tests/TestCase/Model/Table/TranscriptionsTableTest.php
+++ b/tests/TestCase/Model/Table/TranscriptionsTableTest.php
@@ -426,10 +426,10 @@ class TranscriptionsTableTest extends TestCase {
 
     function testCannotUpdateReadonlyTranscriptions() {
         $result = (bool)$this->Transcription->saveTranscription(array(
-            'id' => 2,
-            'sentence_id' => 2,
-            'script' => 'Hant',
-            'text' => '問題的根源是，在當今世界，愚人充滿了自信，而智者充滿了懷疑。',
+            'id' => 4,
+            'sentence_id' => 58,
+            'script' => 'Latn',
+            'text' => 'Ishingni qqq!',
         ));
         $this->assertFalse($result);
     }


### PR DESCRIPTION
This is a PR for @Yorwba :smile:

It solves #2007 by allowing to edit autogenerated simplified/traditional scripts in Chinese sentences.

I initially believed that there weren’t substantial errors in the conversion. I wonder if we should mark converted scripts with the warning icon just like the Pinyin has. What’s the error rate of the converted script?