### PR TITLE
Insert developers notes to help translating ambiguous UI strings

### DIFF
--- a/src/Model/Entity/LanguageNameTrait.php
+++ b/src/Model/Entity/LanguageNameTrait.php
@@ -53,6 +53,7 @@ trait LanguageNameTrait
         if (isset($languages["$code"])) {
             return $languages["$code"];
         } else {
+            /* @translators: dropdown option for unknown language */
             return __('unknown');
         }
     }

--- a/src/Template/Activities/adopt_sentences.ctp
+++ b/src/Template/Activities/adopt_sentences.ctp
@@ -70,6 +70,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
     </div>
     
     <div class="section md-whiteframe-1dp">
+        <?php /* @translators: title of the help text on the Adopt sentence page */ ?>
         <h2><?php echo __('Tips'); ?></h2>
         <p>
         <?php 

--- a/src/Template/Activities/translate_sentences.ctp
+++ b/src/Template/Activities/translate_sentences.ctp
@@ -164,6 +164,7 @@ $langsTo = $this->Languages->profileLanguagesArray(false, false, true, true);
                 </label>
                 <md-radio-group ng-model='sort'>
                     <md-radio-button value='random' class='md-primary'>
+                        <?php /* @translators: sort order dropdown option in Translate sentences page (noun) */ ?>
                         <?= __('Random') ?>
                     </md-radio-button>
                     <md-radio-button value='words' class='md-primary'>

