### PR TITLE
Better display of some checkboxes

### DIFF
--- a/src/Template/Element/advanced_search_form.ctp
+++ b/src/Template/Element/advanced_search_form.ctp
@@ -112,7 +112,7 @@ echo $this->Form->create('AdvancedSearch', [
                     <?= __('Unapproved sentences are likely to be incorrect.') ?>
                 </div>
             </div>
-            
+
             <div class="param" layout="row" layout-align="center">
                 <label for="has-audio" flex><?= __('Has audio:') ?></label>
                 <?php
@@ -155,13 +155,14 @@ echo $this->Form->create('AdvancedSearch', [
                 </div>
             </div>
 
-            <div class="param" layout="row" layout-align="center">
+            <div class="param" layout="row">
                 <md-checkbox
                     ng-false-value="0"
                     ng-true-value="1"
                     ng-model="native"
                     ng-init="native = <?= isset($native) && $native == 'yes' ? 1 : 0 ?>"
                     class="md-primary">
+                    <?= __('Owned by a self-identified native') ?>
                 </md-checkbox>
                 <div ng-hide="true">
                     <?php
@@ -170,7 +171,6 @@ echo $this->Form->create('AdvancedSearch', [
                     ]);
                     ?>
                 </div>
-                <label for="native" flex><?= __('Owned by a self-identified native') ?></label>
             </div>
         </div>
 
@@ -315,13 +315,14 @@ echo $this->Form->create('AdvancedSearch', [
                     ?>
                 </div>
 
-                <div class="param" layout="row" layout-align="center">
+                <div class="param" layout="row">
                     <md-checkbox
                         ng-false-value="0"
                         ng-true-value="1"
                         ng-model="sortReverse"
                         ng-init="sortReverse = <?= $sort_reverse == 'yes' ? 1 : 0 ?>"
                         class="md-primary">
+                        <?= __('Reverse order') ?>
                     </md-checkbox>
                     <div ng-hide="true">
                         <?php
@@ -330,7 +331,6 @@ echo $this->Form->create('AdvancedSearch', [
                         ]);
                         ?>
                     </div>
-                    <label for="sort-reverse" flex><?= __('Reverse order') ?></label>
                 </div>
             </div>
         </div>

--- a/src/Template/Users/login.ctp
+++ b/src/Template/Users/login.ctp
@@ -101,7 +101,7 @@ echo $this->Form->create(
         ng-false-value='0'
         ng-true-value='1' ng-init='rememberLogin = 0'
         class='md-primary'>
-        <label><?= __('Remember me') ?></label>
+        <?= __('Remember me') ?>
     </md-checkbox>
     <?php
     echo $this->Form->checkbox(


### PR DESCRIPTION
This PR modifies three checkboxes by removing the `<label>` text and putting the corresponding text directly inside the `<md-checkbox>` tag. The three checkboxes involved are the "Remember me" on the login page, and "Owned by a native" and "Reverse order" of the advanced search.

If I didn't miss any other checkbox that would need a modification, this PR would close #2134 