### PR TITLE
Improve add tag

### DIFF
--- a/src/Controller/TagsController.php
+++ b/src/Controller/TagsController.php
@@ -69,15 +69,15 @@ class TagsController extends AppController
             $username = CurrentUser::get("username");
             $tag = $this->Tags->addTag($tagName, $userId, $sentenceId);
 
-            $isSaved = $tag && $tag->id;
+            $isSaved = $tag && $tag->link;
             $this->set('isSaved', $isSaved);
             if ($isSaved) {
-                $this->set('tagName', $tagName);
-                $this->set('tagId', $tag->tag_id);
+                $this->set('tagName', $tag->name);
+                $this->set('tagId', $tag->id);
                 $this->set('userId', $userId);
                 $this->set('username', $username);
                 $this->set('sentenceId', $sentenceId);
-                $this->set('date', date("Y-m-d H:i:s"));
+                $this->set('date', $tag->link->added_time);
                 $this->loadModel('Sentences');
                 $sentence = $this->Sentences->get($sentenceId, ['fields' => ['lang']]);
                 $this->set('sentenceLang', $sentence->lang);

--- a/src/Controller/TagsController.php
+++ b/src/Controller/TagsController.php
@@ -69,7 +69,7 @@ class TagsController extends AppController
             $username = CurrentUser::get("username");
             $tag = $this->Tags->addTag($tagName, $userId, $sentenceId);
 
-            $isSaved = $tag && $tag->link;
+            $isSaved = $tag && $tag->link && !$tag->link->alreadyExists;
             $this->set('isSaved', $isSaved);
             if ($isSaved) {
                 $this->set('tagName', $tag->name);

--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -94,36 +94,34 @@ class TagsTable extends Table
             }
         }
 
