### PR TITLE
Allow admins to set a sentence's license to a special value

### DIFF
--- a/docs/database/scripts/weekly_exports.sql
+++ b/docs/database/scripts/weekly_exports.sql
@@ -6,13 +6,13 @@ INTO OUTFILE '/var/tmp/jpn_indices.csv';
   
 -- Sentences
 SELECT id, lang, text FROM `sentences`
-WHERE correctness > -1
+WHERE correctness > -1 AND license != ''
 INTO OUTFILE '/var/tmp/sentences.csv';
 
 -- Sentences with more data
 SELECT s.id, s.lang, s.text, u.username, s.created, s.modified 
 FROM `sentences` s LEFT JOIN `users` u ON s.user_id = u.id
-WHERE correctness > -1
+WHERE correctness > -1 AND license != ''
 INTO OUTFILE '/var/tmp/sentences_detailed.csv';
 
 -- Links between sentences

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -30,6 +30,7 @@ use App\Controller\AppController;
 use App\Model\CurrentUser;
 use App\Lib\LanguagesLib;
 use App\Lib\SphinxClient;
+use App\Lib\Licenses;
 use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Event\Event;
@@ -1130,15 +1131,16 @@ class SentencesController extends AppController
         } else {
             $errors = $sentence->getError('license');
             $savedSentence = $this->Sentences->save($sentence);
+            $licenseName = Licenses::allLicenses()[$newLicense]['name'] ?? $newLicense;
             if ($savedSentence) {
                 $this->Flash->set(format(
-                    __('The license of the sentence has been changed to “{newLicense}”.'),
-                    compact('newLicense')
+                    __('The license of the sentence has been changed to “{licenseName}”.'),
+                    compact('licenseName')
                 ));
             } elseif (!empty($errors)) {
                 $message = format(
-                    __('Unable to change the license to “{newLicense}” because:'),
-                    compact('newLicense')
+                    __('Unable to change the license to “{licenseName}” because:'),
+                    compact('licenseName')
                 );
                 $params = compact('errors');
                 $this->Flash->set($message, compact('params'));

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -1131,7 +1131,7 @@ class SentencesController extends AppController
         } else {
             $errors = $sentence->getError('license');
             $savedSentence = $this->Sentences->save($sentence);
-            $licenseName = Licenses::allLicenses()[$newLicense]['name'] ?? $newLicense;
+            $licenseName = Licenses::getSentenceLicenses()[$newLicense]['name'] ?? $newLicense;
             if ($savedSentence) {
                 $this->Flash->set(format(
                     __('The license of the sentence has been changed to “{newLicense}”.'),

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -1124,15 +1124,14 @@ class SentencesController extends AppController
         }
 
         $sentence = $this->Sentences->get($sentenceId);
-        $sentence = $this->Sentences->patchEntity($sentence, ['license' => $newLicense]);
 
         if (!CurrentUser::canEditLicenseOfSentence($sentence)) {
             $this->Flash->set(__('You are not allowed to change the license of this sentence.'));
         } else {
+            $sentence = $this->Sentences->patchEntity($sentence, ['license' => $newLicense]);
             $errors = $sentence->getError('license');
-            $savedSentence = $this->Sentences->save($sentence);
             $licenseName = Licenses::getSentenceLicenses()[$newLicense]['name'] ?? $newLicense;
-            if ($savedSentence) {
+            if (empty($errors) && $this->Sentences->save($sentence)) {
                 $this->Flash->set(format(
                     __('The license of the sentence has been changed to “{newLicense}”.'),
                     ['newLicense' => $licenseName]

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -1134,13 +1134,13 @@ class SentencesController extends AppController
             $licenseName = Licenses::allLicenses()[$newLicense]['name'] ?? $newLicense;
             if ($savedSentence) {
                 $this->Flash->set(format(
-                    __('The license of the sentence has been changed to “{licenseName}”.'),
-                    compact('licenseName')
+                    __('The license of the sentence has been changed to “{newLicense}”.'),
+                    ['newLicense' => $licenseName]
                 ));
             } elseif (!empty($errors)) {
                 $message = format(
-                    __('Unable to change the license to “{licenseName}” because:'),
-                    compact('licenseName')
+                    __('Unable to change the license to “{newLicense}” because:'),
+                    ['newLicense' => $licenseName]
                 );
                 $params = compact('errors');
                 $this->Flash->set($message, compact('params'));

--- a/src/Lib/Licenses.php
+++ b/src/Lib/Licenses.php
@@ -20,7 +20,7 @@ namespace App\Lib;
 
 class Licenses {
 
-    const forSentences = ['CC0 1.0', 'CC BY 2.0 FR'];
+    const forSentences = ['', 'CC0 1.0', 'CC BY 2.0 FR'];
     const forAudio = ['', 'CC BY 4.0', 'CC BY-NC 4.0', 'CC BY-SA 4.0', 'CC BY-NC-ND 3.0'];
 
     public static function allLicenses() {
@@ -28,7 +28,10 @@ class Licenses {
 
         if (empty($licenses)) {
             $licenses = [
-                '' => ['name' => __('No license for offsite use')],
+                '' => [
+                    'name' => __('Unknown license'),
+                    'admin_only' => true,
+                ],
                 /* @translators: refers to the license used for sentence or audio recordings */
                 'Public domain' => ['name' => __('Public domain')],
                 'CC0 1.0' => [

--- a/src/Lib/Licenses.php
+++ b/src/Lib/Licenses.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2020 Tatoeba Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace App\Lib;
+
+class Licenses {
+
+    const forSentences = ['CC0 1.0', 'CC BY 2.0 FR'];
+    const forAudio = ['', 'CC BY 4.0', 'CC BY-NC 4.0', 'CC BY-SA 4.0', 'CC BY-NC-ND 3.0'];
+
+    public static function allLicenses() {
+        static $licenses = [];
+
+        if (empty($licenses)) {
+            $licenses = [
+                '' => ['name' => __('No license for offsite use')],
+                /* @translators: refers to the license used for sentence or audio recordings */
+                'Public domain' => ['name' => __('Public domain')],
+                'CC0 1.0' => [
+                    'url' => 'https://creativecommons.org/publicdomain/zero/1.0/',
+                ],
+                'CC BY 2.0 FR' => [
+                    'url' => 'https://creativecommons.org/licenses/by/2.0/fr/',
+                ],
+                'CC BY 4.0' => [
+                    'url' => 'https://creativecommons.org/licenses/by/4.0/',
+                ],
+                'CC BY-NC 4.0' => [
+                    'url' => 'https://creativecommons.org/licenses/by-nc/4.0/',
+                ],
+                'CC BY-SA 4.0' => [
+                    'url' => 'https://creativecommons.org/licenses/by-sa/4.0/',
+                ],
+                'CC BY-NC-ND 3.0' => [
+                    'url' => 'https://creativecommons.org/licenses/by-nc-nd/3.0/',
+                ],
+            ];
+        }
+        return $licenses;
+    }
+}

--- a/src/Lib/Licenses.php
+++ b/src/Lib/Licenses.php
@@ -19,27 +19,17 @@
 namespace App\Lib;
 
 class Licenses {
-
-    const forSentences = ['', 'CC0 1.0', 'CC BY 2.0 FR'];
-    const forAudio = ['', 'CC BY 4.0', 'CC BY-NC 4.0', 'CC BY-SA 4.0', 'CC BY-NC-ND 3.0'];
-
-    public static function allLicenses() {
+    /**
+     * Return all valid audio licenses
+     *
+     * @return array
+     **/
+    public static function getAudioLicenses() {
         static $licenses = [];
 
         if (empty($licenses)) {
             $licenses = [
-                '' => [
-                    'name' => __('Unknown license'),
-                    'admin_only' => true,
-                ],
-                /* @translators: refers to the license used for sentence or audio recordings */
-                'Public domain' => ['name' => __('Public domain')],
-                'CC0 1.0' => [
-                    'url' => 'https://creativecommons.org/publicdomain/zero/1.0/',
-                ],
-                'CC BY 2.0 FR' => [
-                    'url' => 'https://creativecommons.org/licenses/by/2.0/fr/',
-                ],
+                '' => ['name' => __('No license for offsite use')],
                 'CC BY 4.0' => [
                     'url' => 'https://creativecommons.org/licenses/by/4.0/',
                 ],
@@ -54,6 +44,32 @@ class Licenses {
                 ],
             ];
         }
+        return $licenses;
+    }
+
+    /**
+     * Return all valid sentence licenses
+     *
+     * @return array
+     **/
+    public static function getSentenceLicenses() {
+        static $license = [];
+
+        if (empty($licenses)) {
+            $licenses = [
+                '' => [
+                    'name' => __('Licensing issue'),
+                    'admin_only' => true,
+                ],
+                'CC0 1.0' => [
+                    'url' => 'https://creativecommons.org/publicdomain/zero/1.0/',
+                ],
+                'CC BY 2.0 FR' => [
+                    'url' => 'https://creativecommons.org/licenses/by/2.0/fr/',
+                ],
+            ];
+        }
+
         return $licenses;
     }
 }

--- a/src/Model/CurrentUser.php
+++ b/src/Model/CurrentUser.php
@@ -364,7 +364,8 @@ class CurrentUser
     {
         $isOwner = self::get('id') == $sentence->user_id;
         $canSwitchLicense = self::getSetting('can_switch_license');
-        return ($isOwner && $canSwitchLicense) || self::isAdmin();
+        $noIssues = $sentence->license != '';
+        return ($isOwner && $canSwitchLicense && $noIssues) || self::isAdmin();
     }
     
     public static function hasAcceptedNewTermsOfUse()

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -98,10 +98,11 @@ class SentencesTable extends Table
         $validator
             ->notEmpty('text');
 
+        $sentenceLicenses = array_keys(Licenses::getSentenceLicenses());
         $validator
             ->add('license', [
                 'inList' => [
-                    'rule' => ['inList', Licenses::forSentences],
+                    'rule' => ['inList', $sentenceLicenses],
                     /* @translators: This string will be preceded by "Unable to
                     change the license to “{newLicense}” because:" */
                     'message' => __('This is not a valid license.')

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -35,6 +35,7 @@ use App\Event\UsersLanguagesListener;
 use Cake\Utility\Hash;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Cache\Cache;
+use Cake\ORM\RulesChecker;
 
 class SentencesTable extends Table
 {
@@ -141,6 +142,23 @@ class SentencesTable extends Table
         $validator->dateTime('modified');
 
         return $validator;
+    }
+
+    public function buildRules(RulesChecker $rules)
+    {
+        $rules->addCreate(
+            function ($entity, $options) {
+                if ($entity->based_on_id != 0) {
+                    $baseSentence = $this->findById($entity->based_on_id)->first();
+                    return !empty($baseSentence->license);
+                } else {
+                    return true;
+                }
+            },
+            'licenseCheck'
+        );
+
+        return $rules;
     }
 
     public function beforeSave($event, $entity, $options)

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -119,7 +119,13 @@ class SentencesTable extends Table
                     'on' => 'update',
                 ]
             ])
-            ->allowEmpty('license');
+            ->allowEmptyString(
+                'license',
+                function ($context) {
+                    return $context['newRecord'] || CurrentUser::isAdmin();
+                },
+                __('This is not a valid license.')
+            );
 
         $languages = array_keys(LanguagesLib::languagesInTatoeba());
         $validator

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -27,6 +27,7 @@ use Cake\Database\Schema\TableSchema;
 use Cake\Event\Event;
 use Cake\Validation\Validator;
 use App\Lib\LanguagesLib;
+use App\Lib\Licenses;
 use App\Model\CurrentUser;
 use App\Model\Entity\User;
 use App\Event\ContributionListener;
@@ -100,7 +101,7 @@ class SentencesTable extends Table
         $validator
             ->add('license', [
                 'inList' => [
-                    'rule' => ['inList', ['CC0 1.0', 'CC BY 2.0 FR']],
+                    'rule' => ['inList', Licenses::forSentences],
                     /* @translators: This string will be preceded by "Unable to
                     change the license to “{newLicense}” because:" */
                     'message' => __('This is not a valid license.')

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -137,6 +137,7 @@ class UsersTable extends Table
             ->maxLength('country_id', 2);
 
         $validator
+            ->allowEmptyString('audio_license')
             ->scalar('audio_license')
             ->maxLength('audio_license', 50);
 

--- a/src/Template/Audio/of.ctp
+++ b/src/Template/Audio/of.ctp
@@ -45,7 +45,7 @@ if (isset($sentencesWithAudio)) {
                ));
                echo $this->Form->input('audio_license', array(
                    'label' => __('License:'),
-                   'options' => $this->Audio->License->getLicenseOptions()
+                   'options' => $this->AudioLicense->getLicenseOptions()
                ));
             ?>
             <md-input-container class="md-block">

--- a/src/Template/Element/logs/log_text.ctp
+++ b/src/Template/Element/logs/log_text.ctp
@@ -57,7 +57,8 @@ $infoLabel = $this->Logs->getInfoLabel($type, $action, $username, $sentenceDate)
             if (isset($withSentenceLink)) {
                 echo $sentenceLink.' ';
             }
-            echo ' ➜ '.$this->Html->tag('span', $sentenceText, array('class' => 'license'));
+            $licenseName = $this->SentenceLicense->getLicenseName($log->text);
+            echo ' ➜ '.$this->Html->tag('span', $licenseName, array('class' => 'license'));
         } else { // link
             echo $sentenceLink.' ➜ '.$translationLink;
         }

--- a/src/Template/Element/sentences/add_sentence_form.ctp
+++ b/src/Template/Element/sentences/add_sentence_form.ctp
@@ -2,7 +2,7 @@
 use App\Model\CurrentUser;
 $this->Html->script('sentences/add.ctrl.js', ['block' => 'scriptBottom']);
 $langs = $this->Languages->profileLanguagesArray(false, false);
-$licencesOptions = $this->Sentences->License->getLicenseOptions();
+$licencesOptions = $this->SentenceLicense->getLicenseOptions();
 $userLanguagesJSON = htmlspecialchars(json_encode($langs), ENT_QUOTES, 'UTF-8');
 $licensesOptionsJSON = htmlspecialchars(json_encode($licencesOptions), ENT_QUOTES, 'UTF-8');
 $defautLicense = CurrentUser::getSetting('default_license');

--- a/src/Template/Element/sentences/add_sentences_jquery.ctp
+++ b/src/Template/Element/sentences/add_sentences_jquery.ctp
@@ -53,7 +53,7 @@ $this->Html->script(JS_PATH . 'sentences.contribute.js', ['block' => 'scriptBott
                     <?php
                     echo $this->Form->select(
                         'sentenceLicense',
-                        $this->Sentences->License->getLicenseOptions(),
+                        $this->SentenceLicense->getLicenseOptions(),
                         array(
                             'id' => 'sentenceLicense',
                             "value" => CurrentUser::getSetting('default_license'),

--- a/src/Template/Element/sentences/license.ctp
+++ b/src/Template/Element/sentences/license.ctp
@@ -24,6 +24,7 @@
  * @license  Affero General Public License
  * @link     https://tatoeba.org
  */
+use App\Model\CurrentUser;
 ?>
 <div class="section md-whiteframe-1dp">
     <h2><?php echo __('License') ?></h2>
@@ -47,12 +48,9 @@ if ($canEdit) {
     );
     $options = array(
         'label' => __('License:'),
-        'options' => $this->SentenceLicense->getLicenseOptions(),
+        'options' => $this->SentenceLicense->getLicenseOptions(CurrentUser::isAdmin()),
         'value' => $license,
     );
-    if (is_null($license)) {
-        $options['empty'] = true;
-    }
     echo $this->Form->control('license', $options);
     echo $this->Form->submit(__d('admin', 'Change'));
     echo $this->Form->end();

--- a/src/Template/Element/sentences/license.ctp
+++ b/src/Template/Element/sentences/license.ctp
@@ -29,7 +29,7 @@
     <h2><?php echo __('License') ?></h2>
 
 <?php
-echo $this->Sentences->License->getLicenseName($license);
+echo $this->SentenceLicense->getLicenseName($license);
 
 if ($canEdit) {
     echo "<hr>";
@@ -47,7 +47,7 @@ if ($canEdit) {
     );
     $options = array(
         'label' => __('License:'),
-        'options' => $this->Sentences->License->getLicenseOptions(),
+        'options' => $this->SentenceLicense->getLicenseOptions(),
         'value' => $license,
     );
     if (is_null($license)) {
@@ -57,10 +57,5 @@ if ($canEdit) {
     echo $this->Form->submit(__d('admin', 'Change'));
     echo $this->Form->end();
 }
-
-// Workaround for error:
-//    The "License" alias has already been loaded with the following config
-// Until someone finds a good way to refactor the involved helpers.
-$this->helpers()->unload('License');
 ?>
 </div>

--- a/src/Template/Element/sentences/sentence_menu.ctp
+++ b/src/Template/Element/sentences/sentence_menu.ctp
@@ -2,7 +2,8 @@
      ng-init="vm.initMenu(<?= (int)$expanded ?>, vm.sentence.permissions)">
     <div class="menu" layout="row" layout-align="space-between center">
         <div>
-            <md-button class="md-icon-button" ng-click="vm.translate(vm.sentence.id)" ng-disabled="vm.sentence.correctness === -1">
+            <md-button class="md-icon-button" ng-click="vm.translate(vm.sentence.id)"
+                ng-disabled="vm.sentence.correctness === -1 || vm.sentence.license === ''">
                 <md-icon>translate</md-icon>
                 <md-tooltip><?= __('Translate') ?></md-tooltip>
             </md-button>

--- a/src/Template/Licensing/switch_my_sentences.ctp
+++ b/src/Template/Licensing/switch_my_sentences.ctp
@@ -30,7 +30,7 @@ if ($isSwitching) {
 } else {
     echo $this->Html->tag('p', format(
         __('This page allows you to massively switch the license of your sentences to {CC0-link}. Among all your sentences, only the ones that meet the following conditions will be affected.'),
-       array('CC0-link' => $this->Sentences->License->licenseLink('CC0 1.0'))
+       array('CC0-link' => $this->SentenceLicense->getLicenseName('CC0 1.0'))
     ));
     echo $this->Html->nestedList(array(
         __('The current license of the sentence must be CC BY 2.0 FR.'),

--- a/src/Template/Sentences/save_translation.ctp
+++ b/src/Template/Sentences/save_translation.ctp
@@ -24,9 +24,7 @@
  * @license  Affero General Public License
  * @link     https://tatoeba.org
  */
-?>
 
-<?php
 if (isset($translation)) {
     $type = 'directTranslation';
     $isEditable = true;

--- a/src/View/Helper/AudioHelper.php
+++ b/src/View/Helper/AudioHelper.php
@@ -25,13 +25,7 @@ class AudioHelper extends AppHelper
 {
     public $helpers = array(
         'Html',
-        'License' => ['availableLicences' => [
-            '',
-            'CC BY 4.0',
-            'CC BY-NC 4.0',
-            'CC BY-SA 4.0',
-            'CC BY-NC-ND 3.0',
-        ]]
+        'AudioLicense'
     );
 
     private function defaultAttribUrl($username) {
@@ -58,7 +52,7 @@ class AudioHelper extends AppHelper
         if (!empty($attribUrl)) {
             $username = $this->Html->link($username, $attribUrl);
         }
-        $license = $this->License->getLicenseName($license);
+        $license = $this->AudioLicense->getLicenseName($license);
 ?>
 <ul>
   <li><?php echo format(__('Recorded by: {username}'), compact('username')); ?></li>
@@ -81,8 +75,8 @@ class AudioHelper extends AppHelper
         } elseif ($license == 'Public domain') {
             $msg = __('The following audio recordings by '.
                       '{userName}, are licensed under the public domain.');
-        } elseif ($this->License->isKnownLicense($license)) {
-            $license = $this->License->licenseLink($license);
+        } elseif ($this->AudioLicense->isKnownLicense($license)) {
+            $license = $this->AudioLicense->getLicenseName($license);
             $msg = __('The following audio recordings by '.
                       '{userName}, are licensed under the {licenseName} '.
                       'license.');

--- a/src/View/Helper/AudioLicenseHelper.php
+++ b/src/View/Helper/AudioLicenseHelper.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2020 Tatoeba Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace App\View\Helper;
+
+use App\View\Helper\LicenseHelper;
+use App\Lib\Licenses;
+
+/**
+ * AudioLicense helper
+ *
+ * Child class of LicenseHelper which defines all valid licenses for audio files.
+ */
+class AudioLicenseHelper extends LicenseHelper
+{
+    public function initialize(array $config) {
+        parent::initialize($config);
+        $this->validLicenses = Licenses::forAudio;
+    }
+}

--- a/src/View/Helper/AudioLicenseHelper.php
+++ b/src/View/Helper/AudioLicenseHelper.php
@@ -29,7 +29,6 @@ use App\Lib\Licenses;
 class AudioLicenseHelper extends LicenseHelper
 {
     public function initialize(array $config) {
-        parent::initialize($config);
-        $this->validLicenses = Licenses::forAudio;
+        $this->licenses = Licenses::getAudioLicenses();
     }
 }

--- a/src/View/Helper/LicenseHelper.php
+++ b/src/View/Helper/LicenseHelper.php
@@ -66,11 +66,17 @@ class LicenseHelper extends AppHelper
     /**
      * Get the options for a selection control
      *
+     * @param boolean $admin  Whether to get the options for regular users
+     *                        or for an admin
+     *
      * @return array
      **/
-    public function getLicenseOptions() {
+    public function getLicenseOptions($admin = false) {
         foreach ($this->validLicenses as $license) {
-            $keyToName[$license] = $this->getLicenseName($license, false);
+            if (!isset($this->licenses[$license]['admin_only']) ||
+                ($this->licenses[$license]['admin_only'] && $admin)) {
+                $keyToName[$license] = $this->getLicenseName($license, false);
+            }
         }
         return $keyToName;
     }

--- a/src/View/Helper/LicenseHelper.php
+++ b/src/View/Helper/LicenseHelper.php
@@ -28,15 +28,12 @@ class LicenseHelper extends AppHelper
         'Html',
     );
 
-    /* Contains data for all licenses used on Tatoeba */
+    /**
+     * The licenses used in the current context (sentences or audio files)
+     *
+     * Should be set in SentenceLicenseHelper and AudioLicenseHelper
+     */
     protected $licenses = [];
-
-    /* The licenses used in the current context (sentences or audio files) */
-    protected $validLicenses = [];
-
-    public function initialize(array $config) {
-        $this->licenses = Licenses::allLicenses();
-    }
 
     /**
      * Get the displayable name for a license
@@ -48,12 +45,10 @@ class LicenseHelper extends AppHelper
      * @return string
      */
     public function getLicenseName($license, $link = true) {
-        if (empty($license) || !in_array($license, $this->validLicenses)) {
+        if (empty($license) || !isset($this->licenses[$license])) {
             $name = $this->licenses['']['name'];
-        } elseif (isset($this->licenses[$license]['name'])) {
-            $name = $this->licenses[$license]['name'];
         } else {
-            $name = $license;
+            $name = $this->licenses[$license]['name'] ?? $license;
         }
 
         if ($link && isset($this->licenses[$license]['url'])) {
@@ -72,10 +67,9 @@ class LicenseHelper extends AppHelper
      * @return array
      **/
     public function getLicenseOptions($admin = false) {
-        foreach ($this->validLicenses as $license) {
-            if (!isset($this->licenses[$license]['admin_only']) ||
-                ($this->licenses[$license]['admin_only'] && $admin)) {
-                $keyToName[$license] = $this->getLicenseName($license, false);
+        foreach ($this->licenses as $key => $license) {
+            if (!isset($license['admin_only']) || ($license['admin_only'] && $admin)) {
+                $keyToName[$key] = $this->getLicenseName($key, false);
             }
         }
         return $keyToName;

--- a/src/View/Helper/SentenceLicenseHelper.php
+++ b/src/View/Helper/SentenceLicenseHelper.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2020 Tatoeba Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace App\View\Helper;
+
+use App\View\Helper\LicenseHelper;
+use App\Lib\Licenses;
+
+/**
+ * SentenceLicense helper
+ *
+ * Child class of LicenseHelper which defines all valid licenses for sentences.
+ */
+class SentenceLicenseHelper extends LicenseHelper
+{
+    public function initialize(array $config) {
+        parent::initialize($config);
+        $this->validLicenses = Licenses::forSentences;
+    }
+}

--- a/src/View/Helper/SentenceLicenseHelper.php
+++ b/src/View/Helper/SentenceLicenseHelper.php
@@ -29,7 +29,6 @@ use App\Lib\Licenses;
 class SentenceLicenseHelper extends LicenseHelper
 {
     public function initialize(array $config) {
-        parent::initialize($config);
-        $this->validLicenses = Licenses::forSentences;
+        $this->licenses = Licenses::getSentenceLicenses();
     }
 }

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -435,7 +435,7 @@ class SentencesHelper extends AppHelper
     ) {
         $user = $sentence->user;
         $sentenceId = $sentence->id;
-        $canTranslate = $sentence->correctness >= 0;
+        $canTranslate = $sentence->correctness >= 0 && $sentence->license != '';
         $hasAudio = isset($sentence->audios) && count($sentence->audios);
         $script = $sentence->script;
         $isFavorited = isset($sentence->favorites_users)

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -66,12 +66,7 @@ class SentencesHelper extends AppHelper
         'Images',
         'Transcriptions',
         'Search',
-        'License' => array(
-            'availableLicences' => array(
-                'CC0 1.0',
-                'CC BY 2.0 FR',
-            ),
-        ),
+        'SentenceLicense',
     );
 
 

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -114,6 +114,7 @@ class UsersFixture extends TestFixture
                 'settings' => [
                     'is_public' => false,
                     'lang' => null,
+                    'can_switch_license' => true,
                 ],
                 'homepage' => '',
                 'image' => '',

--- a/tests/TestCase/Controller/SentencesControllerTest.php
+++ b/tests/TestCase/Controller/SentencesControllerTest.php
@@ -224,6 +224,16 @@ class SentencesControllerTest extends IntegrationTestCase {
         $this->assertResponseOk();
     }
 
+    public function testSaveTranslation_sentenceWithLicensingIssue() {
+        $this->logInAs('contributor');
+        $this->ajaxPost('/eng/sentences/save_translation', [
+            'id' => '52',
+            'selectLang' => 'rus',
+            'value' => 'translation text',
+        ]);
+        $this->assertResponseEmpty();
+    }
+
     public function testChangeLanguage_asGuest() {
         $this->ajaxPost('/jpn/sentences/change_language', [
             'id' => '9',

--- a/tests/TestCase/Controller/SentencesControllerTest.php
+++ b/tests/TestCase/Controller/SentencesControllerTest.php
@@ -203,6 +203,19 @@ class SentencesControllerTest extends IntegrationTestCase {
         $this->assertEquals($oldSentence->license, $newSentence->license);
     }
 
+    public function testEditLicense_cannotSwitchToAdminOnlyLicenseAsUser() {
+        $sentenceId = 48;
+        $sentences = TableRegistry::get('Sentences');
+        $oldSentence = $sentences->get($sentenceId);
+        $this->logInAs('contributor');
+        $this->post('/jpn/sentences/edit_license', [
+            'id' => $sentenceId,
+            'license' => '',
+        ]);
+        $newSentence = $sentences->get($sentenceId);
+        $this->assertEquals($oldSentence->license, $newSentence->license);
+    }
+
     public function testSaveTranslation_asGuest() {
         $this->ajaxPost('/jpn/sentences/save_translation', [
             'id' => '26',

--- a/tests/TestCase/Controller/SentencesControllerTest.php
+++ b/tests/TestCase/Controller/SentencesControllerTest.php
@@ -185,6 +185,8 @@ class SentencesControllerTest extends IntegrationTestCase {
             [54, 'CC0 1.0', 'kazuki', 'assertEquals'],
             'cannot switch to "admin_only" license as user' =>
             [48, '', 'contributor', 'assertEquals'],
+            'cannot switch from "Licensing issue" as user' =>
+            [52, 'CC BY 2.0 FR', 'advanced_contributor', 'assertEquals'],
         ];
     }
 

--- a/tests/TestCase/View/Helper/LicenseHelperTest.php
+++ b/tests/TestCase/View/Helper/LicenseHelperTest.php
@@ -1,0 +1,78 @@
+<?php
+namespace App\Test\TestCase\View\Helper;
+
+use App\View\Helper\LicenseHelper;
+use App\View\Helper\SentenceLicenseHelper;
+use App\View\Helper\AudioLicenseHelper;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+
+/**
+ * App\View\Helper\FooHelper Test Case
+ */
+class LicenseHelperTest extends TestCase
+{
+    public $License;
+    public $SentenceLicense;
+    public $AudioLicense;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $view = new View();
+        $this->License = new LicenseHelper($view);
+        $this->SentenceLicense = new SentenceLicenseHelper($view);
+        $this->AudioLicense = new AudioLicenseHelper($view);
+    }
+
+    public function tearDown()
+    {
+        unset($this->License);
+        unset($this->SentenceLicense);
+        unset($this->AudioLicense);
+
+        parent::tearDown();
+    }
+
+    public function getLicenseNameProvider() {
+        return [
+            // helper, license, link, expected
+            ['SentenceLicense', '', true, 'No license'],
+            ['SentenceLicense', 'CC0 1.0', false, 'CC0'],
+            ['SentenceLicense', 'CC0 1.0', true, '<a'],
+            ['AudioLicense', '', true, 'No license'],
+            ['AudioLicense', 'CC BY 4.0', false, 'CC BY 4.0'],
+            ['AudioLicense', 'CC BY 4.0', true, '<a'],
+        ];
+    }
+
+    /**
+     * @dataProvider getLicenseNameProvider
+     */
+    public function testGetLicenseName($helper, $license, $link, $expected)
+    {
+        $name = $this->$helper->getLicenseName($license, $link);
+        $this->assertStringStartsWith($expected, $name);
+    }
+
+    public function getLicenseOptionsProvider() {
+        return [
+            // helper, expected
+            ['SentenceLicense', 2],
+            ['AudioLicense', 5],
+        ];
+    }
+
+    /**
+     * @dataProvider getLicenseOptionsProvider
+     */
+    public function testGetLicenseOptionsProvider($helper, $expected) {
+        $options = $this->$helper->getLicenseOptions();
+        $this->assertEquals($expected, count($options));
+    }
+
+    public function testIsKnownLicense() {
+        $this->assertTrue($this->License->isKnownLicense('CC0 1.0'));
+        $this->assertFalse($this->License->isKnownLicense('ABC'));
+    }
+}

--- a/tests/TestCase/View/Helper/LicenseHelperTest.php
+++ b/tests/TestCase/View/Helper/LicenseHelperTest.php
@@ -37,10 +37,10 @@ class LicenseHelperTest extends TestCase
     public function getLicenseNameProvider() {
         return [
             // helper, license, link, expected
-            ['SentenceLicense', '', true, 'No license'],
+            ['SentenceLicense', '', true, 'Unknown'],
             ['SentenceLicense', 'CC0 1.0', false, 'CC0'],
             ['SentenceLicense', 'CC0 1.0', true, '<a'],
-            ['AudioLicense', '', true, 'No license'],
+            ['AudioLicense', '', true, 'Unknown'],
             ['AudioLicense', 'CC BY 4.0', false, 'CC BY 4.0'],
             ['AudioLicense', 'CC BY 4.0', true, '<a'],
         ];
@@ -57,17 +57,19 @@ class LicenseHelperTest extends TestCase
 
     public function getLicenseOptionsProvider() {
         return [
-            // helper, expected
-            ['SentenceLicense', 2],
-            ['AudioLicense', 5],
+            // helper, admin, expected
+            ['SentenceLicense', false, 2],
+            ['SentenceLicense', true, 3],
+            ['AudioLicense', false, 4],
+            ['AudioLicense', true, 5],
         ];
     }
 
     /**
      * @dataProvider getLicenseOptionsProvider
      */
-    public function testGetLicenseOptionsProvider($helper, $expected) {
-        $options = $this->$helper->getLicenseOptions();
+    public function testGetLicenseOptionsProvider($helper, $admin, $expected) {
+        $options = $this->$helper->getLicenseOptions($admin);
         $this->assertEquals($expected, count($options));
     }
 

--- a/tests/TestCase/View/Helper/LicenseHelperTest.php
+++ b/tests/TestCase/View/Helper/LicenseHelperTest.php
@@ -37,10 +37,10 @@ class LicenseHelperTest extends TestCase
     public function getLicenseNameProvider() {
         return [
             // helper, license, link, expected
-            ['SentenceLicense', '', true, 'Unknown'],
+            ['SentenceLicense', '', true, 'Licensing'],
             ['SentenceLicense', 'CC0 1.0', false, 'CC0'],
             ['SentenceLicense', 'CC0 1.0', true, '<a'],
-            ['AudioLicense', '', true, 'Unknown'],
+            ['AudioLicense', '', true, 'No license'],
             ['AudioLicense', 'CC BY 4.0', false, 'CC BY 4.0'],
             ['AudioLicense', 'CC BY 4.0', true, '<a'],
         ];
@@ -60,7 +60,7 @@ class LicenseHelperTest extends TestCase
             // helper, admin, expected
             ['SentenceLicense', false, 2],
             ['SentenceLicense', true, 3],
-            ['AudioLicense', false, 4],
+            ['AudioLicense', false, 5],
             ['AudioLicense', true, 5],
         ];
     }
@@ -74,7 +74,7 @@ class LicenseHelperTest extends TestCase
     }
 
     public function testIsKnownLicense() {
-        $this->assertTrue($this->License->isKnownLicense('CC0 1.0'));
-        $this->assertFalse($this->License->isKnownLicense('ABC'));
+        $this->assertTrue($this->SentenceLicense->isKnownLicense('CC0 1.0'));
+        $this->assertFalse($this->SentenceLicense->isKnownLicense('ABC'));
     }
 }


### PR DESCRIPTION
This PR addresses #1659 

The first commit refactors the LicenseHelper.

The rest implement the first three points of the suggested solution. (The last one was already implemented).