### PR TITLE
Move download and delete list buttons (new design)

### DIFF
--- a/src/Template/SentencesLists/show_angular.ctp
+++ b/src/Template/SentencesLists/show_angular.ctp
@@ -79,13 +79,6 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
     <?php
     $this->Lists->displayTranslationsDropdown($listId, $translationsLang);
     ?>
-    <div layout="column" layout-align="end center">
-        <?php
-        if ($permissions['canEdit']) {
-            $this->Lists->displayDeleteButton($listId);
-        }
-        ?>
-    </div>
     </div>
 
 </div>
@@ -111,6 +104,22 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
                     <md-tooltip><?= __('Download this list') ?></md-tooltip>
                 </md-icon>
             </md-button>
+
+            <?php
+                if ($permissions['canEdit']) {
+                    $deleteUrl = $this->Url->build([
+                        'controller' => 'sentences_lists',
+                        'action' => 'delete',
+                    ]);
+                ?>
+                <md-button class="md-icon-button" ng-cloak
+                           ng-href="<?= $deleteUrl; ?>/{{vm.list.id}}"
+                           onclick="return confirm('<?= __('Are you sure?') ?>');">
+                    <md-icon>delete
+                        <md-tooltip><?= __('Delete this list') ?></md-tooltip>
+                    </md-icon>
+                </md-button>
+            <?php } ?>
 
             <?php if ($permissions['canEdit']) { ?>
             <md-button class="md-icon-button" ng-cloak ng-click="vm.editName()">

--- a/src/Template/SentencesLists/show_angular.ctp
+++ b/src/Template/SentencesLists/show_angular.ctp
@@ -84,8 +84,6 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
         if ($permissions['canEdit']) {
             $this->Lists->displayDeleteButton($listId);
         }
-
-        $this->Lists->displayDownloadLink($listId);
         ?>
     </div>
     </div>
@@ -100,7 +98,20 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
             <h2 ng-cloak flex>{{vm.list.currentName}}</h2>
 
             <?= $this->element('sentences/expand_all_menus_button'); ?>
-            
+
+            <?php
+                $downloadUrl = $this->Url->build([
+                    'controller' => 'sentences_lists',
+                    'action' => 'download',
+                ]);
+            ?>
+            <md-button class="md-icon-button" ng-cloak
+                       ng-href="<?= $downloadUrl ?>/{{vm.list.id}}">
+                <md-icon>get_app
+                    <md-tooltip><?= __('Download this list') ?></md-tooltip>
+                </md-icon>
+            </md-button>
+
             <?php if ($permissions['canEdit']) { ?>
             <md-button class="md-icon-button" ng-cloak ng-click="vm.editName()">
                 <md-icon>edit


### PR DESCRIPTION
This PR moves the download and delete list buttons of a list page from the bottom-right to the toolbar. This helps getting rid of items on the right side. I cannot say whether the buttons are easier to find or not, but at least it feels more consistent. It only affects members who activated the new design and guests.

Before:
![image](https://user-images.githubusercontent.com/5107734/78575951-9af18580-785e-11ea-9339-7ed03591e28d.png)

After (now in the toolbar as "little bin" and "arrow down" icons):
![image](https://user-images.githubusercontent.com/5107734/78575854-7dbcb700-785e-11ea-9e34-671afe1bdfb8.png)