-        $tag = $this->newEntity([
+        $newTag = $this->newEntity([
             'name' => $tagName,
             'user_id' => $userId,
         ]);
 
-        if ($tag->hasErrors()) {
+        if ($newTag->hasErrors()) {
             return false;
         }
 
-        $added = $this->findOrCreate(
-            ['name' => $tag->name],
-            function ($entity) use ($tag) { $entity = $tag; }
+        $tag = $this->findOrCreate(
+            ['name' => $newTag->name],
+            function ($entity) use ($newTag) { return $newTag; }
         );
 
-        if ($added) {
-            $event = new Event('Model.Tag.tagAdded', $this, ['tagName' => $added->name]);
+        if ($tag && !isset($tag->nbrOfSentences)) {
+            $event = new Event('Model.Tag.tagAdded', $this, ['tagName' => $tag->name]);
             $this->getEventManager()->dispatch($event);
-
-            if ($sentenceId != null) {
-                $added->link = $this->TagsSentences->tagSentence(
-                    $sentenceId,
-                    $added->id,
-                    $userId
-                );
-            }
-
-            return $added;
         }
 
-        return false;
+        if ($tag && $sentenceId != null) {
+            $tag->link = $this->TagsSentences->tagSentence(
+                $sentenceId,
+                $tag->id,
+                $userId
+            );
+        }
+
+        return $tag;
     }
 
     public function removeTagFromSentence($tagId, $sentenceId) {

--- a/src/Template/Tags/add_tag_post.ctp
+++ b/src/Template/Tags/add_tag_post.ctp
@@ -24,9 +24,7 @@
  * @license  Affero General Public License
  * @link     https://tatoeba.org
  */
-
 if ($isSaved) {
     $this->Tags->displayTag($tagName, $tagId, $sentenceId, $userId, $username, $date, $sentenceLang);
 }
 ?>
-

--- a/tests/TestCase/Controller/TagsControllerTest.php
+++ b/tests/TestCase/Controller/TagsControllerTest.php
@@ -76,6 +76,15 @@ class TagsControllerTest extends IntegrationTestCase {
         $this->assertResponseOk();
     }
 
+    public function testAddTagPost_getBackTruncatedName() {
+        $this->logInAs('advanced_contributor');
+        $this->ajaxPost('/eng/tags/add_tag_post', [
+            'sentence_id' => 18,
+            'tag_name' => '1234567890123456789012345678901234567890123456789 cut after 9',
+        ]);
+        $this->assertResponseNotContains(' cut after 9');
+    }
+
     public function testSearch_asGuest() {
         $this->enableCsrfToken();
         $this->enableSecurityToken();

--- a/tests/TestCase/Controller/TagsControllerTest.php
+++ b/tests/TestCase/Controller/TagsControllerTest.php
@@ -85,6 +85,16 @@ class TagsControllerTest extends IntegrationTestCase {
         $this->assertResponseNotContains(' cut after 9');
     }
 
+    public function testAddTagPost_duplicateTagReturnsEmptyResponse ()
+    {
+        $this->logInAs('advanced_contributor');
+        $this->ajaxPost('/eng/tags/add_tag_post', [
+            'sentence_id' => 8,
+            'tag_name' => '@needs native check',
+        ]);
+        $this->assertResponseEmpty();
+    }
+
     public function testSearch_asGuest() {
         $this->enableCsrfToken();
         $this->enableSecurityToken();

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -159,9 +159,9 @@ class TagsTableTest extends TestCase {
 
     public function testAddTag_correctDateUsingArabicLocale() {
         I18n::setLocale('ar');
-        $added = $this->Tag->addTag('arabic', 4, 1);
+        $added = $this->Tag->addTag('arabic', 4);
         $returned = $this->Tag->get($added->id);
-        $this->assertEquals($added->added_time, $returned->created);
+        $this->assertEquals($added->created, $returned->created);
     }
 
     public function testAddTagWithoutSentenceId_NoDuplicateAdded() {

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -163,4 +163,14 @@ class TagsTableTest extends TestCase {
         $returned = $this->Tag->get($added->id);
         $this->assertEquals($added->added_time, $returned->created);
     }
+
+    public function testAddTagWithoutSentenceId_NoDuplicateAdded() {
+        $added = $this->Tag->addTag('regional', 4);
+        $this->assertNotEquals($added->user_id, 4);
+    }
+
+    public function testAddTag_addEmptyTag() {
+        $added = $this->Tag->addTag('', 1);
+        $this->assertFalse($added);
+    }
 }

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -66,7 +66,7 @@ class TagsTableTest extends TestCase {
 
     public function testAddTag_tagAlreadyAdded() {
         $result = $this->Tag->addTag('OK', 1, 2);
-        $this->assertTrue($result->alreadyExists);
+        $this->assertTrue($result->link->alreadyExists);
     }
 
     public function testSentenceOwnerCannotTagOwnSentenceAsOK() {
@@ -172,5 +172,12 @@ class TagsTableTest extends TestCase {
     public function testAddTag_addEmptyTag() {
         $added = $this->Tag->addTag('', 1);
         $this->assertFalse($added);
+    }
+
+    public function testAddTag_noTrailingSpaceAfterCuttingTo50Bytes() {
+        $tagName = '1234567890123456789012345678901234567890123456789 content after 9 gets cut';
+        $added = $this->Tag->addTag($tagName, 4);
+        $storedId = $this->Tag->getIdFromName(substr($tagName, 0, 49));
+        $this->assertEquals($storedId, $added->id);
     }
 }

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -176,8 +176,9 @@ class TagsTableTest extends TestCase {
 
     public function testAddTag_noTrailingSpaceAfterCuttingTo50Bytes() {
         $tagName = '1234567890123456789012345678901234567890123456789 content after 9 gets cut';
+        $expectedName = '1234567890123456789012345678901234567890123456789';
         $added = $this->Tag->addTag($tagName, 4);
-        $storedId = $this->Tag->getIdFromName(substr($tagName, 0, 49));
-        $this->assertEquals($storedId, $added->id);
+        $storedName = $this->Tag->getNameFromId($added->id);
+        $this->assertEquals($expectedName, $storedName);
     }
 }


### PR DESCRIPTION
This PR addresses #2231 

In order to fix this bug I've refactored `TagsTable::addTag`:

1) Avoid a redundant SQL query when we try to add an already existing tag
2) Move the trimming part to `beforeMarshal` event listener and use CakePHP's validation process
3) Make it work when no sentence id is provided
4) Add the `TagsSentence` entity to the `Tags` entity instead of throwing away the `Tags` entity. We need the name which is actually stored in the database later in the controller