### PR TITLE
Lighten SQL queries and json

### DIFF
--- a/src/Controller/ActivitiesController.php
+++ b/src/Controller/ActivitiesController.php
@@ -66,7 +66,7 @@ class ActivitiesController extends AppController
             'limit' => CurrentUser::getSetting('sentences_per_page'),
             'conditions' => $conditions,
             'fields' => $this->Sentences->fields(),
-            'contain' => $this->Sentences->paginateContain(),
+            'contain' => $this->Sentences->contain(),
         );
         $results = $this->paginate('Sentences');
         $this->set('results', $results);
@@ -184,7 +184,7 @@ class ActivitiesController extends AppController
             'finder' => 'filteredTranslations',
             'fields' => $this->Sentences->fields(),
             'conditions' => $conditions,
-            'contain' => $this->Sentences->paginateContain(),
+            'contain' => $this->Sentences->contain(['translations' => true]),
             'limit' => CurrentUser::getSetting('sentences_per_page'),
             'order' => ['Sentences.created' => 'DESC'],
         ];

--- a/src/Controller/ActivitiesController.php
+++ b/src/Controller/ActivitiesController.php
@@ -61,7 +61,8 @@ class ActivitiesController extends AppController
         $this->loadModel('Sentences');
         $this->paginate = array(
             'finder' => ['filteredTranslations' => [
-                'translationLang' => 'none'
+                'translationLang' => 'none',
+                'hideFields' => $this->Sentences->hideFields(),
             ]],
             'limit' => CurrentUser::getSetting('sentences_per_page'),
             'conditions' => $conditions,
@@ -181,7 +182,9 @@ class ActivitiesController extends AppController
         }
 
         $this->paginate = [
-            'finder' => 'filteredTranslations',
+            'finder' => ['filteredTranslations' => [
+                'hideFields' => $this->Sentences->hideFields(),
+            ]],
             'fields' => $this->Sentences->fields(),
             'conditions' => $conditions,
             'contain' => $this->Sentences->contain(['translations' => true]),

--- a/src/Controller/LinksController.php
+++ b/src/Controller/LinksController.php
@@ -74,7 +74,7 @@ class LinksController extends AppController
     {
         $this->loadModel('Sentences');
         $langFilter = isset($this->request->data['langFilter']) ? $this->request->data['langFilter'] : 'und'; // not sure what this is for
-        $translations = $this->Sentences->getSentenceWithId($sentenceId)->translations;
+        $translations = $this->Sentences->getSentenceWith($sentenceId, ['translations' => true])->translations;
 
         $this->set('sentenceId', $sentenceId);
         $this->set('translations', $translations);

--- a/src/Controller/PagesController.php
+++ b/src/Controller/PagesController.php
@@ -222,7 +222,10 @@ class PagesController extends AppController
         if (is_null($randomId)) {
             $this->set('searchProblem', true);
         } else {
-            $randomSentence = $this->Sentences->getSentenceWithId($randomId);
+            $randomSentence = $this->Sentences->getSentenceWith(
+                $randomId,
+                ['translations' => true]
+            );
             $this->set('random', $randomSentence);
         }
 

--- a/src/Controller/SController.php
+++ b/src/Controller/SController.php
@@ -60,7 +60,7 @@ class SController extends AppController
     {
         $this->loadModel('Sentences');
 
-        $sentence = $this->Sentences->getSentenceWithId($id);
+        $sentence = $this->Sentences->getSentenceWith($id, ['translations' => true]);
 
         if (!$sentence) {
             throw new \Cake\Http\Exception\NotFoundException(format(

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -185,7 +185,10 @@ class SentencesController extends AppController
             $this->set('contributions', $contributions);
 
             // And now we retrieve the sentence
-            $sentence = $this->Sentences->getSentenceWithId($id);
+            $sentence = $this->Sentences->getSentenceWith($id, [
+                'translations' => true,
+                'sentenceDetails' => true
+            ]);
 
             $canComment = CurrentUser::isMember()
                 && (!empty($contributions) || !empty($sentence));
@@ -335,7 +338,10 @@ class SentencesController extends AppController
 
         // saving
         if ($savedSentence) {
-            $sentence = $this->Sentences->getSentenceWithId($savedSentence->id);
+            $sentence = $this->Sentences->getSentenceWith(
+                $savedSentence->id,
+                ['translations' => true] // in case it's a duplicate
+            );
             $this->set('duplicate', $savedSentence->isDuplicate);
             $this->set('sentence', $sentence);
         }
@@ -769,18 +775,13 @@ class SentencesController extends AppController
         $sphinx['limit'] = $limit;
 
         $model = 'Sentences';
-        if (CurrentUser::isMember()) {
-            $contain = $this->Sentences->contain();
-        } else {
-            $contain = $this->Sentences->minimalContain();
-        }
         $pagination = [
             'finder' => ['withSphinx' => [
                 'translationLang' => $to,
                 'nativeMarker' => CurrentUser::getSetting('native_indicator')
             ]],
             'fields' => $this->Sentences->fields(),
-            'contain' => $contain,
+            'contain' => $this->Sentences->contain(['translations' => true]),
             'limit' => CurrentUser::getSetting('sentences_per_page'),
             'sphinx' => $sphinx,
             'search' => $query
@@ -845,7 +846,7 @@ class SentencesController extends AppController
                 'nativeMarker' => CurrentUser::getSetting('native_indicator')
             ]],
             'fields' => $this->Sentences->fields(),
-            'contain' => $this->Sentences->paginateContain($translationLang),
+            'contain' => $this->Sentences->contain(['translations' => true]),
             'conditions' => $conditions,
             'limit' => CurrentUser::getSetting('sentences_per_page'),
             'order' => ['Sentences.id' => 'DESC']
@@ -888,7 +889,10 @@ class SentencesController extends AppController
             $this->set('searchProblem', true);
             $randomSentence = null;
         } else {
-            $randomSentence = $this->Sentences->getSentenceWithId($randomId);
+            $randomSentence = $this->Sentences->getSentenceWith(
+                $randomId,
+                ['translations' => true]
+            );
         }
 
         $this->request->getSession()->write('random_lang_selected', $lang);

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -778,7 +778,8 @@ class SentencesController extends AppController
         $pagination = [
             'finder' => ['withSphinx' => [
                 'translationLang' => $to,
-                'nativeMarker' => CurrentUser::getSetting('native_indicator')
+                'nativeMarker' => CurrentUser::getSetting('native_indicator'),
+                'hideFields' => $this->Sentences->hideFields(),
             ]],
             'fields' => $this->Sentences->fields(),
             'contain' => $this->Sentences->contain(['translations' => true]),
@@ -843,7 +844,8 @@ class SentencesController extends AppController
         $pagination = [
             'finder' => ['filteredTranslations' => [
                 'translationLang' => $translationLang,
-                'nativeMarker' => CurrentUser::getSetting('native_indicator')
+                'nativeMarker' => CurrentUser::getSetting('native_indicator'),
+                'hideFields' => $this->Sentences->hideFields(),
             ]],
             'fields' => $this->Sentences->fields(),
             'contain' => $this->Sentences->contain(['translations' => true]),

--- a/src/Controller/SentencesListsController.php
+++ b/src/Controller/SentencesListsController.php
@@ -171,7 +171,8 @@ class SentencesListsController extends AppController
         $contain = $this->Sentences->contain(['translations' => true]);
         $contain['fields'] = $this->Sentences->fields();
         $contain['finder'] = ['filteredTranslations' => [
-            'translationLang' => $translationsLang
+            'translationLang' => $translationsLang,
+            'hideFields' => $this->Sentences->hideFields(),
         ]];
         $pagination = [
             'contain' => ['Sentences' => $contain],

--- a/src/Controller/SentencesListsController.php
+++ b/src/Controller/SentencesListsController.php
@@ -168,7 +168,8 @@ class SentencesListsController extends AppController
 
         $this->loadModel('Sentences');
 
-        $contain = $this->Sentences->paginateContain();
+        $contain = $this->Sentences->contain(['translations' => true]);
+        $contain['fields'] = $this->Sentences->fields();
         $contain['finder'] = ['filteredTranslations' => [
             'translationLang' => $translationsLang
         ]];

--- a/src/Controller/TagsController.php
+++ b/src/Controller/TagsController.php
@@ -194,7 +194,9 @@ class TagsController extends AppController
             $this->loadModel('Sentences');
             $contain = $this->Sentences->contain(['translations' => true]);
             $contain['fields'] = $this->Sentences->fields();
-            $contain['finder'] = 'filteredTranslations';
+            $contain['finder'] = ['filteredTranslations' => [
+                'hideFields' => $this->Sentences->hideFields(),
+            ]];
 
             $conditions = ['tag_id' => $tagId];
             if (!empty($lang) && $lang != 'und') {

--- a/src/Controller/TagsController.php
+++ b/src/Controller/TagsController.php
@@ -192,7 +192,8 @@ class TagsController extends AppController
 
         if ($tagExists) {
             $this->loadModel('Sentences');
-            $contain = $this->Sentences->paginateContain();
+            $contain = $this->Sentences->contain(['translations' => true]);
+            $contain['fields'] = $this->Sentences->fields();
             $contain['finder'] = 'filteredTranslations';
 
             $conditions = ['tag_id' => $tagId];

--- a/src/Model/CurrentUser.php
+++ b/src/Model/CurrentUser.php
@@ -282,25 +282,6 @@ class CurrentUser
     }
 
     /**
-     * Indicates if sentence of given id has been favorited by current user.
-     *
-     * @param int $sentenceId Id of the sentence.
-     *
-     * @return bool
-     */
-    public static function hasFavorited($sentenceId)
-    {
-        if (!self::isMember()) {
-            return false;
-        }
-
-        $userId = self::get('id');
-        $Favorite = TableRegistry::get('Favorites');
-        return $Favorite->isSentenceFavoritedByUser($sentenceId, $userId);
-    }
-
-
-    /**
      * Retrieve correctness that the user has set for a certain sentence.
      *
      * @param int $sentenceId Id of the sentence.

--- a/src/Model/Entity/Audio.php
+++ b/src/Model/Entity/Audio.php
@@ -5,6 +5,10 @@ use Cake\ORM\Entity;
 
 class Audio extends Entity
 {
+    protected $_virtual = [
+        'author',
+    ];
+
     public static $defaultExternal = array(
         'username' => null,
         'license' => null,
@@ -25,5 +29,13 @@ class Audio extends Entity
             $external = array_merge($existingExternal, $external);
         }
         return $external;
+    }
+
+    protected function _getAuthor() {
+        if ($this->user && $this->user->username) {
+            return $this->user->username;
+        } else {
+            return $this->external['username'];
+        }
     }
 }

--- a/src/Model/Entity/Sentence.php
+++ b/src/Model/Entity/Sentence.php
@@ -38,6 +38,7 @@ class Sentence extends Entity
 
     protected $_hidden = [
         'favorites_users',
+        'highlight',
     ];
 
     public function __construct($properties = [], $options = []) {

--- a/src/Model/Entity/Sentence.php
+++ b/src/Model/Entity/Sentence.php
@@ -36,6 +36,10 @@ class Sentence extends Entity
         'is_owned_by_current_user'
     ];
 
+    protected $_hidden = [
+        'favorites_users',
+    ];
+
     public function __construct($properties = [], $options = []) {
         parent::__construct($properties, $options);
         $hash = $properties['hash'] ?? null;

--- a/src/Model/Entity/Sentence.php
+++ b/src/Model/Entity/Sentence.php
@@ -115,7 +115,9 @@ class Sentence extends Entity
 
     protected function _getIsFavorite()
     {
-        return CurrentUser::hasFavorited($this->id);
+        if ($this->has('favorites_users')) {
+            return count($this->favorites_users) > 0;
+        }
     }
 
     protected function _getIsOwnedByCurrentUser()

--- a/src/Model/Entity/SentencesList.php
+++ b/src/Model/Entity/SentencesList.php
@@ -22,6 +22,11 @@ use Cake\ORM\Entity;
 
 class SentencesList extends Entity
 {
+    protected $_hidden = [
+        '_joinData',
+        'SentencesSentencesLists',
+    ];
+
     protected function _getOldFormat()
     {
         return [

--- a/src/Model/Entity/Transcription.php
+++ b/src/Model/Entity/Transcription.php
@@ -22,6 +22,11 @@ use Cake\ORM\Entity;
 
 class Transcription extends Entity
 {
+    protected $_hidden = [
+        'created',
+        'sentence',
+    ];
+
     private $scriptsByLang = array( /* ISO 15924 */
         'jpn' => array('Jpan'),
         'uzb' => array('Cyrl', 'Latn'),

--- a/src/Model/Entity/Translation.php
+++ b/src/Model/Entity/Translation.php
@@ -14,6 +14,11 @@ class Translation extends Entity
         'lang_tag',
     ];
 
+    protected $_hidden = [
+        '_joinData',
+        'SentencesTranslations',
+    ];
+
     protected function _getLangName()
     {
         return $this->codeToNameAlone($this->lang);

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -7,6 +7,10 @@ use Cake\ORM\TableRegistry;
 
 class User extends Entity
 {
+    protected $_hidden = [
+        'password',
+    ];
+
     const ROLE_ADMIN = 'admin';
     const ROLE_CORPUS_MAINTAINER = 'corpus_maintainer';
     const ROLE_ADV_CONTRIBUTOR = 'advanced_contributor';

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -20,6 +20,7 @@
 namespace App\Model\Table;
 
 use Cake\ORM\Table;
+use Cake\ORM\Query;
 use Cake\Core\Configure;
 use Cake\Database\Schema\TableSchema;
 use Cake\Event\Event;
@@ -652,9 +653,10 @@ class SentencesTable extends Table
 
         if (CurrentUser::isMember()) {
             $contain += [
-                'Favorites_users' => [
-                    'fields' => ['id', 'Favorites_users.favorite_id']
-                ],
+                'Favorites_users' => function (Query $q) {
+                    return $q->select(['id', 'favorite_id'])
+                             ->where(['user_id' => CurrentUser::get('id')]);
+                },
                 'SentencesLists' => [
                     'fields' => ['id', 'SentencesSentencesLists.sentence_id']
                 ],

--- a/src/Template/Element/sentences/audio.ctp
+++ b/src/Template/Element/sentences/audio.ctp
@@ -72,12 +72,7 @@ if (CurrentUser::isAdmin()) {
 
     $ownerName = '';
     if ($hasaudio) {
-        $audio = $audios[0];
-        if ($audio->user_id && $audio->user->username) {
-            $ownerName = $audio->user->username;
-        } else {
-            $ownerName = $audios->external->username;
-        }
+        $ownerName = $audios[0]->author;
     }
     echo $this->Form->control("ownerName",
         array(

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -606,7 +606,8 @@ class MenuHelper extends AppHelper
         $chineseScript = null,
         $canTranslate,
         $langFilter = 'und',
-        $hasAudio = true
+        $hasAudio = true,
+        $isFavorited
     ) {
         ?>
         <ul class="menu">
@@ -627,7 +628,6 @@ class MenuHelper extends AppHelper
         }
 
         // Favorite
-        $isFavorited = CurrentUser::hasFavorited($sentenceId);
         $this->favoriteButton($sentenceId, $isFavorited, $isLogged);
 
         // Add to list

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -443,8 +443,10 @@ class SentencesHelper extends AppHelper
         $canTranslate = $sentence->correctness >= 0;
         $hasAudio = isset($sentence->audios) && count($sentence->audios);
         $script = $sentence->script;
+        $isFavorited = isset($sentence->favorites_users)
+                       && count($sentence->favorites_users);
         $this->Menu->displayMenu(
-            $sentenceId, $user, $script, $canTranslate, $langFilter, $hasAudio
+            $sentenceId, $user, $script, $canTranslate, $langFilter, $hasAudio, $isFavorited
         );
 
         $ownerName = $user ? $user->username : null;

--- a/tests/Fixture/FavoritesUsersFixture.php
+++ b/tests/Fixture/FavoritesUsersFixture.php
@@ -1,23 +1,49 @@
 <?php
-/* FavoritesUser Fixture generated on: 2014-09-14 16:11:49 : 1410711109 */
 namespace App\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 
-class FavoritesUsersFixture extends TestFixture {
-	public $name = 'FavoritesUser';
-
-	public $fields = array(
-		'favorite_id' => ['type' => 'integer', 'null' => false, 'default' => null],
-		'user_id' => ['type' => 'integer', 'null' => false, 'default' => null],
-		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['favorite_id']], 'favorite_id' => ['type' => 'unique', 'columns' => ['favorite_id', 'user_id']]],
-		'_options' => ['charset' => 'latin1', 'collate' => 'latin1_swedish_ci', 'engine' => 'MyISAM']
-	);
-
-	public $records = array(
-		array(
-			'favorite_id' => '4',
-			'user_id' => '7',
-		)
-	);
+/**
+ * FavoritesUsersFixture
+ */
+class FavoritesUsersFixture extends TestFixture
+{
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    // @codingStandardsIgnoreStart
+    public $fields = [
+        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
+        'favorite_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        'user_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        'created' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+            'favorite_id' => ['type' => 'unique', 'columns' => ['favorite_id', 'user_id'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'latin1_swedish_ci'
+        ],
+    ];
+    // @codingStandardsIgnoreEnd
+    /**
+     * Init method
+     *
+     * @return void
+     */
+    public function init()
+    {
+        $this->records = [
+            [
+                'id' => 1,
+                'favorite_id' => 4,
+                'user_id' => 7,
+                'created' => '2020-03-03 03:03:03'
+            ],
+        ];
+        parent::init();
+    }
 }

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -1157,6 +1157,17 @@ class SentencesTableTest extends TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+	function testGetSentenceWith_isHidingUnneededFieldsFromJson() {
+		$sentence = $this->Sentence->getSentenceWith(1, ['translations' => true]);
+		$sentence = json_decode(json_encode($sentence));
+		$this->assertFalse(isset($sentence->user_id));
+		$this->assertFalse(isset($sentence->user->id));
+		$this->assertFalse(isset($sentence->user->level));
+		$this->assertFalse(isset($sentence->user->role));
+		$translationAudio = $sentence->translations[0][1]->audios[0];
+		$this->assertFalse(isset($translationAudio->sentence_id));
+	}
+
     function testSaveNewSentence_correctDateUsingArabicLocale() {
         I18n::setLocale('ar');
         $added = $this->Sentence->saveNewSentence('test', 'eng', 1);

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -1137,20 +1137,20 @@ class SentencesTableTest extends TestCase {
 		$this->assertEquals(asort($expected), asort($languages));
 	}
 
-	function testGetSentenceWithId_translationsHaveAudioInfo() {
+	function testGetSentenceWith_translationsHaveAudioInfo() {
 		CurrentUser::store(null);
-		$sentence = $this->Sentence->getSentenceWithId(1);
+		$sentence = $this->Sentence->getSentenceWith(1, ['translations' => true]);
 		$result = [];
 		foreach($sentence->translations as $translationsGroup) {
 			foreach($translationsGroup as $translation) {
 				$audios = $translation->audios;
-				$result[$translation->id] = isset($audios[0]) ? $audios[0]->user_id : null;
+				$result[$translation->id] = isset($audios[0]) ? $audios[0]->author : null;
 			}
 		}
 		$expected = [
 			2 => null,
-			3 => 4,
-			4 => null,
+			3 => 'contributor',
+			4 => 'Philippe Petit',
 			5 => null,
 			6 => null,
 		];

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -262,13 +262,7 @@
         function getAudioAuthor(sentence) {
             var audio = sentence.audios ? sentence.audios[0] : null;
 
-            if (audio && audio.user) {
-                return audio.user.username;
-            } else if (audio && audio.external) {
-                return audio.external.username;
-            } else {
-                return null;
-            }
+            return audio.author;
         }
 
         function translate(id) {


### PR DESCRIPTION
This PR aims at removing unnecessary fields that are used in SQL queries and serialized as json for the initialization of Angular components.

On the Sentences table, we already had `$this->contain()` and `$this->fields()` to set the fields and containment of queries to display sentence blocks. These methods now take a parameter to return an appropriate value depending on the context: sentence block with or without translations, or sentence page. We can easily add more contexts in the future.

In addition, the new find parameter `hideFields` allows to hide certain fields that we need in the SQL queries but not in json.

I also removed `CurrentUser::hasFavorited()` because that information was already retrieved using contain.

Since this PR is mingling with core stuff, please read and test it as much as you can.