### PR TITLE
Correct display of activity timeline page

### DIFF
--- a/src/Template/Contributions/activity_timeline.ctp
+++ b/src/Template/Contributions/activity_timeline.ctp
@@ -100,32 +100,12 @@ if (!empty($stats)) {
     <?php
     foreach ($stats as $date => $stat) {
         $bar = '';
-        if(isset($stat['added']) && $stat['added'] > 0){
-            $width = ($stat['added'] / $maxTotal) * 100;
-            $bar .= $this->Html->div('logs_stats added', '+' . $stat['added'],
-                array('style' => 'width:'.$width.'%')
-            );
-            $totalSentences += $stat['added'];
-        }
-        if(isset($stat['linked']) && $stat['linked'] > 0){
-            $width = ($stat['linked'] / $maxTotal) * 100;
-            $bar .= $this->Html->div('logs_stats linked', '+' . $stat['linked'],
-                array('style' => 'width:'.$width.'%')
-            );
-            $totalLinks += $stat['linked'];
-        }
-        if(isset($stat['unlinked']) && $stat['unlinked'] > 0){
-            $width = ($stat['unlinked'] / $maxTotal) * 100;
-            $bar .= $this->Html->div('logs_stats unlinked', '-' . $stat['unlinked'],
-                array('style' => 'width:'.$width.'%')
-            );
-        }
-        if(isset($stat['deleted']) && $stat['deleted'] > 0){
-            $width = ($stat['deleted'] / $maxTotal) * 100;
-            $bar .= $this->Html->div('logs_stats deleted', '-' . $stat['deleted'],
-                array('style' => 'width:'.$width.'%')
-            );
-        }
+        $bar .= $this->ContributionsStats->statBar($stat, 'added', $maxTotal);
+        $bar .= $this->ContributionsStats->statBar($stat, 'linked', $maxTotal);
+        $bar .= $this->ContributionsStats->statBar($stat, 'unlinked', $maxTotal);
+        $bar .= $this->ContributionsStats->statBar($stat, 'deleted', $maxTotal);
+        $totalSentences += $stat['added'] ?? 0;
+        $totalLinks += $stat['linked'] ?? 0;
 
         $formattedDate = $this->Time->i18nFormat($date, [IntlDateFormatter::SHORT, IntlDateFormatter::NONE]);
         echo '<tr>';

--- a/src/View/Helper/ContributionsStatsHelper.php
+++ b/src/View/Helper/ContributionsStatsHelper.php
@@ -51,9 +51,12 @@ class ContributionsStatsHelper extends AppHelper
     {
         if(isset($stat[$category]) && $stat[$category] > 0){
             $width = ($stat[$category] / $maxTotal) * 100;
-            $minWidth = (mb_strwidth($stat[$category]) + 1) * 13;
-            return $this->Html->div('logs_stats '.$category, '+' . $stat[$category],
-                array('style' => 'width:'.$width.'%;min-width:'.$minWidth.'px')
+            $stringWidth = mb_strwidth($stat[$category]) + 1; // + 1 for the sign
+            $sign = '+';
+            if ($category == "unlinked" || $category == "deleted")
+                $sign = '-';
+            return $this->Html->div("logs_stats ${category}", $sign . $stat[$category],
+                array('style' => "width: ${width}%; min-width: calc(1em * ${stringWidth});")
             );
         }
     }

--- a/src/View/Helper/ContributionsStatsHelper.php
+++ b/src/View/Helper/ContributionsStatsHelper.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2020
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @category PHP
+ * @package  Tatoeba
+ * @license  Affero General Public License
+ * @link     https://tatoeba.org
+ */
+namespace App\View\Helper;
+
+use App\Model\CurrentUser;
+use App\View\Helper\AppHelper;
+
+
+/**
+ * Helper for contributions.
+ *
+ * @category SentenceComments
+ * @package  Helpers
+ * @author   HO Ngoc Phuong Trang <tranglich@gmail.com>
+ * @license  Affero General Public License
+ * @link     https://tatoeba.org
+ */
+class ContributionsStatsHelper extends AppHelper
+{
+    public $helpers = array('Html');
+
+    /**
+     * Return the HTML to display the stats bar corresponding to $category
+     *
+     * @param $stat             Stats array containing number of sentences for each category
+     * @param string $category  Currently one of 'added' 'linked' 'unlinked' 'deleted'
+     * @param int $maxTotal     The highest number of contributions in a day of the month
+     *
+     * @return string
+     */
+    public function statBar($stat, $category, $maxTotal)
+    {
+        if(isset($stat[$category]) && $stat[$category] > 0){
+            $width = ($stat[$category] / $maxTotal) * 100;
+            $minWidth = (mb_strwidth($stat[$category]) + 1) * 13;
+            return $this->Html->div('logs_stats '.$category, '+' . $stat[$category],
+                array('style' => 'width:'.$width.'%;min-width:'.$minWidth.'px')
+            );
+        }
+    }
+}
+?>

--- a/src/View/Helper/ContributionsStatsHelper.php
+++ b/src/View/Helper/ContributionsStatsHelper.php
@@ -24,16 +24,13 @@
  */
 namespace App\View\Helper;
 
-use App\Model\CurrentUser;
 use App\View\Helper\AppHelper;
 
-
 /**
- * Helper for contributions.
+ * Helper for contributions stats.
  *
- * @category SentenceComments
+ * @category ContributionsStats
  * @package  Helpers
- * @author   HO Ngoc Phuong Trang <tranglich@gmail.com>
  * @license  Affero General Public License
  * @link     https://tatoeba.org
  */

--- a/webroot/css/contributions/activity_timeline.css
+++ b/webroot/css/contributions/activity_timeline.css
@@ -45,7 +45,6 @@
     border-left: none;
     display: inline-block;
     text-align: center;
-    min-width: 30px;
 }
 
 #timeline .added {


### PR DESCRIPTION
This is a following of #2180. I dynamically set `min-width` to value proportional to the number of characters in the string, which gives a big enough width (I hope). I'm not sure it's a very good way to do it. If there's a better way to do that, please let me know.

I also added a `ContributionsStatsHelper` in order to factorize the code of the page.

Hopefully, this will give us a nice activity timeline page :) 