### PR TITLE
Replace all control characters in a sentence's text with space

### DIFF
--- a/src/Model/Entity/Sentence.php
+++ b/src/Model/Entity/Sentence.php
@@ -67,9 +67,11 @@ class Sentence extends Entity
         $text = preg_replace('/[\p{Z}\p{Cc}]+$/u', '', $text);
         // Strip out any byte-order mark that might be present.
         $text = preg_replace("/\xEF\xBB\xBF/", '', $text);
-        // Replace any series of whitespace or control characters
+        // Replace all control characters and any series of whitespace
         // with a single space.
-        $text = preg_replace('/[\p{Z}\p{Cc}]{2,}/u', ' ', $text);
+        // The control characters must be replaced first, so that a possibly
+        // resulting series of whitespace is replaced too.
+        $text = preg_replace(['/\p{Cc}+/u', '/\p{Z}{2,}/u'], ' ', $text);
         // Normalize to NFC
         $text = \Normalizer::normalize($text, \Normalizer::FORM_C);
         // MySQL will truncate to a byte length of 1500, which may split

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -1223,4 +1223,12 @@ class SentencesTableTest extends TestCase {
         $new = $this->Sentence->get(1);
         $this->assertNotEquals($old->hash, $new->hash);
     }
+
+    function testSaveNewSentence_replaceControlCharactersWithSpace() {
+        $text = "Text\u{a}with\u{1}\u{7f}whitespace\u{a0}and\u{a0}\u{a} control\u{90}characters\u{2009}in between.";
+        $expected = "Text with whitespace\u{a0}and control characters\u{2009}in between.";
+        $sentence = $this->Sentence->saveNewSentence($text, 'eng', 1);
+        $stored = $this->Sentence->get($sentence->id)->text;
+        $this->assertEquals($expected, $stored);
+    }
 }


### PR DESCRIPTION
This PR addresses #2250 

The old version only replaced a series of at least two control characters so it was still possible to add sentences which contained single control characters.