--- a/src/Template/Audio/import.ctp
+++ b/src/Template/Audio/import.ctp
@@ -105,13 +105,13 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__d('admin', 'Import re
                       __d('admin', 'Invalid');
         $hasaudio = isset($file['hasaudio']) ? (
                         $file['hasaudio'] ?
-                        __('Yes') :
-                        __('No')
+                        __d('admin', 'Yes') :
+                        __d('admin', 'No')
                     ) :
                     __d('admin', 'N/A');
         $isValid = $file['valid'] ?
-                   __('Yes') :
-                   __('No');
+                   __d('admin', 'Yes') :
+                   __d('admin', 'No');
 
         if (isset($file['hasaudio']) && $file['hasaudio']) {
             $path = Configure::read('Recordings.url')

--- a/src/Template/Audio/of.ctp
+++ b/src/Template/Audio/of.ctp
@@ -60,6 +60,7 @@ if (isset($sentencesWithAudio)) {
             </md-input-container>
             <div layout="row" layout-align="center center">
                 <md-button type="submit" class="md-raised md-primary">
+                    <?php /* @translators: submit button for saving audio contribution settings (verb) */
                     <?php echo __('Save'); ?>
                 </md-button>
             </div>

--- a/src/Template/Audio/of.ctp
+++ b/src/Template/Audio/of.ctp
@@ -60,7 +60,7 @@ if (isset($sentencesWithAudio)) {
             </md-input-container>
             <div layout="row" layout-align="center center">
                 <md-button type="submit" class="md-raised md-primary">
-                    <?php /* @translators: submit button for saving audio contribution settings (verb) */
+                    <?php /* @translators: submit button for saving audio contribution settings (verb) */ ?>
                     <?php echo __('Save'); ?>
                 </md-button>
             </div>

--- a/src/Template/Contributions/activity_timeline.ctp
+++ b/src/Template/Contributions/activity_timeline.ctp
@@ -85,6 +85,7 @@ if (!empty($stats)) {
 
     <thead>
         <tr>
+            <?php /* @translators: first column header on the Activity timeline page */ ?>
             <td class="date"><?= __('Day'); ?></td>
             <td>
                 <div layout="row">

--- a/src/Template/Element/advanced_search_form.ctp
+++ b/src/Template/Element/advanced_search_form.ctp
@@ -32,6 +32,7 @@ echo $this->Form->create('AdvancedSearch', [
 <div layout="column" ng-app="app" ng-cloak>
     <div layout="<?= $layout ?>">
         <div class="column-1" layout="column" flex>
+            <?php /* @translators: section title in advanced search form */ ?>
             <h3><?= __('Sentences'); ?></h3>
 
             <md-input-container>
@@ -80,8 +81,11 @@ echo $this->Form->create('AdvancedSearch', [
                     echo $this->Form->input('orphans', [
                         'label' => '',
                         'options' => [
+                            /* @translators: dropdown option of "Is orphan" field in search form */
                             '' => __x('orphan', 'Any'),
+                            /* @translators: part of Any/No/Yes dropdown options in search form */
                             'no' => __('No'),
+                            /* @translators: part of Any/No/Yes dropdown options in search form */
                             'yes' => __('Yes'),
                         ],
                         'value' => $orphans,
@@ -100,6 +104,7 @@ echo $this->Form->create('AdvancedSearch', [
                     echo $this->Form->input('unapproved', array(
                         'label' => '',
                         'options' => array(
+                            /* @translators: dropdown option of "Is unapproved" field in search form */
                             '' => __x('unapproved', 'Any'),
                             'no' => __('No'),
                             'yes' => __('Yes'),
@@ -119,6 +124,7 @@ echo $this->Form->create('AdvancedSearch', [
                 echo $this->Form->input('has_audio', array(
                     'label' => '',
                     'options' => array(
+                        /* @translators: dropdown option of "Has audio" field in search form */
                         '' => __x('audio', 'Any'),
                         'no' => __('No'),
                         'yes' => __('Yes'),
@@ -176,6 +182,7 @@ echo $this->Form->create('AdvancedSearch', [
 
         <div class="column-2" <?= isset($isSidebar) && $isSidebar ? '' : 'flex' ?>>
             <div layout="column">
+                <?php /* @translators: section title in advanced search form */ ?>
                 <h3><?php echo __('Translations'); ?></h3>
 
                 <div class="param">
@@ -220,8 +227,11 @@ echo $this->Form->create('AdvancedSearch', [
                     echo $this->Form->input('trans_link', array(
                         'label' => '',
                         'options' => array(
+                            /* @translators: dropdown option of "Link" field in search form */
                             '' => __x('link', 'Any'),
+                            /* @translators: dropdown option of "Link" field in search form (noun) */
                             'direct' => __('Direct'),
+                            /* @translators: dropdown option of "Link" field in search form (noun) */
                             'indirect' => __('Indirect'),
                         ),
                         'value' => $trans_link,
@@ -296,18 +306,22 @@ echo $this->Form->create('AdvancedSearch', [
             </div>
 
             <div layout="column">
+                <?php /* @translators: section title in search form (noun) */ ?>
                 <h3><?php echo __('Sort'); ?></h3>
 
                 <div class="param" layout="<?= $layout ?>" layout-align="center">
+                    <?php /* @translators: field name in search form (noun) */ ?>
                     <label for="sort" flex><?= __('Order:') ?></label>
                     <?php
                     echo $this->Form->input('sort', array(
                         'label' => '',
                         'options' => array(
+                            /* @translators: sort order dropdown option in search form */
                             'relevance' => __('Relevance'),
                             'words' => __('Fewest words first'),
                             'created' => __('Last created first'),
                             'modified' => __('Last modified first'),
+                            /* @translators: sort order dropdown option in advanced search form (noun) */
                             'random' => __('Random'),
                         ),
                         'value' => $sort,
@@ -338,6 +352,7 @@ echo $this->Form->create('AdvancedSearch', [
 
     <div class="buttons" layout="<?= $layout ?>">
         <md-button type="submit" class="md-primary md-raised">
+            <?php /* @translators: search form submit button (verb) */ ?>
             <?= __x('button', 'Search') ?>
         </md-button>
 

--- a/src/Template/Element/calendar.ctp
+++ b/src/Template/Element/calendar.ctp
@@ -41,6 +41,7 @@ $months = $this->Date->months();
 ?>
 
 <div class="section md-whiteframe-1dp month">
+    <?php /* @translators: used in the calendar on the Activity timeline page */ ?>
     <h2><?php echo __('Month'); ?></h2>
     <ul>
     <?php
@@ -67,6 +68,7 @@ $months = $this->Date->months();
 </div>
 
 <div class="section md-whiteframe-1dp years">
+    <?php /* @translators: used in the calendar on the Activity timeline page */ ?>
     <h2><?php echo __('Year'); ?></h2>
     <ul>
     <?php

--- a/src/Template/Element/foot.ctp
+++ b/src/Template/Element/foot.ctp
@@ -50,7 +50,8 @@
             <li>
                 <?php
                 echo $this->Html->link(
-                    __('FAQ'),
+                    /* @translators: link text in the footer */
+                    __x('footer', 'FAQ'),
                     'http://en.wiki.tatoeba.org/articles/show/faq'
                 );
                 ?>
@@ -58,6 +59,7 @@
             <li>
                 <?php
                 echo $this->Html->link(
+                    /* @translators: link text to the Help page in the footer (noun) */
                     __('Help'),
                     array(
                         "controller" => "pages",
@@ -70,11 +72,13 @@
     </div>
 
     <div class="category">
+        <?php /* @translators: section name in the footer */ ?>
         <h3><?php echo __('Developers'); ?></h3>
         <ul>
             <li>
                 <?php
                 echo $this->Html->link(
+                    /* @translators: link text to the Downloads page in the footer (noun) */
                     __('Downloads'),
                     array(
                         "controller" => "pages",
@@ -86,6 +90,7 @@
             <li>
                 <?php
                 echo $this->Html->link(
+                    /* @translators: link text to the Tatoeba GitHub page in the footer (noun) */
                     __('GitHub'),
                     'https://github.com/Tatoeba/tatoeba2',
                     array('target' => '_blank')
@@ -95,6 +100,7 @@
             <li>
                 <?php
                 echo $this->Html->link(
+                    /* @translators: link text to the Google group page in the footer (noun) */
                     __('Google group'),
                     'https://groups.google.com/forum/#!forum/tatoebaproject'
                 );
@@ -104,6 +110,7 @@
     </div>
 
     <div class="category">
+        <?php /* @translators: section name in the footer */ ?>
         <h3><?php echo __('About'); ?></h3>
         <ul>
             <li>
@@ -131,6 +138,7 @@
             <li>
                 <?php
                 echo $this->Html->link(
+                   /* @translators: link text to the Status page in the footer (noun) */
                     __('Status'),
                     'https://status.tatoeba.org'
                 );
@@ -138,6 +146,7 @@
             </li>
             <li>
                 <?php
+                /* @translators: link text to the Terms of use page in the footer (noun) */
                 echo $this->Html->link(
                     __('Terms of use'),
                     array(
@@ -150,6 +159,7 @@
             <li>
                 <?php
                 echo $this->Html->link(
+                    /* @translators: link text to the Blog page in the footer (noun) */
                     __('Blog'),
                     'http://blog.tatoeba.org/',
                     array('target' => '_blank')
@@ -159,6 +169,7 @@
             <li>
                 <?php
                 echo $this->Html->link(
+                    /* @translators: link text to the Tatoeba Twitter account in the footer (noun) */
                     __('Twitter'),
                     'http://twitter.com/tatoeba_org',
                     array('target' => '_blank')
@@ -168,6 +179,7 @@
             <li>
                 <?php
                 echo $this->Html->link(
+                    /* @translators: link text to the Tatoeba Facebook page in the footer (noun) */
                     __('Facebook'),
                     'https://www.facebook.com/groups/129340017083187/',
                     array('target' => '_blank')
@@ -185,6 +197,7 @@
                 'Our data is released under various Creative Commons licenses.'
             );
             echo $this->Html->link(
+                /* @translators: link text (in the footer) to the section 6 of the Terms of use page */
                 __('More information'),
                 array(
                     'controller' => 'pages',

--- a/src/Template/Element/header.ctp
+++ b/src/Template/Element/header.ctp
@@ -31,6 +31,9 @@ use Cake\Core\Configure;
     if (Configure::read('Tatoeba.devStylesheet')) {
         $name = 'TatoDev';
     } else {
+        /* @translators: top-left site name written in big.
+           You shouldn't translate it unless speakers of your
+           language cannot read the Latin script. */
         $name = __('Tatoeba');
     }
 

--- a/src/Template/Element/login.ctp
+++ b/src/Template/Element/login.ctp
@@ -44,6 +44,7 @@ use Cake\Controller\Component\AuthComponent;
     <li>
     <?php
     echo $this->Html->link(
+        /* @translators: link to the Register page in the top bar (verb) */
         __('Register'),
         array(
             'controller' => 'users',
@@ -59,6 +60,7 @@ use Cake\Controller\Component\AuthComponent;
     <li>
     <?php
     echo $this->Html->link(
+        /* @translators: link to open the Login box in the top bar (verb) */
         __('Log in'),
         array(
             'controller' => 'users',
@@ -126,6 +128,7 @@ echo $this->Html->link(
     )
 );
 echo $this->Html->link(
+    /* @translators: button to close the top-right login box (verb) */
     __('Close'),
     '#',
     array(

--- a/src/Template/Element/pmmenu.ctp
+++ b/src/Template/Element/pmmenu.ctp
@@ -42,6 +42,7 @@ $isTrashFolder = $this->request->params['action'] == 'folder'
     <div layout="column" layout-margin>
         <md-button class="md-raised md-primary" href="<?= $newMessageUrl ?>">
             <md-icon>email</md-icon>
+            <?php /* @translators: button to compose a new private message (verb) */ ?>
             <?= __('Compose') ?>
         </md-button>
     </div>

--- a/src/Template/Element/private_messages/form.ctp
+++ b/src/Template/Element/private_messages/form.ctp
@@ -4,10 +4,16 @@ if (!isset($isReply)) {
 }
 
 if ($isReply) {
-    $headerTitle = __('Reply');
+    /* @translators: title of section containing a reply
+       form to a private message (noun) */
+    $headerTitle = __x('header', 'Reply');
 } else if (!$pm->id) {
+    /* @translators: title of section containing a form for
+       a new private message (noun) */
     $headerTitle = __('New message');
 } else {
+    /* @translators: title of section containing a form for
+       a private message previously saved as draft (noun) */
     $headerTitle = __('Message');
 }
 ?>
@@ -39,6 +45,7 @@ if ($isReply) {
         <md-input-container>
         <?php
         echo $this->Form->control('recipients', [
+            /* @translators: recipient field label in private message form */
             'label' => __x('message', 'To'),
             'value' => $this->safeForAngular($recipients),
             'maxlength' => 250,
@@ -52,6 +59,7 @@ if ($isReply) {
         <md-input-container>
         <?php
         echo $this->Form->input('title', [
+            /* @translators: title field label in private message form */
             'label' => __('Title'),
             'value' => $this->safeForAngular($pm->title),
             'class' => 'pmTitle',
@@ -77,9 +85,11 @@ if ($isReply) {
 
         <div ng-cloak layout="row" layout-align="end center" layout-padding>
             <md-button type="submit" name="submitType" value="saveDraft" class="md-raised">
+                <?php /* @translators: button to save a private message as draft */ ?>
                 <?php echo __('Save as draft'); ?>
             </md-button>
             <md-button type="submit" name="submitType" value="send" class="md-raised md-primary">
+                <?php /* @translators: button to send a private message (verb) */ ?>
                 <?php echo __('Send'); ?>
             </md-button>
         </div>

--- a/src/Template/Element/random_sentence_header.ctp
+++ b/src/Template/Element/random_sentence_header.ctp
@@ -64,6 +64,7 @@ $langArray = $this->Languages->languagesArrayAlone();
     ) ?></p>
     <div layout="row" layout-align="end center">
         <md-button class="md-primary" href="/user/settings"><?= __('Go to settings') ?></md-button>
+        <?php /* @translators: button to close the announcement about the new design (verb) */ ?>
         <md-button class="md-primary" ng-click="vm.hideAnnouncement()"><?= __('Close') ?></md-button>
     </div>
 </div>

--- a/src/Template/Element/search_bar.ctp
+++ b/src/Template/Element/search_bar.ctp
@@ -73,7 +73,8 @@ echo $this->Form->create(
 
         <div layout="row">
             <label for="SentenceQuery">
-                <?php echo __('Search'); ?>
+                <?php /* @translators: keywords field label in top search bar (not displayed) */ ?>
+                <?php echo __x('label', 'Search'); ?>
             </label>
             <input id="SentenceQuery"
                    type="search"
@@ -90,6 +91,7 @@ echo $this->Form->create(
 
     <div layout="row" layout-align="center end">
         <div layout="column">
+            <?php /* @translators: search language field label in top search bar */ ?>
             <label for="SentenceFrom"><?= __('From') ?></label>
             <?php
             echo $this->element(
@@ -111,6 +113,7 @@ echo $this->Form->create(
 
         <div layout="column">
             <label for="SentenceTo">
+                <?php /* @translators: translation language field label in top search bar */ ?>
                 <?= __x('language', 'To') ?>
             </label>
             <?php

--- a/src/Template/Element/sentence_comments/comment.ctp
+++ b/src/Template/Element/sentence_comments/comment.ctp
@@ -121,7 +121,11 @@ if ($sentenceOwnerLink) {
 
         <?php foreach ($menu as $menuItem) {
             if ($menuItem['text'] == '#') {
-                $itemLabel = $replyIcon ? __('Reply') : __('Permalink');
+                $itemLabel = $replyIcon ?
+                             /* @translators: tooltip of reply button on a comment (verb) */
+                             __x('button', 'Reply') :
+                             /* @translators: tooltip of permalink button on a comment (noun) */
+                             __('Permalink');
             } else {
                 $itemLabel = $menuItem['text'];
             }

--- a/src/Template/Element/sentence_comments/edit_form.ctp
+++ b/src/Template/Element/sentence_comments/edit_form.ctp
@@ -55,10 +55,12 @@ $cancelUrl = $this->Url->build([
 
         <div layout="row" layout-align="end center" layout-padding>
             <md-button class="md-raised" href="<?= $cancelUrl; ?>">
+                <?php /* @translators: cancel button of sentence comment edition form (verb) */ ?>
                 <?php echo __('Cancel'); ?>
             </md-button>
 
             <md-button type="submit" class="md-raised md-primary">
+                <?php /* @translators: save button of sentence comment edition form (verb) */ ?>
                 <?php echo __('Save changes'); ?>
             </md-button>
         </div>

--- a/src/Template/Element/sentences/add_sentence_form.ctp
+++ b/src/Template/Element/sentences/add_sentence_form.ctp
@@ -21,6 +21,7 @@ if (empty($langs)) {
 
         <div layout="row" layout-align="start center">
             <md-input-container flex="50">
+                <?php /* @translators: language field label on new sentence addition form */ ?>
                 <label><?= __('Language') ?></label>
                 <md-select ng-model="vm.newSentence.lang">
                     <md-option value="auto" ng-if="vm.showAutoDetect"><?= __('Auto detect') ?></md-option>
@@ -37,6 +38,7 @@ if (empty($langs)) {
 
             <?php if (CurrentUser::getSetting('can_switch_license')) : ?>
             <md-input-container>
+                <?php /* @translators: label for licence selection dropdown in sentence addition form */ ?>
                 <label><?= __('License'); ?></label>
                 <md-select ng-model="vm.newSentence.license" ng-init="vm.newSentence.license = '<?= $defautLicense ?>'">
                     <md-option ng-repeat="(code, name) in vm.licenses" ng-value="code">
@@ -48,6 +50,7 @@ if (empty($langs)) {
         </div>
 
         <md-input-container>
+            <?php /* @translators: label for sentence text in sentence addition form */ ?>
             <label><?= __('Sentence') ?></label>
             <textarea name="text" ng-model="vm.newSentence.text" ng-enter="vm.addSentence(sentenceForm)"></textarea>
             

--- a/src/Template/Element/sentences/add_sentences_jquery.ctp
+++ b/src/Template/Element/sentences/add_sentences_jquery.ctp
@@ -31,6 +31,7 @@ $this->Html->script(JS_PATH . 'sentences.contribute.js', ['block' => 'scriptBott
         <div layout="column" layout-margin>
             <div layout="row">
                 <div class="language-select" layout="row" layout-align="start center" flex>
+                    <?php /* @translators: language field label on new sentence addition form */ ?>
                     <label><?= __('Language'); ?></label>
                     <?php
                     echo $this->Form->select(
@@ -49,6 +50,7 @@ $this->Html->script(JS_PATH . 'sentences.contribute.js', ['block' => 'scriptBott
 
                 <?php if (CurrentUser::getSetting('can_switch_license')) : ?>
                 <div class="license-select" layout="row" layout-align="end center" flex>
+                    <?php /* @translators: licence field label on new sentence addition form */ ?>
                     <label><?= __('License'); ?></label>
                     <?php
                     echo $this->Form->select(
@@ -76,6 +78,7 @@ $this->Html->script(JS_PATH . 'sentences.contribute.js', ['block' => 'scriptBott
 
             <div layout="row" layout-align="center center">
                 <md-button id="submitNewSentence" class="md-raised md-primary">
+                    <?php /* @translators: submit button of new sentence addition form */ ?>
                     <?= __('OK') ?>
                 </md-button>
             </div>

--- a/src/Template/Element/sentences/audio.ctp
+++ b/src/Template/Element/sentences/audio.ctp
@@ -34,6 +34,7 @@ if (!$shouldDisplayBlock) {
 
 ?>
 <div class="section md-whiteframe-1dp">
+    <?php /* @translators: header text in sentence page */ ?>
     <h2><?php echo __('Audio') ?></h2>
 <?php
 

--- a/src/Template/Element/sentences/license.ctp
+++ b/src/Template/Element/sentences/license.ctp
@@ -27,6 +27,7 @@
 use App\Model\CurrentUser;
 ?>
 <div class="section md-whiteframe-1dp">
+    <?php /* @translators: header text on sentence page */ ?>
     <h2><?php echo __('License') ?></h2>
 
 <?php

--- a/src/Template/Element/sentences/list_form.ctp
+++ b/src/Template/Element/sentences/list_form.ctp
@@ -5,6 +5,7 @@
             <input ng-attr-id="list-form-{{vm.sentence.id}}" ng-model="vm.listSearch"
                    ng-change="vm.searchList()" ng-enter="vm.addToNewList()" ng-escape="vm.closeList()">
         </md-input-container>
+        <?php /* @translators: button to create a new list directly from a sentence block */ ?>
         <md-button class="md-raised md-primary" ng-click="vm.addToNewList()" ng-disabled="!vm.listSearch"><?= __('Create') ?></md-button>
     </div>
 

--- a/src/Template/Element/sentences/navigation.ctp
+++ b/src/Template/Element/sentences/navigation.ctp
@@ -21,15 +21,18 @@ $sentenceUrl = $this->Url->build([
         <md-button ng-href="<?= $sentenceUrl ?>/{{vm.prev}}" class="md-primary"
                    ng-disabled="!vm.prev">
             <md-icon>keyboard_arrow_left</md-icon>
+            <?php /* @translators: link to neighbour sentence on sentence page */ ?>
             <?= __('previous') ?>
         </md-button>
 
         <md-button ng-href="<?= $sentenceUrl ?>/{{vm.lang}}" class="md-primary">
+            <?php /* @translators: link to a random sentence on sentence page */ ?>
             <?= __('random') ?>
         </md-button>
 
         <md-button ng-href="<?= $sentenceUrl ?>/{{vm.next}}" class="md-primary"
                    ng-disabled="!vm.next">
+            <?php /* @translators: link to neighbour sentence on sentence page */ ?>
             <?= __('next') ?>
             <md-icon>keyboard_arrow_right</md-icon>
         </md-button>

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -180,6 +180,7 @@ $sentenceUrl = $this->Url->build([
 
     <div layout="column" class="direct translations" ng-if="vm.visibility.translations && vm.directTranslations.length > 0">
         <md-divider></md-divider>
+        <?php /* @translators: text divider between a sentence and its translations */ ?>
         <md-subheader><?= __('Translations') ?></md-subheader>
 
         <?php

--- a/src/Template/Element/sentences/sentence_form.ctp
+++ b/src/Template/Element/sentences/sentence_form.ctp
@@ -14,6 +14,7 @@
 
     <div layout="row" layout-align="start center" ng-if="vm.sentence.permissions.canEdit">
         <md-input-container flex="50">
+            <?php /* @translators: language field label on sentence addition form */ ?>
             <label><?= __('Language') ?></label>
             <md-select ng-model="vm.sentence.lang">
                 <md-option value="unknown"><?= __('Other language') ?></md-option>
@@ -30,6 +31,7 @@
     </div>
 
     <md-input-container ng-if="vm.sentence.permissions.canEdit">
+        <?php /* @translators: sentence text field label on new sentence addition form */ ?>
         <label><?= __('Sentence') ?></label>
         <textarea ng-attr-id="sentence-form-{{vm.sentence.id}}" ng-model="vm.sentence.text" 
                   ng-enter="vm.editSentence()" ng-escape="vm.cancelEdit()"></textarea>
@@ -39,6 +41,7 @@
     <div layout="column" ng-if="transcription.markup" ng-repeat="transcription in vm.sentence.transcriptions">
         <div layout="row" layout-align="start center" flex>
             <md-input-container flex>
+                <?php /* @translators: label for transcription edition/addition form */ ?>
                 <label><?= __('Transcription') ?></label>
                 <textarea ng-attr-id="transcription-form-{{transcription.sentence.id}}" ng-model="transcription.markup"
                           ng-change="transcription.error = null; transcription.needsReview = false;"
@@ -49,6 +52,7 @@
             
             <md-button class="md-icon-button" ng-click="vm.saveTranscription(transcription, vm.sentence, 'reset')">
                 <md-icon>undo</md-icon>
+                <?php /* @translators: reset button of transcription edition form (verb) */ ?>
                 <md-tooltip><?= __('Reset') ?></md-tooltip>
             </md-button>
                         
@@ -61,9 +65,11 @@
 
     <div layout="row" layout-align="end center">
         <md-button class="md-raised" ng-click="vm.cancelEdit()">
+            <?php /* @translators: cancel button of sentence text edition form (verb) */ ?>
             <?= __('Cancel') ?>
         </md-button>
         <md-button class="md-raised md-primary" ng-click="vm.editSentence()">
+            <?php /* @translators: submit button of sentence text edition form (verb) */ ?>
             <?= __('Save') ?>
         </md-button>
     </div>

--- a/src/Template/Element/sentences/sentence_menu.ctp
+++ b/src/Template/Element/sentences/sentence_menu.ctp
@@ -5,11 +5,13 @@
             <md-button class="md-icon-button" ng-click="vm.translate(vm.sentence.id)"
                 ng-disabled="vm.sentence.correctness === -1 || vm.sentence.license === ''">
                 <md-icon>translate</md-icon>
+                <?php /* @translators: translate button on sentence menu (verb) */ ?>
                 <md-tooltip><?= __('Translate') ?></md-tooltip>
             </md-button>
 
             <md-button ng-if="vm.menu.canEdit || vm.menu.canTranscribe" class="md-icon-button" ng-click="vm.edit()">
                 <md-icon>edit</md-icon>
+                <?php /* @translators: edit button on sentence menu (verb) */ ?>
                 <md-tooltip><?= __('Edit') ?></md-tooltip>
             </md-button>
             
@@ -33,6 +35,7 @@
                        onclick="return confirm('<?= __('Are you sure?') ?>');"
                        ng-href="<?= $this->Url->build(['controller' => 'sentences', 'action' => 'delete']) ?>/{{vm.sentence.id}}">
                 <md-icon>delete</md-icon>
+                <?php /* @translators: delete button on sentence menu (verb) */ ?>
                 <md-tooltip><?= __('Delete') ?></md-tooltip>
             </md-button>
         </div>

--- a/src/Template/Element/sentences/translation_form.ctp
+++ b/src/Template/Element/sentences/translation_form.ctp
@@ -3,6 +3,7 @@
 <?php if (!empty($langs)) { ?>
     <form layout="column" layout-margin>
         <md-input-container>
+            <?php /* @translators: translation field label on new translation addition form */ ?>
             <label><?= __('Translation') ?></label>
             <textarea ng-attr-id="translation-form-{{vm.sentence.id}}" ng-model="vm.newTranslation.text" 
                       ng-enter="vm.saveTranslation(vm.sentence.id)"></textarea>
@@ -10,6 +11,7 @@
         
         <div layout="row" layout-align="start center">
             <md-input-container flex="50">
+                <?php /* @translators: language field label on new translation addition form */ ?>
                 <label><?= __('Language') ?></label>
                 <md-select ng-model="vm.newTranslation.lang">
                     <md-option value="auto" ng-if="vm.showAutoDetect"><?= __('Auto detect') ?></md-option>
@@ -27,6 +29,7 @@
 
         <div layout="row" layout-align="end center">
             <md-button class="md-raised" ng-click="vm.hide('translation_form')">
+                <?php /* @translators: cancel button of translation addition/edition form (verb) */ ?>
                 <?= __('Cancel') ?>
             </md-button>
             <md-button class="md-raised md-primary" ng-click="vm.saveTranslation(vm.sentence.id)">

--- a/src/Template/Element/space.ctp
+++ b/src/Template/Element/space.ctp
@@ -53,6 +53,7 @@ use Cake\ORM\TableRegistry;
     <ul class='sub-menu'>
         <li class="item">
             <?php
+            /* @ŧranslators: top-right user menu item to open your profile page */
             echo $this->Html->link(
                 __('My profile'),
                 array(
@@ -67,6 +68,7 @@ use Cake\ORM\TableRegistry;
         <li class="item">
             <?php
             echo $this->Html->link(
+                /* @ŧranslators: top-right user menu item to list your sentences */
                 __('My sentences'),
                 array(
                     'controller' => 'sentences',
@@ -80,6 +82,7 @@ use Cake\ORM\TableRegistry;
         <li class="item">
             <?php
             echo $this->Html->link(
+                /* @ŧranslators: top-right user menu item to list your vocabulary */
                 __('My vocabulary'),
                 array(
                     'controller' => 'vocabulary',
@@ -93,6 +96,7 @@ use Cake\ORM\TableRegistry;
         <li class="item">
             <?php
             echo $this->Html->link(
+                /* @ŧranslators: top-right user menu item to list your reviews */
                 __('My reviews'),
                 array(
                     'controller' => 'reviews',
@@ -106,6 +110,7 @@ use Cake\ORM\TableRegistry;
         <li class="item">
             <?php
             echo $this->Html->link(
+                /* @ŧranslators: top-right user menu item to list your lists */
                 __('My lists'),
                 array(
                     'controller' => 'sentences_lists',
@@ -119,6 +124,7 @@ use Cake\ORM\TableRegistry;
         <li class="item">
             <?php
             echo $this->Html->link(
+                /* @ŧranslators: top-right user menu item to list your favorites */
                 __('My favorites'),
                 array(
                     'controller' => 'favorites',
@@ -132,6 +138,7 @@ use Cake\ORM\TableRegistry;
         <li class="item">
             <?php
             echo $this->Html->link(
+                /* @ŧranslators: top-right user menu item to list your comments */
                 __('My comments'),
                 array(
                     'controller' => 'sentence_comments',
@@ -145,6 +152,7 @@ use Cake\ORM\TableRegistry;
         <li class="item">
             <?php
             echo $this->Html->link(
+                /* @ŧranslators: top-right user menu item to list comments made on your sentences */
                 __("Comments on my sentences"),
                 array(
                     'controller' => 'sentence_comments',
@@ -158,6 +166,7 @@ use Cake\ORM\TableRegistry;
         <li class="item">
             <?php
             echo $this->Html->link(
+                /* @ŧranslators: top-right user menu item to list your wall posts */
                 __('My Wall messages'),
                 array(
                     'controller' => 'wall',
@@ -171,6 +180,7 @@ use Cake\ORM\TableRegistry;
         <li class="item">
             <?php
             echo $this->Html->link(
+                /* @ŧranslators: top-right user menu item to list your contributions */
                 __('My sentence logs'),
                 array(
                     'controller' => 'contributions',
@@ -184,6 +194,7 @@ use Cake\ORM\TableRegistry;
         <li class="settings">
             <?php
             echo $this->Html->link(
+                /* @ŧranslators: top-right user menu item to open your settings */
                 __('Settings'),
                 array(
                     'controller' => 'user',

--- a/src/Template/Element/top_menu.ctp
+++ b/src/Template/Element/top_menu.ctp
@@ -45,92 +45,111 @@ if (empty($showTranslationsInto)) {
 
 // array containing the elements of the menu : $title => $route
 $menuElements = array(
+    /* @translators: menu on the top (verb) */
     __('Browse') => array(
         "route" => array(
             "controller" => false,
             "action" => false
         ),
         "sub-menu" => array(
+            /* @translators: menu item on the top (verb) */
             __('Random sentence') => array(
                 "controller" => "sentences",
                 "action" => "show",
                 "random"
             ),
+            /* @translators: menu item on the top (verb) */
             __('Browse by language') => array(
                 "controller" => "sentences",
                 "action" => "show_all_in",
                 $currentLanguage, $showTranslationsInto
             ),
+            /* @translators: menu item on the top (verb) */
             __('Browse by list') => array(
                 "controller" => "sentences_lists",
                 "action" => "index"
             ),
+            /* @translators: menu item on the top (verb) */
             __('Browse by tag') => array(
                 "controller" => "tags",
                 "action" => "view_all"
             ),
+            /* @translators: menu item on the top (verb) */
             __('Browse audio') => array(
                 "controller" => "audio",
                 "action" => "index"
             )
         )
     ),
+    /* @translators: menu on the top (verb) */
     __('Contribute') => array(
         "route" => array(
             "controller" => false,
             "action" => false
         ),
         "sub-menu" => array(
+            /* @translators: menu item on the top (verb) */
             __('Add sentences') => array(
                 "controller" => "sentences",
                 "action" => "add"
             ),
+            /* @translators: menu item on the top (verb) */
             __('Translate sentences') => array(
                 "controller" => "activities",
                 "action" => "translate_sentences"
             ),
+            /* @translators: menu item on the top (verb) */
             __('Adopt sentences') => array(
                 "controller" => "activities",
                 "action" => "adopt_sentences",
                 $currentLanguage
             ),
+            /* @translators: menu item on the top (verb) */
             __('Improve sentences') => array(
                 "controller" => "activities",
                 "action" => "improve_sentences"
             ),
+            /* @translators: menu item on the top (verb) */
             __('Discuss sentences') => array(
                 "controller" => "sentence_comments",
                 "action" => "index"
             ),
+            /* @translators: menu item on the top (verb) */
             __('Add vocabulary request') => array(
                 "controller" => "vocabulary",
                 "action" => "add_sentences",
                 $filteredLanguage
             ),
+            /* @translators: menu item on the top (verb) */
             __('Show activity timeline') => array(
                 "controller" => "contributions",
                 "action" => "activity_timeline"
             ),
         )
     ),
+    /* @translators: menu on the top (verb) */
     __('Community') => array(
         "route" => array(
             "controller" => false,
             "action" => false
         ),
         "sub-menu" => array(
+            /* @translators: menu item on the top (verb) */
             __('Wall') => array(
                 "controller" => "wall",
                 "action" => "index"
             ),
+            /* @translators: menu item on the top (verb) */
             __('List of all members') => array(
                 "controller" => "users",
                 "action" => "all"
             ),
+            /* @translators: menu item on the top (verb) */
             __('Languages of members') => array(
                 "controller" => "stats",
                 "action" => "users_languages"
             ),
+            /* @translators: menu item on the top (verb) */
             __('Native speakers') => array(
                 "controller" => "stats",
                 "action" => "native_speakers"

--- a/src/Template/Element/users_menu.ctp
+++ b/src/Template/Element/users_menu.ctp
@@ -29,6 +29,7 @@ use App\Model\CurrentUser;
 $this->Html->script('elements/user-menu.ctrl.js', ['block' => 'scriptBottom']);
 $menu = [
     [
+        /* @translators: link to the user's profile in the sidebar */
         'label' => __('Profile'),
         'url' => [
             'controller' => 'user',
@@ -37,6 +38,7 @@ $menu = [
         ]
     ],
     [
+        /* @translators: link to the user's sentences on profile page sidebar */
         'label' => __('Sentences'),
         'url' => [
             'controller' => 'sentences',
@@ -45,6 +47,7 @@ $menu = [
         ]
     ],
     [
+        /* @translators: link to the user's vocabulary on profile page sidebar */
         'label' => __('Vocabulary'),
         'url' => [
             'controller' => 'vocabulary',
@@ -53,6 +56,7 @@ $menu = [
         ]
     ],
     [
+        /* @translators: link to the user's reviews on profile page sidebar */
         'label' => __('Reviews'),
         'url' => [
             'controller' => 'reviews',
@@ -61,6 +65,7 @@ $menu = [
         ]
     ],
     [
+        /* @translators: link to the user's lists on profile page sidebar */
         'label' => __('Lists'),
         'url' => [
             'controller' => 'sentences_lists',
@@ -69,6 +74,7 @@ $menu = [
         ]
     ],
     [
+        /* @translators: link to the user's favorite sentences on profile page sidebar */
         'label' => __('Favorites'),
         'url' => [
             'controller' => 'favorites',
@@ -77,6 +83,7 @@ $menu = [
         ]
     ],
     [
+        /* @translators: link to the user's sentence comments on profile page sidebar */
         'label' => __('Comments'),
         'url' => [
             'controller' => 'sentence_comments',
@@ -85,6 +92,7 @@ $menu = [
         ]
     ],
     [
+        /* @translators: link on profile page sidebar */
         'label' => format(__("Comments on {user}'s sentences"), ['user' => $username]),
         'url' => [
             'controller' => 'sentence_comments',
@@ -93,6 +101,7 @@ $menu = [
         ]
     ],
     [
+        /* @translators: link to the user's wall posts on profile page sidebar */
         'label' => __('Wall messages'),
         'url' => [
             'controller' => 'wall',
@@ -101,6 +110,7 @@ $menu = [
         ]
     ],
     [
+        /* @translators: link to the user's contributions on profile page sidebar */
         'label' => __('Logs'),
         'url' => [
             'controller' => 'contributions',
@@ -112,6 +122,7 @@ $menu = [
         'separator'
     ],
     [
+        /* @translators: link to the list of audio on profile page sidebar */
         'label' => __('Audio'),
         'url' => [
             'controller' => 'audio',
@@ -120,6 +131,7 @@ $menu = [
         ]
     ],
     [
+        /* @translators: link to the list of transcriptions on profile page sidebar */
         'label' => __('Transcriptions'),
         'url' => [
             'controller' => 'transcriptions',
@@ -132,6 +144,7 @@ $menu = [
     ],
     [
         'icon' => 'translate',
+        /* @translators: link text on profile page sidebar */
         'label' => format(__("Translate {user}'s sentences"), ['user' => $username]),
         'url' => [
             'controller' => 'activities',

--- a/src/Template/Element/wall/add_form.ctp
+++ b/src/Template/Element/wall/add_form.ctp
@@ -43,6 +43,7 @@ $avatar = $user['image'];
 
         <div ng-cloak layout="row" layout-align="end center">
             <md-button type="submit" class="md-raised md-primary submit">
+                <?php /* @translators: button to post a new message on the Wall (verb) */ ?>
                 <?php echo __('Send'); ?>
             </md-button>
         </div>

--- a/src/Template/Element/wall/edit_form.ctp
+++ b/src/Template/Element/wall/edit_form.ctp
@@ -42,10 +42,12 @@ $cancelUrl = $this->Url->build([
 
         <div layout="row" layout-align="end center" layout-padding>
             <md-button class="md-raised" href="<?= $cancelUrl; ?>">
+                <?php /* @translators: cancel button of wall post edition form (verb) */ ?>
                 <?php echo __('Cancel'); ?>
             </md-button>
 
             <md-button type="submit" class="md-raised md-primary">
+                <?php /* @translators: save button of wall post edition form (verb) */ ?>
                 <?php echo __('Save changes'); ?>
             </md-button>
         </div>

--- a/src/Template/Element/wall/message.ctp
+++ b/src/Template/Element/wall/message.ctp
@@ -38,7 +38,8 @@ if (isset($message['Permissions'])) {
     $menu = [];
 }
 $menu[] = [
-    'text' => 'permalink',
+    /* tooltip of permalink button on a wall post (noun) */
+    'text' => __('Permalink'),
     'icon' => 'link',
     'url' => [
         'controller' => 'wall',

--- a/src/Template/Element/wall/reply_form.ctp
+++ b/src/Template/Element/wall/reply_form.ctp
@@ -27,7 +27,7 @@ $editUrl = $this->Url->build([
             </span>
         </md-card-header-text>
 
-        <md-button class="md-icon-button" aria-label="<?= __('edit') ?>"
+        <md-button class="md-icon-button" aria-label="<?= __('Edit') ?>"
                    ng-if="vm.savedReplies[<?= $parentId ?>].id"
                    ng-href="<?= $editUrl ?>/{{vm.savedReplies[<?= $parentId ?>].id}}">
             <md-icon>edit</md-icon>

--- a/src/Template/Element/wall/reply_form.ctp
+++ b/src/Template/Element/wall/reply_form.ctp
@@ -31,6 +31,7 @@ $editUrl = $this->Url->build([
                    ng-if="vm.savedReplies[<?= $parentId ?>].id"
                    ng-href="<?= $editUrl ?>/{{vm.savedReplies[<?= $parentId ?>].id}}">
             <md-icon>edit</md-icon>
+            <?php /* @translators: edit button on a just-posted reply of a wall post (verb) */ ?>
             <md-tooltip><?= __('Edit') ?></md-tooltip>
         </md-button>
     </md-card-header>
@@ -62,11 +63,13 @@ $editUrl = $this->Url->build([
 
         <div ng-cloak layout="row" layout-align="end center">
             <md-button class="md-raised" ng-click="vm.hideForm(<?= $parentId ?>)">
+                <?php /* @translators: button to cancel posting a reply on the Wall (verb) */ ?>
                 <?php echo __('Cancel'); ?>
             </md-button>
 
             <md-button type="submit" class="md-raised md-primary submit"
                        ng-disabled="vm.isSaving[<?= $parentId ?>]">
+                <?php /* @translators: button to post a reply on the Wall (verb) */ ?>
                 <?php echo __('Send'); ?>
             </md-button>
         </div>

--- a/src/Template/Exports/index.ctp
+++ b/src/Template/Exports/index.ctp
@@ -13,7 +13,10 @@
     <span ng-show="export.status == 'online' && export.generated">{{export.generated | date:'yyyy-MM-dd'}}</span>
     <md-button class="md-raised md-primary"
                ng-href="/exports/download/{{export.id}}/{{export.pretty_filename | urlEncode}}"
-               ng-show="export.status == 'online'"><?= __x('button', 'Download') ?></md-button>
+               ng-show="export.status == 'online'">
+        <?php /* @translators: button to download a list (verb) */ ?>
+        <?= __x('button', 'Download') ?>
+    </md-button>
     <span ng-show="export.status == 'queued'"><?= __('Export in progress') ?></span>
     <span ng-show="export.status == 'failed'">
         <md-icon>error</md-icon>

--- a/src/Template/Layout/error.ctp
+++ b/src/Template/Layout/error.ctp
@@ -32,6 +32,7 @@
 <body>
     <div id="container">
         <div id="header">
+            <?php /* @translators: title of error page (noun) */ ?>
             <h1><?= __('Error') ?></h1>
         </div>
         <div id="content">
@@ -40,6 +41,7 @@
             <?= $this->fetch('content') ?>
         </div>
         <div id="footer">
+            <?php /* @translators: link to go back the previous page from an error page (noun) */ ?>
             <?= $this->Html->link(__('Back'), 'javascript:history.back()') ?>
         </div>
     </div>

--- a/src/Template/Links/add.ctp
+++ b/src/Template/Links/add.ctp
@@ -2,10 +2,12 @@
 
 if ($saved) {
     $image = 'unlink.svg';
+    /* @translators: alt text for unlink translation button (verb) */
     $alt = __('Unlink');
     $title = __('Unlink this translation.');
 } else {
     $image = 'link.svg';
+    /* @translators: alt text for link translation button (verb) */
     $alt = __('Link');
     $title = __('Make into direct translation.');
 }

--- a/src/Template/Links/delete.ctp
+++ b/src/Template/Links/delete.ctp
@@ -1,10 +1,12 @@
 <?php
 if (!$saved) {
     $image = 'unlink.svg';
+    /* @translators: alt text for unlink translation button (verb) */
     $alt = __('Unlink');
     $title = __('Unlink this translation.');
 } else {
     $image = 'link.svg';
+    /* @translators: alt text for link translation button (verb) */
     $alt = __('Link');
     $title = __('Make into direct translation.');
 }

--- a/src/Template/Pages/contact.ctp
+++ b/src/Template/Pages/contact.ctp
@@ -39,7 +39,8 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Contact us')));
 ?>
 <div id="annexe_content">
     <div class="section md-whiteframe-1dp">
-        <h2><?php echo __('FAQ'); ?></h2>
+        <?php /* @translators: section title in the Contact page */ ?>
+        <h2><?php echo __x('header', 'FAQ'); ?></h2>
         <p>
         <?php
         $faqUrl = $this->Url->build(array('action' => 'faq'));

--- a/src/Template/Pages/donate.ctp
+++ b/src/Template/Pages/donate.ctp
@@ -25,6 +25,7 @@
  * @link     https://tatoeba.org
  */
 
+/* @translators: title of the Donate page */
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Donate')));
 ?>
 

--- a/src/Template/Pages/downloads.ctp
+++ b/src/Template/Pages/downloads.ctp
@@ -36,30 +36,53 @@ $tanaka_url2 = "http://www.edrdg.org/wiki/index.php/Tanaka_Corpus";
 $download_url = Configure::read('Downloads.url');
 
 // Section Headers
+/* @translators: header text on Downloads page */
 $filename =  __('Filename');
+/* @translators: header text on Downloads page */
 $format = __('Fields and structure');
+/* @translators: header text on Downloads page */
 $description = __('File description');
 
 // Field names
+/* @translators: field name in Fields and structure on Downloads page */
 $sentence_id = __('Sentence id');
+/* @translators: field name in Fields and structure on Downloads page (noun) */
 $review = __('Review');
+/* @translators: field name in Fields and structure on Downloads page (noun) */
 $text = __('Text');
+/* @translators: field name in Fields and structure on Downloads page */
 $lang = __('Lang');
+/* @translators: field name in Fields and structure on Downloads page */
 $username = __('Username');
+/* @translators: field name in Fields and structure on Downloads page */
 $date_added = __('Date added');
+/* @translators: field name in Fields and structure on Downloads page */
 $date_created = __('Date created');
+/* @translators: field name in Fields and structure on Downloads page */
 $date_modified = __('Date last modified');
+/* @translators: field name in Fields and structure on Downloads page */
 $translation_id = __('Translation id');
+/* @translators: field name in Fields and structure on Downloads page */
 $tag_name = __('Tag name');
+/* @translators: field name in Fields and structure on Downloads page */
 $list_id = __('List id');
+/* @translators: field name in Fields and structure on Downloads page */
 $list_name = __('List name');
+/* @translators: field name in Fields and structure on Downloads page */
 $list_editable_by = __('Editable by');
+/* @translators: field name in Fields and structure on Downloads page */
 $meaning_id = __('Meaning id');
+/* @translators: field name in Fields and structure on Downloads page */
 $skill_level = __('Skill level');
+/* @translators: field name in Fields and structure on Downloads page */
 $details = __('Details');
+/* @translators: field name in Fields and structure on Downloads page (noun) */
 $license = __('License');
+/* @translators: field name in Fields and structure on Downloads page */
 $attribution_url = __('Attribution URL');
+/* @translators: field name in Fields and structure on Downloads page */
 $script = __('Script name');
+/* @translators: field name in Fields and structure on Downloads page */
 $transcription = __('Transcription');
 
 // Examples in description
@@ -77,6 +100,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
 
 <div id="annexe_content">
     <div class="section md-whiteframe-1dp">
+        <?php /* @translators: header text in the Downloads page on the sidebar (noun) */ ?>
         <h2><?= __('Note') ?></h2>
         <p>
             <?= __(
@@ -117,6 +141,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
     </div>
 
     <div class="section md-whiteframe-1dp">
+        <?php /* @translators: header text in the Downloads page on the sidebar */ ?>
         <h2><?= __('Creative commons') ?></h2>
         <p><?= __('These files are released under CC BY 2.0 FR.') ?></p>
         <a rel="license" href="https://creativecommons.org/licenses/by/2.0/fr/">
@@ -131,6 +156,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
     </div>
 
     <div class="section md-whiteframe-1dp">
+        <?php /* @translators: header text in the Downloads page on the sidebar */ ?>
         <h2><?= __('Licenses covering audio') ?></h2>
         <p>
             <?= __(
@@ -142,6 +168,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
     </div>
 
     <div class="section md-whiteframe-1dp">
+        <?php /* @translators: header text in the Downloads page on the sidebar */ ?>
         <h2><?= __('Questions?') ?></h2>
         <p>
             <?= format(
@@ -157,10 +184,12 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
 
 <div id="main_content">
     <div>
+        <?php /* @translators: title of the Downloads page */ ?>
         <h1><?= __('Downloads') ?></h1>
 
         <!-- Sentences -->
         <div  class="section md-whiteframe-1dp">
+            <?php /* @translators: section title in the Downloads page */ ?>
             <h2><?= __('Sentences') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
@@ -189,6 +218,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
 
         <!-- Sentences detailed-->
         <div  class="section md-whiteframe-1dp">
+            <?php /* @translators: section title in the Downloads page */ ?>
             <h2><?= __('Detailed Sentences') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
@@ -219,6 +249,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
 
         <!-- Sentences CC0 -->
         <div  class="section md-whiteframe-1dp">
+            <?php /* @translators: section title in the Downloads page */ ?>
             <h2><?= __('Sentences (CC0)') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
@@ -242,6 +273,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
 
         <!-- Links -->
         <div  class="section md-whiteframe-1dp">
+            <?php /* @translators: section title in the Downloads page */ ?>
             <h2><?= __('Links') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
@@ -268,6 +300,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
 
         <!-- Tags -->
         <div  class="section md-whiteframe-1dp">
+            <?php /* @translators: section title in the Downloads page */ ?>
             <h2><?= __('Tags') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
@@ -293,6 +326,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
 
         <!-- Lists -->
         <div  class="section md-whiteframe-1dp">
+            <?php /* @translators: section title in the Downloads page */ ?>
             <h2><?= __('Lists') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
@@ -316,6 +350,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
         </div>
 
         <div  class="section md-whiteframe-1dp">
+            <?php /* @translators: section title in the Downloads page */ ?>
             <h2><?= __('Sentences in lists') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
@@ -344,6 +379,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
 
         <!-- Indices -->
         <div  class="section md-whiteframe-1dp">
+            <?php /* @translators: section title in the Downloads page */ ?>
             <h2><?= __('Japanese indices') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
@@ -374,6 +410,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
 
         <!-- Sentences with audio -->
         <div  class="section md-whiteframe-1dp">
+            <?php /* @translators: section title in the Downloads page */ ?>
             <h2><?= __('Sentences with audio') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
@@ -403,6 +440,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
 
         <!-- User skill level per language -->
         <div  class="section md-whiteframe-1dp">
+            <?php /* @translators: section title in the Downloads page */ ?>
             <h2><?= __('User skill level per language') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
@@ -422,6 +460,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
 
         <!-- Users' reviews -->
         <div  class="section md-whiteframe-1dp">
+            <?php /* @translators: section title in the Downloads page */ ?>
             <h2><?= __('Users\' sentence reviews') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>
@@ -447,6 +486,7 @@ $transcriptionsOptions = $this->Downloads->createOptions('transcriptions');
 
         <!-- Transcriptions -->
         <div class="section md-whiteframe-1dp">
+            <?php /* @translators: section title in the Downloads page */ ?>
             <h2><?= __('Transcriptions') ?></h2>
             <dl>
                 <dt><?= $filename ?></dt>

--- a/src/Template/Pages/help.ctp
+++ b/src/Template/Pages/help.ctp
@@ -25,6 +25,7 @@
  * @link     https://tatoeba.org
  */
 
+/* @translators: title of the Help page (noun) */
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Help')));
 ?>
 

--- a/src/Template/Pages/index.ctp
+++ b/src/Template/Pages/index.ctp
@@ -42,6 +42,7 @@ $moreCommentsUrl = $this->Url->build([
 ?>
 <div id="annexe_content">
     <div class="stats annexe-menu md-whiteframe-1dp" layout="column" flex>
+        <?php /* @translators: header text in the home page (noun) */ ?>
         <md-subheader><?= __('Stats')?></md-subheader>
         <?= $this->element('stats/homepage_stats',
                 [ 'contribToday' => $contribToday,

--- a/src/Template/PrivateMessages/folder.ctp
+++ b/src/Template/PrivateMessages/folder.ctp
@@ -28,15 +28,20 @@
 $folderName = '';
 if ($folder == 'Inbox') {
     if ($status == 'unread') {
+        /* @translators: folder name in private messages (noun) */
         $folderName = __('Unread');
     } else {
+        /* @translators: folder name in private messages (noun) */
         $folderName = __('Inbox');
     }
 } elseif ($folder == 'Sent') {
+    /* @translators: folder name in private messages (noun) */
     $folderName = __('Sent');
 } elseif ($folder == 'Trash') {
+    /* @translators: folder name in private messages (noun) */
     $folderName = __('Trash');
 } elseif ($folder == 'Drafts') {
+    /* @translators: folder name in private messages (noun) */
     $folderName = __('Drafts');
 }
 
@@ -122,6 +127,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(
                     $deleteIcon = 'delete_forever';
                 } else {
                     $deleteConfirmation = '';
+                    /* @translators: delete button on private message (verb) */
                     $deleteLabel = __('Delete');
                     $deleteIcon = 'delete';
                 }
@@ -148,6 +154,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(
                     <?php if ($folder == 'Trash') { ?>
                     <md-button class="md-icon-button" href="<?= $restoreUrl ?>">
                         <md-icon>restore</md-icon>
+                        <?php /* @translators: button to restore a private message that has been put to trash (verb) */ ?>
                         <md-tooltip><?= __('Restore') ?></md-tooltip>
                     </md-button>
                     <?php } ?>

--- a/src/Template/Reviews/of.ctp
+++ b/src/Template/Reviews/of.ctp
@@ -69,6 +69,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
     ?>
 
     <md-list class="annexe-menu md-whiteframe-1dp" ng-cloak>
+        <?php /* @translators: header text in the sidebar of a list of reviews (verb) */ ?>
         <md-subheader><?= __('Filter') ?></md-subheader>
         <?php
         foreach($categories as $categoryKey => $categoryValue) {
@@ -108,10 +109,13 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
         <div class="sortBy">
             <strong><?php echo __("Sort by:") ?> </strong>
             <?php
+            /* @translators: sort option in the list of reviews */
             echo $this->Paginator->sort('modified', __("date modified"));
             echo " | ";
+            /* @translators: sort option in the list of reviews */
             echo $this->Paginator->sort('created', __("date created"));
             echo " | ";
+            /* @translators: sort option in the list of reviews */
             echo $this->Paginator->sort('sentence_id', __("sentence id"));
             ?>
         </div>

--- a/src/Template/Sentences/add.ctp
+++ b/src/Template/Sentences/add.ctp
@@ -39,6 +39,7 @@ $vocabularyUrl = $this->Url->build(array(
 
 <div id="annexe_content">
     <div class="section md-whiteframe-1dp">
+    <?php /* @translators: header text in side bar of the "Add sentences" page */ ?>
     <h2><?php echo __('Important'); ?></h2>
     <p>
     <?php

--- a/src/Template/Sentences/of_user.ctp
+++ b/src/Template/Sentences/of_user.ctp
@@ -118,8 +118,10 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
                 );
                 $this->Paginator->options(array('url' => $urlOptions));
             }
+            /* @translators: sort option in the "Sentences of user" page */
             echo $this->Paginator->sort('modified', __('date modified'));
             echo " | ";
+            /* @translators: sort option in the "Sentences of user" page */
             echo $this->Paginator->sort('created', __('date created'));
             ?>
         </div>

--- a/src/Template/Sentences/show.ctp
+++ b/src/Template/Sentences/show.ctp
@@ -140,6 +140,7 @@ echo $this->element('/sentences/navigation', [
     <div class="section md-whiteframe-1dp">
         <?php
         echo '<h2>';
+        /* @translators: header text in sentence page */
         echo __('Logs');
         echo '</h2>';
 
@@ -208,6 +209,7 @@ echo $this->element('/sentences/navigation', [
     <section class="md-whiteframe-1dp">
         <md-toolbar class="md-hue-2">
             <div class="md-toolbar-tools">
+                <?php /* @translators: header text in sentence page */ ?>
                 <h2><?= __('Comments'); ?></h2>
             </div>
         </md-toolbar>

--- a/src/Template/SentencesLists/download.ctp
+++ b/src/Template/SentencesLists/download.ctp
@@ -42,6 +42,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Download list: ') .
     <?php $this->Lists->displayListsLinks(); ?>
 
     <div class="section md-whiteframe-1dp">
+    <?php /* @translators: header text in the side bar of the download list page */ ?>
     <h2><?php echo __('Actions'); ?></h2>
     <ul class="sentencesListActions">
     <?php
@@ -55,7 +56,8 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Download list: ') .
     <div class="section md-whiteframe-1dp">
     <h2><?= $this->safeForAngular($listName) ?></h2>
 
-    <h3><?php echo __('Download'); ?></h3>
+    <?php /* @translators: subheader text in the download list page (noun) */ ?>
+    <h3><?php echo __x('header', 'Download'); ?></h3>
 
     <div id="SentencesListExportToCsvForm" ng-controller="SentencesListsDownloadCtrl">
     <table>
@@ -146,7 +148,8 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Download list: ') .
                 <md-button ng-click="addListExport(<?= $listId ?>)"
                            ng-disabled="preparingDownload"
                            class="md-raised md-primary">
-                    <span><?php echo __('Download'); ?></span>
+                   <?php /* @translators: button to download on the download list page (verb) */ ?>
+                    <span><?php echo __x('button', 'Download'); ?></span>
                 </md-button>
                 <md-progress-circular md-diameter="16" ng-if="preparingDownload"/>
                 </md-progress-circular>

--- a/src/Template/SentencesLists/index.ctp
+++ b/src/Template/SentencesLists/index.ctp
@@ -69,16 +69,20 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
         <div class="sortBy">
             <strong><?php echo __("Sort by:") ?> </strong>
             <?php
+            /* @translators: sort option in the "List of lists" page */
             echo $this->Paginator->sort('name', __('list name'));
             echo " | ";
+            /* @translators: sort option in the "List of lists" page */
             echo $this->Paginator->sort('created', __('date created'));
             echo " | ";
             echo $this->Paginator->sort(
               'numberOfSentences',
+                /* @translators: sort option in the "List of lists" page */
                 __('number of sentences')
             );
             echo " | ";
             $options = array('defaultOrders' => array('modified' => 'desc'));
+            /* @translators: sort option in the "List of lists" page */
             echo $this->Pagination->sortDefaultOrder(__('last updated'), 'modified', $options);
             ?>
         </div>

--- a/src/Template/SentencesLists/show.ctp
+++ b/src/Template/SentencesLists/show.ctp
@@ -126,6 +126,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
         $editImage = $this->Images->svgIcon(
             'edit',
             array(
+                /* @translators: edit button for list name (verb) */
                 'alt'=> __('Edit'),
                 'title'=> __('Edit name'),
                 'width' => 15,
@@ -141,7 +142,9 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
         [
             'id'    => "l$listId",
             'class' => $class,
+            /* @translators: submit button of list name edition form */
             'data-submit'  => __('OK'),
+            /* @translators: cancel button of list name edition form (verb) */
             'data-cancel'  => __('Cancel'),
             'data-tooltip' => __('Click to edit...'),
         ]

--- a/src/Template/SentencesLists/show_angular.ctp
+++ b/src/Template/SentencesLists/show_angular.ctp
@@ -58,6 +58,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
     if ($permissions['canEdit']) {
         ?>
         <div class="section md-whiteframe-1dp">
+            <?php /* @translators: header text in the side bar of a list page (noun) */ ?>
             <h2><?php echo __('Options'); ?></h2>
             <ul class="sentencesListActions">
                 <?php
@@ -148,9 +149,11 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
             
             <div layout="row" layout-align="end">
                 <md-button class="md-raised" ng-click="vm.showEditNameForm = false">
+                    <?php /* @translators: cancel button of list name edition form (verb) */ ?>
                     <?= __('Cancel') ?>
                 </md-button>
                 <md-button class="md-raised md-primary" ng-click="vm.saveListName()">
+                    <?php /* @translators: submit button of list name edition form (verb) */ ?>
                     <?= __('Save') ?>
                 </md-button>
             </div>
@@ -206,8 +209,10 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
         <div class="sortBy" id="sortBy">
         <strong><?php echo __("Sort by:") ?> </strong>
         <?php
+        /* @translators: sort option in a list page */
         echo $this->Paginator->sort('created', __('date added to list'));
         echo ' | ';
+        /* @translators: sort option in a list page */
         echo $this->Paginator->sort('sentence_id', __('date created'));
         ?>
         </div>

--- a/src/Template/Stats/native_speakers.ctp
+++ b/src/Template/Stats/native_speakers.ctp
@@ -28,14 +28,19 @@
 $title = __('Native speakers');
 $this->set('title_for_layout', $this->Pages->formatTitle($title));
 $membersIcons = array(
+    /* @translators: refer to user status, used on the Native speakers page */
     'status_admin' => __('Admins'),
+    /* @translators: refer to user status, used on the Native speakers page */
     'status_corpus_maintainer' => __('Corpus maintainers'),
+    /* @translators: refer to user status, used on the Native speakers page */
     'status_advanced_contributor' => __('Advanced contributors'),
+    /* @translators: refer to user status, used on the Native speakers page */
     'status_contributor' => __('Contributors')
 );
 ?>
 <div id="annexe_content">
     <div class="section md-whiteframe-1dp usersLanguagesStats">
+        <?php /* @translators: header text in the side bar of the Native speakers page (noun) */ ?>
         <h2><?php echo __('Legend'); ?></h2>
         <?php
         foreach ($membersIcons as $iconClass => $tooltip) {
@@ -66,6 +71,7 @@ $membersIcons = array(
             <tr>
                 <th></th>
                 <th></th>
+                <?php /* @translators: table header text in Native speakers page */ ?>
                 <th><?php echo __('Language'); ?></th>
                 <?php
                 foreach ($membersIcons as $iconClass => $tooltip) {
@@ -80,6 +86,7 @@ $membersIcons = array(
                     echo $this->Html->tag('th', $icon, array('title' => $tooltip));
                 }
                 ?>
+                <?php /* @translators: table header text in Native speakers page */ ?>
                 <th><?php echo __('Total'); ?></th>
             </tr>
 

--- a/src/Template/Stats/sentences_by_language.ctp
+++ b/src/Template/Stats/sentences_by_language.ctp
@@ -54,6 +54,7 @@ $max = $stats[0]['sentences'];
         <th></th>
         <th></th>
         <th></th>
+        <?php /* @translators: table header text in "Number of sentences per language" page */ ?>
         <th><?php echo __('Language'); ?></th>
         <th><?php echo __('Sentences'); ?></th>
     </tr>

--- a/src/Template/Stats/users_languages.ctp
+++ b/src/Template/Stats/users_languages.ctp
@@ -31,6 +31,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Languages of member
 
 <div id="annexe_content">
     <div class="section md-whiteframe-1dp">
+        <?php /* @translators: header text in the side bar of the Languages of members page (noun) */ ?>
         <h2><?php echo __('Legend'); ?></h2>
         <ul class="usersLanguagesLegend">
             <?php
@@ -59,6 +60,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Languages of member
         <table class="usersLanguagesStats">
             <tr>
                 <th></th>
+                <?php /* @translators: table header text in Languages of members page */ ?>
                 <th><?php echo __('Language'); ?></th>
                 <?php
                 for ($i = Language::MAX_LEVEL; $i >= 0; $i--) {
@@ -70,6 +72,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Languages of member
                         <div class="unknownLevel">?</div>
                     </div>
                 </th>
+                <?php /* @translators: table header text in Languages of members page */ ?>
                 <th><?php echo __('Total'); ?></th>
             </tr>
             <?php

--- a/src/Template/Stats/users_languages.ctp
+++ b/src/Template/Stats/users_languages.ctp
@@ -35,16 +35,18 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Languages of member
         <h2><?php echo __('Legend'); ?></h2>
         <ul class="usersLanguagesLegend">
             <?php
-            for ($i = Language::MAX_LEVEL; $i >= 0; $i--) {
+            $levels = $this->Languages->getLevelsLabels();
+            uksort($levels, function($a, $b) {
+                $va = $a === '' ? -1 : $a;
+                $vb = $b === '' ? -1 : $b;
+                return $vb - $va;
+            });
+
+            foreach ($levels as $i => $level) {
                 $legend = $this->Html->tag('span', $this->Languages->getLevelsLabels($i));
                 echo $this->Html->tag('li', $this->Languages->smallLevelBar($i) . $legend);
             }
             ?>
-            <li>
-                <div class="languageLevel">
-                    <div class="unknownLevel key">?</div>
-                </div><span><?php echo __('Unspecified'); ?></span>
-            </li>
         </ul>
     </div>
 </div>

--- a/src/Template/Tags/show_sentences_with_tag.ctp
+++ b/src/Template/Tags/show_sentences_with_tag.ctp
@@ -63,10 +63,12 @@ $tagsIndexUrl = $this->Url->build([
         <div class="sortBy">
             <strong><?php echo __("Sort by:") ?></strong>
             <?php
+            /* @translators: sort option in the page that lists sentences having a certain tag */
             echo $this->Paginator->sort('sentence_id', __('date created'));
             ?>
             |
             <?php
+            /* @translators: sort option in the page that lists sentences having a certain tag */
             echo $this->Paginator->sort('added_time', __("date of tag"));
             ?>
         </div>

--- a/src/Template/Tags/view_all.ctp
+++ b/src/Template/Tags/view_all.ctp
@@ -48,7 +48,8 @@ $tagsIndexUrl = $this->Url->build([
                 ]);
             ?>
             <md-button type="submit" class="md-raised md-default">
-                <?= __('Search') ?>
+                <?php /* @translators: search button in All tags page (verb) */ ?>
+                <?= __x('button', 'Search') ?>
             </md-button>
         </md-input-container>
 
@@ -90,8 +91,10 @@ $tagsIndexUrl = $this->Url->build([
         <div class="sortBy">
             <strong><?php echo __("Sort by:") ?> </strong>
             <?php
+            /* @translators: sort option in the All tags page */
             echo $this->Paginator->sort('nbrOfSentences', __("count"));
             echo " | ";
+            /* @translators: sort option in the All tags page */
             echo $this->Paginator->sort('name', __("name"));
             ?>
         </div>

--- a/src/Template/User/edit_profile.ctp
+++ b/src/Template/User/edit_profile.ctp
@@ -67,6 +67,7 @@ $this->Languages->localizedAsort($countries);
         if (!empty($user->image)) {
             ?>
             <md-button type="submit" class="md-raised md-warn">
+                <?php /* @translators: button to remove profile picture */ ?>
                 <?php echo __('Remove'); ?>
             </md-button>
             <?php
@@ -92,6 +93,7 @@ $this->Languages->localizedAsort($countries);
         echo $this->Form->file('image');
         ?>
         <md-button type="submit" class="md-raised md-primary">
+                <?php /* @translators: button to upload a new profile picture */ ?>
             <?php echo __('Upload'); ?>
         </md-button>
         <?php
@@ -109,12 +111,14 @@ $this->Languages->localizedAsort($countries);
     ]);
 
     echo $this->Form->control('name', [
+        /* @translators: label for user name in profile page */
         'label' => __x('user', 'Name'),
         'lang' => '',
         'dir' => 'auto'
     ]);
 
     echo $this->Form->control('country_id', [
+        /* @translators: label for user's country in profile page */
         'label' => __('Country'),
         'options' => $countries,
         'empty' => true
@@ -125,6 +129,7 @@ $this->Languages->localizedAsort($countries);
     $year = !isset($birthday[0]) || $birthday[0] == '0000' ? '' : $birthday[0];
     $month = !isset($birthday[1]) || $birthday[1] == '00' ? '' : $birthday[1];
     $day = !isset($birthday[2]) || $birthday[2] == '00' ? '' : $birthday[2];
+    /* @translators: label for user's birthday in profile page */
     echo $this->Form->label('birthday', __('Birthday'));
     echo $this->Form->year('birthday', [
         'empty' => true,
@@ -142,11 +147,13 @@ $this->Languages->localizedAsort($countries);
     ]);
 
     echo $this->Form->control('homepage', [
+        /* @translators: label for user's homepage in profile page */
         'label' => __('Homepage'),
         'lang' => '',
         'dir' => 'ltr'
     ]);
 
+    /* @translators: label for user's description in profile page */
     echo $this->Form->label('description', __('Description'));
     echo $this->Form->textarea('description', [
         'lang' => '',
@@ -155,6 +162,7 @@ $this->Languages->localizedAsort($countries);
     ?>
     <div layout="row" layout-align="end center" layout-padding>
         <md-button type="submit" class="md-raised md-primary">
+            <?php /* @translators: submit button of profile edition form (verb) */ ?>
             <?php echo __('Save'); ?>
         </md-button>
     </div>

--- a/src/Template/User/language.ctp
+++ b/src/Template/User/language.ctp
@@ -30,6 +30,7 @@ if (!$userLanguage) {
     $submitLabel = __('Add language');
 } else {
     $title = __('Edit language');
+    /* @translators: submit button of user language edition form (verb) */
     $submitLabel = __('Save');
     $userLanguage->details = $this->safeForAngular($userLanguage->details);
 }
@@ -148,6 +149,7 @@ $this->set('title_for_layout', h($this->Pages->formatTitle($title)));
             );
             ?>
             <md-button class="md-raised" href="<?= $cancelUrl; ?>">
+                <?php /* @translators: cancel button of user language addition/edition form (verb) */ ?>
                 <?php echo __('Cancel'); ?>
             </md-button>
 

--- a/src/Template/User/profile.ctp
+++ b/src/Template/User/profile.ctp
@@ -88,6 +88,7 @@ $this->set('title_for_layout', h($this->Pages->formatTitle($title)));
     </md-list>
 
     <div class="section md-whiteframe-1dp">
+        <?php /* @translators: header text in side bar of profile pages (noun) */ ?>
         <h2><?php echo __('Stats'); ?></h2>
         <dl>
             <dt><?php echo __('Comments posted'); ?></dt>
@@ -120,6 +121,7 @@ $this->set('title_for_layout', h($this->Pages->formatTitle($title)));
     if ($isDisplayed) {
         ?>
         <div class="section md-whiteframe-1dp">
+            <?php /* @translators: header text for settings on profile page */ ?>
             <h2><?php echo __('Settings'); ?></h2>
 
             <ul class="annexeMenu">
@@ -172,6 +174,7 @@ $this->set('title_for_layout', h($this->Pages->formatTitle($title)));
                     <md-button class="md-primary md-raised"
                                aria-label="<?= __('Edit') ?>"
                                href="<?= $editSettingsUrl ?>">
+                        <?php /* @translators: edit button for settings on profile page (verb) */ ?>
                         <?= __('Edit') ?>
                     </md-button>
                 </div>
@@ -227,6 +230,7 @@ $this->set('title_for_layout', h($this->Pages->formatTitle($title)));
                         <md-button class="md-primary md-raised"
                                    aria-label="<?= __('Edit') ?>"
                                    href="<?= $editUrl ?>">
+                            <?php /* @translators: profile edition button on profile page (verb) */ ?>
                             <?= __('Edit') ?>
                         </md-button>
                         <?php
@@ -327,6 +331,7 @@ $userLanguages = htmlspecialchars(json_encode($userLanguages), ENT_QUOTES, 'UTF-
          ng-cloak
          ng-controller="LanguageController as vm"
          ng-init="vm.init(<?= str_replace('{{', '\{\{', $userLanguages) ?>)">
+        <?php /* @translators: header text on profile page */ ?>
         <h2><?= __('Languages'); ?></h2>
 
         <p ng-if="vm.langs.length === 0">
@@ -372,6 +377,7 @@ $userLanguages = htmlspecialchars(json_encode($userLanguages), ENT_QUOTES, 'UTF-
                     <md-button class="md-secondary md-icon-button"
                                aria-label="<?= __('Edit') ?>"
                                ng-href="<?= $editLangUrl.'/{{lang.language_code}}' ?>">
+                        <?php /* @translators: user language edition button on profile page (verb) */ ?>
                         <md-icon aria-label="<?= __('Edit') ?>">
                             edit
                         </md-icon>
@@ -380,6 +386,7 @@ $userLanguages = htmlspecialchars(json_encode($userLanguages), ENT_QUOTES, 'UTF-
                     <md-button type="submit" class="md-secondary md-icon-button"
                                ng-href="<?= $deleteUrl.'/{{lang.id}}'; ?>"
                                onclick="return confirm('<?= $confirmation; ?>');">
+                        <?php /* @translators: user language deletion button on profile page (verb) */ ?>
                         <md-icon aria-label="<?= __('Delete') ?>">
                             delete
                         </md-icon>
@@ -479,6 +486,7 @@ $userLanguages = htmlspecialchars(json_encode($userLanguages), ENT_QUOTES, 'UTF-
                 <div ng-if="vm.addLangStep === 'error'">
                     <p>{{vm.error}}</p>
                     <md-button ng-click="vm.addLangNextStep()" class="md-raised">
+                        <?php /* @translators: closing button of error message on user language addition form */ ?>
                         <?= __('OK') ?>
                     </md-button>
                 </div>
@@ -486,6 +494,7 @@ $userLanguages = htmlspecialchars(json_encode($userLanguages), ENT_QUOTES, 'UTF-
                 <!-- Form buttons -->
                 <div ng-if="vm.addLangStep != 'error' && vm.addLangStep != 'loading'" layout="row">
                     <md-button class="md-raised" ng-click="vm.resetForm()">
+                        <?php /* @translators: cancel button of user language addition form (directly from profile page) (verb) */ ?>
                         <?= __('Cancel') ?>
                     </md-button>
 

--- a/src/Template/User/settings.ctp
+++ b/src/Template/User/settings.ctp
@@ -26,6 +26,7 @@
  */
 use App\Model\CurrentUser;
 
+/* @translators: title of Settings page */
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
 ?>
 <div id="annexe_content">
@@ -219,6 +220,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                 <md-input-container class="md-block">
                     <?php
                     echo $this->Form->control('settings.lang', [
+                        /* @translators: option label on settings page */
                         'label' => __('Languages')
                     ]);
                     ?>
@@ -329,6 +331,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
 
         <div layout="row" layout-align="center center">
             <md-button type="submit" class="md-raised md-primary">
+                <?php /* @translators: submit button of settings edition form in settings page (verb) */ ?>
                 <?php echo __('Save'); ?>
             </md-button>
         </div>
@@ -359,6 +362,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
             </md-input-container>
             <div layout="row" layout-align="center center">
                 <md-button type="submit" class="md-raised md-primary">
+                    <?php /* @translators: submit button of email address edition form in settings page (verb) */ ?>
                     <?php echo __('Save'); ?>
                 </md-button>
             </div>
@@ -407,6 +411,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
             </md-input-container>
             <div layout="row" layout-align="center center">
                 <md-button type="submit" class="md-raised md-primary">
+                    <?php /* @translators: submit button of password edition form in settings page (verb) */ ?>
                     <?php echo __('Save'); ?>
                 </md-button>
             </div>

--- a/src/Template/Users/all.ctp
+++ b/src/Template/Users/all.ctp
@@ -54,7 +54,8 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Members')));
         ]);
         ?>
         <md-button type="submit" class="md-raised">
-            <?= __('Search') ?>
+            <?php /* @translators: search button in All members page (verb) */ ?>
+            <?= __x('button', 'Search') ?>
         </md-button>
     </md-input-container>
 
@@ -95,8 +96,10 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Members')));
         <div class="sortBy">
             <strong><?php echo __('Sort by:'); ?></strong>
             <?php
+            /* @translators: sort option in the All members page */
             echo $this->Paginator->sort('username', __('Username'));
             echo ' | ';
+            /* @translators: sort option in the All members page */
             echo $this->Paginator->sort('since', __('Member since'));
             echo ' | ';
             echo $this->Pagination->sortForRole();

--- a/src/Template/Users/for_language.ctp
+++ b/src/Template/Users/for_language.ctp
@@ -43,6 +43,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
 
 <div id="annexe_content">
     <div class="section md-whiteframe-1dp">
+        <?php /* @translators: header text on the side bar of "Members speaking x" page */ ?>
         <h2><?php echo __('Languages'); ?></h2>
 
         <p>

--- a/src/Template/Users/login.ctp
+++ b/src/Template/Users/login.ctp
@@ -116,6 +116,7 @@ echo $this->Form->create(
 
     <div layout="column">
         <md-button type="submit" class="md-raised md-primary">
+            <?php /* @translators: button to submit login form (verb) */ ?>
             <?php echo __('Log in'); ?>
         </md-button>
 
@@ -124,6 +125,7 @@ echo $this->Form->create(
         </md-button>
 
         <md-button href="<?= $registerUrl; ?>">
+            <?php /* @translators: link to the Register page in the login page (verb) */ ?>
             <?php echo __('Register'); ?>
         </md-button>
     </div>

--- a/src/Template/Users/new_password.ctp
+++ b/src/Template/Users/new_password.ctp
@@ -55,6 +55,8 @@ $this->Security->enableCSRFProtection();
 
     <div layout="column">
         <md-button type="submit" class="md-raised md-primary">
+            <?php /* @translators: button to send a new password by email
+                     because the password was forgotten (verb) */ ?>
             <?php echo __('Send'); ?>
         </md-button>
     </div>

--- a/src/Template/Users/register.ctp
+++ b/src/Template/Users/register.ctp
@@ -36,6 +36,7 @@ use Cake\Core\Configure;
  * @link     https://tatoeba.org
  */
 
+/* @translators: title of the Register page (verb) */
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Register')));
 
 $this->Html->script('users/register.ctrl.js', ['block' => 'scriptBottom']);
@@ -247,6 +248,7 @@ $label = format(
         echo $this->Form->input(
             'quiz',
             array(
+                /* @translators: captcha field name in register form (noun) */
                 'label' => __('Answer'),
                 'ng-model' => 'registration.quizAnswer',
                 'required' => true,
@@ -295,6 +297,7 @@ $label = format(
 
 <div layout="column">
     <md-button type="submit" class="md-raised md-primary">
+        <?php /* @translators: button to submit registration form (verb) */ ?>
         <?php echo __('Register'); ?>
     </md-button>
 </div>

--- a/src/Template/Vocabulary/add.ctp
+++ b/src/Template/Vocabulary/add.ctp
@@ -37,6 +37,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
     <?php echo $this->element('vocabulary/menu'); ?>
 
     <div class="section md-whiteframe-1dp" layout="column">
+        <?php /* @translators: title of the help text on the Add vocabulary page */ ?>
         <h2><?= __('Tips'); ?></h2>
         <p><?= __(
             'Add vocabulary that you are learning. If your vocabulary does not '.
@@ -65,6 +66,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
         ]) ?>
             <div layout="row">
                 <div class="language" layout="column">
+                    <?php /* @translators: language field label in new vocabulary request form */ ?>
                     <label for="lang-select"><?= __('Language'); ?></label>
                     <?php
                     $langArray = $this->Languages->profileLanguagesArray(
@@ -99,6 +101,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
             <div layout="row" layout-align="center center">
                 <md-button type="submit" class="md-raised md-primary"
                            ng-disabled="ctrl.isAdding || !ctrl.data.text || !ctrl.data.lang">
+                    <?php /* @translators: button to add a vocabulary request */ ?>
                     <?= __('Add'); ?>
                 </md-button>
             </div>

--- a/src/Template/Vocabulary/add_sentences.ctp
+++ b/src/Template/Vocabulary/add_sentences.ctp
@@ -109,6 +109,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
                     <?= $this->Form->hidden('lang', ['value' => $lang]) ?>
                     <md-input-container flex>
                         <?= $this->Form->input('text', [
+                            /* @translators: sentence text field label of sentence addition form on vocabulary page */
                             'label' => __('Sentence'),
                             'ng-model' => "ctrl.sentence['$id']"
                         ]); ?>
@@ -117,10 +118,12 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
                         <md-button class="md-raised"
                                    ng-disabled="ctrl.isAdding"
                                    ng-click="ctrl.hideForm('<?= $id ?>')">
+                            <?php /* @translators: cancel button of sentence addition form on wanted vocabulary requests page (verb) */ ?>
                             <?= __('Cancel') ?>
                         </md-button>
                         <md-button type="submit" class="md-raised md-primary"
                                    ng-disabled="ctrl.isAdding">
+                            <?php /* @translators: button to submit new sentence from wanted vocabulary requests page (verb) */ ?>
                             <?= __('Submit') ?>
                         </md-button>
                     </div>

--- a/src/Template/Wall/index.ctp
+++ b/src/Template/Wall/index.ctp
@@ -35,6 +35,7 @@
  * @link     https://tatoeba.org
  */
 
+/* @translators: title of the Wall page */
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Wall')));
 
 echo $this->Html->script('wall/wall.ctrl.js', ['block' => 'scriptBottom']);
@@ -51,6 +52,7 @@ echo format(__n('Wall (one thread)', 'Wall ({n}&nbsp;threads)', $threadsCount),
 
 <div id="annexe_content" >
     <div class="section md-whiteframe-1dp">
+        <?php /* @translators: title of the sidebar text on the Wall page */ ?>
         <h2><?php echo __('Tips'); ?></h2>
         <p>
         <?php

--- a/src/Template/Wall/show_message.ctp
+++ b/src/Template/Wall/show_message.ctp
@@ -43,6 +43,7 @@ echo $this->Html->script('wall/wall.ctrl.js', ['block' => 'scriptBottom']);
 ?>
 <div id="annexe_content">
     <div class="module">
+    <?php /* @translators: header text the side bar of the page of a Wall post */ ?>
     <h2><?php echo __('Menu'); ?></h2>
         <p>
             <?php

--- a/src/View/Helper/CommentsHelper.php
+++ b/src/View/Helper/CommentsHelper.php
@@ -90,9 +90,11 @@ class CommentsHelper extends AppHelper
             $hidden = $comment['hidden'];
 
             if ($hidden) {
+                /* @translators: button to unhide a sentence comment (verb) */
                 $hiddenLinkText = __('Unhide');
                 $hiddenLinkAction = 'unhide_message';
             } else {
+                /* @translators: button to hide a sentence comment (verb) */
                 $hiddenLinkText = __('Hide');
                 $hiddenLinkAction = 'hide_message';
             }
@@ -111,6 +113,7 @@ class CommentsHelper extends AppHelper
         // edit
         if ($permissions['canEdit']) {
             $menu[] = array(
+                /* @translators: edit button on sentence comment (verb) */
                 'text' => __('Edit'),
                 'icon' => 'edit',
                 'url' => array(
@@ -124,6 +127,7 @@ class CommentsHelper extends AppHelper
         // delete
         if ($permissions['canDelete']) {
             $menu[] = array(
+                /* @translators: delete button on sentence comment (verb) */
                 'text' => __('Delete'),
                 'icon' => 'delete',
                 'url' => array(

--- a/src/View/Helper/DownloadsHelper.php
+++ b/src/View/Helper/DownloadsHelper.php
@@ -113,6 +113,8 @@ class DownloadsHelper extends AppHelper
         }
         $tab = $this->Html->tag(
             'span',
+            /* @translators: tab character, used on the Downloads page,
+               see https://en.wikipedia.org/wiki/Tab_key (noun) */
             format('[{}]', __('tab')),
             ['class' => 'symbol']
         );

--- a/src/View/Helper/LanguagesHelper.php
+++ b/src/View/Helper/LanguagesHelper.php
@@ -247,7 +247,9 @@ class LanguagesHelper extends AppHelper
     {
         $languages = $this->onlyLanguagesArray();
         $options = [
+            /* @translators: option used in language selection dropdowns such as "Show translations in" */
             'none' => __('None'),
+            /* @translators: option used in language selection dropdowns such as "Show translations in" */
             'und' => __('All languages')
         ];
 
@@ -266,6 +268,7 @@ class LanguagesHelper extends AppHelper
         $languages = $this->onlyLanguagesArray();
         $options = [
             'none' => '—',
+            /* @translators: option used in language selection dropdowns such as "Not directly translated into" */
             'und' => __('Any language')
         ];
 
@@ -428,6 +431,7 @@ class LanguagesHelper extends AppHelper
     {
         if (!isset($__languagesLevels)) {
             $__languagesLevels = array(
+                /* @translators: language level */
                 '' => __x('level', 'Unspecified'),
                 0 => __('0: Almost no knowledge'),
                 1 => __('1: Beginner'),

--- a/src/View/Helper/LanguagesHelper.php
+++ b/src/View/Helper/LanguagesHelper.php
@@ -452,16 +452,19 @@ class LanguagesHelper extends AppHelper
 
     public function smallLevelBar($level)
     {
-        $opacity = $opacity = 0.5 + 0.5 * ($level / Language::MAX_LEVEL);
-        $size = ($level / Language::MAX_LEVEL) * 100;
-        $levelDiv = $this->Html->div(
-            null,
-            "",
-            array(
+        if ($level === '') {
+            $text = '?';
+            $options = ['class' => 'unknownLevel'];
+        } else {
+            $text = '';
+            $opacity = $opacity = 0.5 + 0.5 * ($level / Language::MAX_LEVEL);
+            $size = ($level / Language::MAX_LEVEL) * 100;
+            $options = [
+                'class' => 'level',
                 'style' => 'opacity:'.$opacity.'; width:'.$size.'%;',
-                'class' => 'level'
-            )
-        );
+            ];
+        }
+        $levelDiv = $this->Html->div(null, $text, $options);
         $levelDivContainer = $this->Html->div(
             'languageLevel',
             $levelDiv,

--- a/src/View/Helper/ListsHelper.php
+++ b/src/View/Helper/ListsHelper.php
@@ -72,11 +72,13 @@ class ListsHelper extends AppHelper
                  <td></td>
                 <td class="date createdDate">
                      <?php
+                     /* @translators: sort option in list of lists */
                      echo __('created');
                      ?>
                 </td>
                 <td class="date lastUpdatedDate">
                     <?php
+                     /* @translators: sort option in list of lists */
                      echo __('last updated');
                      ?>
                 </td>
@@ -336,12 +338,15 @@ class ListsHelper extends AppHelper
             <input type="radio"  name="visibility" data-list-id='<?= $listId ?>'  value="{{visibility}}" checked hidden ng-init="visibility = '<?= $value ?>';"/>
             <md-radio-group ng-controller='optionsCtrl' ng-model='visibility' ng-change='visibilityChanged()'>
                 <md-radio-button value='public' class='md-primary'>
+                    <?php /* @translators: visibility option of a list */ ?>
                     <?=  __('Public') ?>
                 </md-radio-button>
                 <md-radio-button value='unlisted' class='md-primary'>
+                    <?php /* @translators: visibility option of a list */ ?>
                     <?=  __('Unlisted') ?>
                 </md-radio-button>
                 <md-radio-button value='private' class='md-primary'>
+                    <?php /* @translators: visibility option of a list */ ?>
                     <?=  __('Private') ?>
                 </md-radio-button>
             </md-radio-group>
@@ -373,12 +378,15 @@ class ListsHelper extends AppHelper
             <input type="radio"  name="editable_by" data-list-id='<?= $listId ?>'  value="{{editable}}" checked hidden ng-init="editable = '<?= $value ?>';"/>
             <md-radio-group ng-controller='optionsCtrl' ng-model='editable' ng-change='editableChanged("{{editable}}")'>
                 <md-radio-button value='anyone' class='md-primary'>
+                    <?php /* @translators: option when choosing who can edit a list */ ?>
                     <?=  __('Anyone') ?>
                 </md-radio-button>
                 <md-radio-button value='creator' class='md-primary'>
+                    <?php /* @translators: option when choosing who can edit a list */ ?>
                     <?= __('Only me') ?>
                 </md-radio-button>
                 <md-radio-button value='no_one' class='md-primary'>
+                    <?php /* @translators: option when choosing who can edit a list */ ?>
                     <?= __('No one (list inactive)') ?>
                 </md-radio-button>
             </md-radio-group>
@@ -494,6 +502,7 @@ class ListsHelper extends AppHelper
             )
         );
         echo $this->Form->button(
+            /* @translators: submit button of sentence addition form on list page */
             __('OK'),
             array(
                 'id' => 'submitNewSentenceToList',
@@ -530,6 +539,7 @@ class ListsHelper extends AppHelper
     {
         if (count($listsArray) > 0) {
             echo '<div class="section md-whiteframe-1dp">';
+            /* @translators: header text on the sidebar of a sentence page */
             echo $this->Html->tag('h2', __('Lists'));
             echo '<ul class="sentence-lists">';
             foreach($listsArray as $list) {
@@ -571,11 +581,13 @@ class ListsHelper extends AppHelper
             <md-input-container layout="column">
                 <?php
                 echo $this->Form->control('name', [
+                    /* @translators: field for the name of a list to create (noun) */
                     'label' => __x('list', 'Name')
                 ]);
                 ?>
                 <md-button type="submit" class="md-raised md-primary">
-                    <?= __('create') ?>
+                    <?php /* @translators: button to create a new list from the lists of list page (verb) */ ?>
+                    <?= __('Create') ?>
                 </md-button>
             </md-input-container>
 
@@ -592,7 +604,8 @@ class ListsHelper extends AppHelper
         ?>
         <div class="section md-whiteframe-1dp">
             <?php
-            echo $this->Html->tag('h2', __('Search'));
+            /* @translators: header text in List of lists page (noun) */
+            echo $this->Html->tag('h2', __x('header', 'Search'));
 
             echo $this->Form->create('SentencesList', ['type' => 'get']);
 
@@ -612,7 +625,8 @@ class ListsHelper extends AppHelper
                 ?>
 
                 <md-button type="submit" class="md-raised">
-                    <?= __('Search') ?>
+                    <?php /* @translators: search form button in List of lists pages (verb) */ ?>
+                    <?= __x('button', 'Search') ?>
                 </md-button>
             </md-input-container>
 
@@ -627,6 +641,7 @@ class ListsHelper extends AppHelper
     {
         ?>
         <md-list class="annexe-menu md-whiteframe-1dp" ng-cloak>
+            <?php /* @translators: header text in sidebar on pages related to sentences lists */ ?>
             <md-subheader><?= __('Lists') ?></md-subheader>
 
             <?php
@@ -675,6 +690,7 @@ class ListsHelper extends AppHelper
      */
     public function listsAsSelectable($lists)
     {
+        /* @translators: dropdown option when no list is selected (used to filter by list in advanced search) */
         $unspecified = __x('list', 'Unspecified');
         if (CurrentUser::isMember()) {
             $sortedLists = array(0 => array(), 1 => array());

--- a/src/View/Helper/MembersHelper.php
+++ b/src/View/Helper/MembersHelper.php
@@ -82,11 +82,17 @@ class MembersHelper extends AppHelper
     public function groupName($role)
     {
         switch ($role) {
+            /* @translators: one of the user status displayed on profile pages (noun) */
             case User::ROLE_ADMIN             : return __('admin');
+            /* @translators: one of the user status displayed on profile pages */
             case User::ROLE_CORPUS_MAINTAINER : return __('corpus maintainer');
+            /* @translators: one of the user status displayed on profile pages */
             case User::ROLE_ADV_CONTRIBUTOR   : return __('advanced contributor');
+            /* @translators: one of the user status displayed on profile pages */
             case User::ROLE_CONTRIBUTOR       : return __('contributor');
+            /* @translators: one of the user status displayed on profile pages */
             case User::ROLE_INACTIVE          : return __('inactive');
+            /* @translators: one of the user status displayed on profile pages */
             case User::ROLE_SPAMMER           : return __('suspended');
             default                           : return null;
         }

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -209,6 +209,7 @@ class MenuHelper extends AppHelper
             $type = 'add';
             if($withRemoveAndUndo){
                 $image = 'undo';
+                /* @translators: button after removing a favorite from the My favorites page (verb) */
                 $tooltip = __('Undo');
             } else {
                 $image = 'favorite-add';
@@ -286,6 +287,7 @@ class MenuHelper extends AppHelper
         ));
 
         echo $this->Form->button(
+            /* @translators: button to link translations (verb) */
             __('Link'),
             array(
                 'type' => 'button',
@@ -387,6 +389,7 @@ class MenuHelper extends AppHelper
 
         // ok button
         echo $this->Form->button(
+            /* @translators: submit button to add a sentence to a list from the sentence block */
             __('OK'),
             array(
                 'type' => 'button',
@@ -428,6 +431,7 @@ class MenuHelper extends AppHelper
 
         } else {
 
+            /* @translators: delete button on sentence menu (verb) */
             $title = __('Delete');
             $liContent = $this->Html->link(
                 $deleteImage,
@@ -478,6 +482,7 @@ class MenuHelper extends AppHelper
                 'a', $editImage, array('class' => 'disabled')
             );
         } else {
+            /* @translators: edit button on sentence menu (verb) */
             $title = __('Edit');
             $liContent = $editImage;
         }

--- a/src/View/Helper/MessagesHelper.php
+++ b/src/View/Helper/MessagesHelper.php
@@ -114,6 +114,7 @@ class MessagesHelper extends AppHelper
             );
         } elseif ($this->_isDraftMessage($folder, $msg)) {
             $user = null;
+            /* @translators: private message type (noun) */
             $label = __('Draft');
         } elseif ($msg->type == 'machine') {
             $user = null;

--- a/src/View/Helper/PrivateMessagesHelper.php
+++ b/src/View/Helper/PrivateMessagesHelper.php
@@ -66,6 +66,7 @@ class PrivateMessagesHelper extends AppHelper
 
         if ($folder == 'Trash') {
             $menu[] = array(
+                /* @translators: button to restore a private message that has been put to trash (verb) */
                 'text' => __('Restore'),
                 'icon' => 'restore',
                 'url' => array(
@@ -75,6 +76,7 @@ class PrivateMessagesHelper extends AppHelper
             );
 
             $menu[] = array(
+                /* @translators: button to delete a private message that has already been put in the trash (verb) */
                 'text' => __('Permanently delete'),
                 'icon' => 'delete_forever',
                 'url' => array(
@@ -85,6 +87,7 @@ class PrivateMessagesHelper extends AppHelper
             );
         } else {
             $menu[] = array(
+                /* @translators: button to put a private message in the trash (verb) */
                 'text' => __('Delete'),
                 'icon' => 'delete',
                 'url' => array(
@@ -107,7 +110,8 @@ class PrivateMessagesHelper extends AppHelper
 
             if ($type == 'human') {
                 $menu[] = array(
-                    'text' => __('Reply'),
+                    /* @translators: button to reply to a private message (verb) */
+                    'text' => __x('button', 'Reply'),
                     'icon' => 'reply',
                     'url' => '#reply'
                 );

--- a/src/View/Helper/SentenceButtonsHelper.php
+++ b/src/View/Helper/SentenceButtonsHelper.php
@@ -95,6 +95,7 @@ class SentenceButtonsHelper extends AppHelper
         $image = $this->Images->svgIcon(
             'unlink',
             array(
+                /* @translators: alt text for unlink translation button (verb) */
                 "alt"=>__('Unlink'),
                 "width" => 16,
                 "height" => 16
@@ -136,6 +137,7 @@ class SentenceButtonsHelper extends AppHelper
         $image = $this->Images->svgIcon(
             'link',
             array(
+                /* @translators: alt text for link translation button (verb) */
                 "alt"=>__('Link'),
                 "width" => 16,
                 "height" => 16

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -404,6 +404,7 @@ class SentencesHelper extends AppHelper
 
         // Cancel
         echo $this->Form->button(
+            /* @translators: cancel button of "add translation" form on a sentence (verb) */
             __('Cancel'),
             array(
                 'id' => '_'.$id.'_cancel',
@@ -698,7 +699,9 @@ class SentencesHelper extends AppHelper
                 array(
                     'class' => join(' ', $classes),
                     'id' => $sentenceLang.'_'.$sentenceId,
+                    /* @translators: submit button of sentence edition form */
                     'data-submit' => __('OK'),
+                    /* @translators: cancel button of sentence edition form (verb) */
                     'data-cancel' => __('Cancel'),
                     'escape' => !$sentenceEscaped,
                 ),

--- a/src/View/Helper/TagsHelper.php
+++ b/src/View/Helper/TagsHelper.php
@@ -63,6 +63,7 @@ class TagsHelper extends AppHelper
         ?>
 
         <div class="section md-whiteframe-1dp">
+            <?php /* @translators: header text on a sentence page in the sidebar (noun) */ ?>
             <h2><?php echo __('Tags'); ?></h2>
 
             <div class="tagsListOnSentence" >

--- a/src/View/Helper/TranscriptionsHelper.php
+++ b/src/View/Helper/TranscriptionsHelper.php
@@ -114,8 +114,11 @@ class TranscriptionsHelper extends AppHelper
         }
         $options = [
             'data-script' => $transcr['script'],
+            /* @translators: submit button of transcription edition form */
             'data-submit' => __('OK'),
+            /* @translators: cancel button of transcription edition form (verb) */
             'data-cancel' => __('Cancel'),
+            /* @translators: reset button of transcription edition form (verb) */
             'data-reset' => __('Reset'),
             'title' => $log,
             'class' => $class,

--- a/src/View/Helper/WallHelper.php
+++ b/src/View/Helper/WallHelper.php
@@ -146,7 +146,8 @@ class WallHelper extends AppHelper
 
         if ($permissions['canEdit']) {
             $menu[] = array(
-                'text' => __("edit"),
+                /* @translators: edit button on a wall post (verb) */
+                'text' => __('Edit'),
                 'icon' => 'edit',
                 'url' => array(
                     'controller' => 'wall',
@@ -160,7 +161,8 @@ class WallHelper extends AppHelper
         if ($permissions['canDelete']) {
             // delete link
             $menu[] = array(
-                'text' => __('delete'),
+                /* @translators: delete button on a wall post (verb) */
+                'text' => __('Delete'),
                 'icon' => 'delete',
                 'url' => array(
                     "controller"=>"wall",
@@ -175,7 +177,8 @@ class WallHelper extends AppHelper
             $replyLinkId = 'reply_' . $messageId;
             $replyClasses = 'replyLink ' . $messageId;
             $menu[] = array(
-                'text' => __("reply"),
+                /* @translators: reply button on a wall post (verb) */
+                'text' => __x('button', 'Reply'),
                 'icon' => 'reply',
                 'url' => null,
                 'class' => $replyClasses,

--- a/tools/generate_pot.sh
+++ b/tools/generate_pot.sh
@@ -21,9 +21,10 @@ throw_to_gettext() {
         "$@"
 }
 
-adjust_file_refs() {
+cosmetics() {
     sed 's/#: \([^ ]\+\) \([^ ]\+\)/#: \1\n#: \2/g' | \
-    sed 's/^#: \([^:]\+\):\([0-9]\+\)/#: github.com\/Tatoeba\/tatoeba2\/tree\/dev\/\1#L\2/'
+    sed 's/^#: \([^:]\+\):\([0-9]\+\)/#: github.com\/Tatoeba\/tatoeba2\/tree\/dev\/\1#L\2/' | \
+    sed '/#\. @translators:/ {s/@translators: *//; :a; /^#[^.]/!{s,@translators: *,/ ,; n; ba;};}'
 }
 
 get_all_contexts_from() {
@@ -57,7 +58,7 @@ xgettext --version >/dev/null 2>&1 || {
 DEFAULT_DOMAIN_K='--keyword=__ --keyword=__x:1c,2 --keyword=__n:1,2 --keyword=__xn:1c,2,3'
 list_source_files | \
     throw_to_gettext $DEFAULT_DOMAIN_K | \
-    adjust_file_refs > "$POT" \
+    cosmetics > "$POT" \
     && echo "$POT created." \
     || echo "Something went wrong while creating $POT."
 
@@ -70,7 +71,7 @@ list_source_files | \
 OTHER_DOMAINS_K='--keyword=__d:1c,2'
 list_source_files | \
     throw_to_gettext $OTHER_DOMAINS_K | \
-    adjust_file_refs > "$POT_TMP"
+    cosmetics > "$POT_TMP"
 
 # sounds like the charset is autodetected and the autodetection fails
 sed -i 's/charset=CHARSET/charset=utf-8/' "$POT_TMP"


### PR DESCRIPTION
This PR solves #2192 by inserting 313 developers notes (that show up on Transifex) on translatable strings that are potentially difficult to translate for UI translators because of the lack of context. I focused on strings that are one-word long, or could otherwise be difficult to understand.

Not only the notes tell the context, but when a string is used a different places around, I took care of inserting a separate note on every place it is used. This might be seen as very verbose, but I believe this is especially useful for translators to see all the different contexts the string is used.

I also added msgctxt where appropriate, capitalized all tooltips, refactored a legend, and removed the `@translators` markers from the final notes in the POT files.

I believe this approach is efficient but it is quite verbose and takes a lot of space in the source code. Are you okay with that?

If you want to see how the developers notes would ultimately look like on Transifex, run `./tools/generate_pot.sh` on this branch and look for lines that start with `#. ` in `src/Locale/default.pot`.