### PR TITLE
More fixes for the furigana copy-paste hack

### DIFF
--- a/webroot/js/generic_functions.js
+++ b/webroot/js/generic_functions.js
@@ -156,7 +156,8 @@ $(document).on('copy', function (e) {
 
     var sel = window.getSelection();
     var clipboardData = e.originalEvent.clipboardData; // not available in IE
-    if (sel.rangeCount > 0 && clipboardData) {
+    var setData = clipboardData && clipboardData.setData; // not available in iOS Safari
+    if (sel.rangeCount > 0 && setData) {
         $('rt').css('visibility', 'hidden');
         clipboardData.setData('text', sel.toString());
         $('rt').css('visibility', 'visible');

--- a/webroot/js/generic_functions.js
+++ b/webroot/js/generic_functions.js
@@ -150,11 +150,10 @@ if (!Array.prototype.find) {
 // Fix for Chrome: prevent copy-pasting furigana when selecting a sentence
 // https://stackoverflow.com/questions/13438391
 $(document).on('copy', function (e) {
-    // ClipboardJS uses a textarea to implement copying in Firefox.
-    // We shouldn't mess with that event.
-    // Also in Firefox, selections in <input> tags may nondeterministically
-    // appear empty even if they are not, causing setData() to erroneously clear
-    // the clipboard. Ignoring those events works around that.
+    // "currently getSelection() doesn't work on the content of <textarea> and
+    // <input> elements in Firefox, Edge (not Chromium) and Internet Explorer"
+    // according to https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection
+    // Since those elements don't contain ruby tags, we can just ignore them.
     var tagName = e.target.tagName;
     if(tagName == 'INPUT' || tagName == 'TEXTAREA') return;
 

--- a/webroot/js/generic_functions.js
+++ b/webroot/js/generic_functions.js
@@ -152,7 +152,11 @@ if (!Array.prototype.find) {
 $(document).on('copy', function (e) {
     // ClipboardJS uses a textarea to implement copying in Firefox.
     // We shouldn't mess with that event.
-    if(e.target.tagName == 'TEXTAREA') return;
+    // Also in Firefox, selections in <input> tags may nondeterministically
+    // appear empty even if they are not, causing setData() to erroneously clear
+    // the clipboard. Ignoring those events works around that.
+    var tagName = e.target.tagName;
+    if(tagName == 'INPUT' || tagName == 'TEXTAREA') return;
 
     var sel = window.getSelection();
     var clipboardData = e.originalEvent.clipboardData; // not available in IE


### PR DESCRIPTION
I think that #2211 was most likely caused by `setData` being unsupported in Safari on iOS ([according to MDN](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/setData), it's the only modern browser that doesn't support this API). This PR checks whether the function is present before calling it and that hopefully should allow people using iOS to copy things again.

While testing in Firefox, I noticed a different problem, which is that when copying from an `input` element (I was using the search bar), `toString()` on the selection sometimes returns an empty string even though the selection is not empty. I'm not sure what causes this. In the debugger I could see that the selection markers on the `input` element were set, so it might be a browser bug that it returned the wrong selection content. Anyways, since it doesn't seem to affect other elements and we have no ruby tags in `input` elements, ignoring those should be an acceptable workaround.