### PR TITLE
Move activity timeline link out of Contribute menu

### DIFF
--- a/src/Template/Element/random_sentence_header.ctp
+++ b/src/Template/Element/random_sentence_header.ctp
@@ -35,6 +35,7 @@ $langArray = $this->Languages->languagesArrayAlone();
 <div ng-controller="RandomSentenceController as vm" ng-init="vm.init()">
 <md-toolbar class="md-hue-2">
     <div class="md-toolbar-tools">
+        <?php /* @translators: random sentence block header on the home page for members */ ?>
         <h2 flex><?= __('Random sentence') ?></h2>
 
         <span>

--- a/src/Template/Element/stats/homepage_stats.ctp
+++ b/src/Template/Element/stats/homepage_stats.ctp
@@ -3,16 +3,20 @@ $statsUrl = $this->Url->build([
     'controller' => 'stats',
     'action' => 'sentences_by_language'
 ]);
+$activityUrl = $this->Url->build([
+    'controller' => 'contributions',
+    'action' => 'activity_timeline'
+]);
 ?>
 
 <div class="content" flex>
     <div>
-    <?=  format(
-        __n('{number} contribution today',
-            '{number} contributions today',
-            $contribToday,
+    <?= format(
+        __n('{number} sentence',
+            '{number} sentences',
+            $numSentences,
             true),
-        ['number' => $this->Html->tag('strong', $this->Number->format($contribToday))]
+        ['number' => $this->Html->tag('strong', $this->Number->format($numSentences))]
     ) ?>
     </div>
 
@@ -26,20 +30,27 @@ $statsUrl = $this->Url->build([
     ) ?>
     </div>
 
+    <div layout="row" layout-align="center center">
+        <md-button class="md-primary" href="<?= $statsUrl ?>">
+            <?= __('Stats per languages') ?>
+            <md-icon ng-cloak>keyboard_arrow_right</md-icon>
+        </md-button>
+    </div>
+
     <div>
-    <?= format(
-        __n('{number} sentence',
-            '{number} sentences',
-            $numSentences,
+    <?=  format(
+        __n('{number} contribution today',
+            '{number} contributions today',
+            $contribToday,
             true),
-        ['number' => $this->Html->tag('strong', $this->Number->format($numSentences))]
+        ['number' => $this->Html->tag('strong', $this->Number->format($contribToday))]
     ) ?>
     </div>
-</div>
 
-<div layout="row" layout-align="center center">
-    <md-button class="md-primary" href="<?= $statsUrl ?>">
-        <?= __('stats per languages') ?>
-        <md-icon ng-cloak>keyboard_arrow_right</md-icon>
-    </md-button>
+    <div layout="row" layout-align="center center">
+        <md-button class="md-primary" href="<?= $activityUrl ?>">
+            <?= __('Activity timeline') ?>
+            <md-icon ng-cloak>keyboard_arrow_right</md-icon>
+        </md-button>
+    </div>
 </div>

--- a/src/Template/Element/top_menu.ctp
+++ b/src/Template/Element/top_menu.ctp
@@ -53,7 +53,7 @@ $menuElements = array(
         ),
         "sub-menu" => array(
             /* @translators: menu item on the top (verb) */
-            __('Random sentence') => array(
+            __('Show random sentence') => array(
                 "controller" => "sentences",
                 "action" => "show",
                 "random"

--- a/src/Template/Element/top_menu.ctp
+++ b/src/Template/Element/top_menu.ctp
@@ -120,11 +120,6 @@ $menuElements = array(
                 "action" => "add_sentences",
                 $filteredLanguage
             ),
-            /* @translators: menu item on the top (verb) */
-            __('Show activity timeline') => array(
-                "controller" => "contributions",
-                "action" => "activity_timeline"
-            ),
         )
     ),
     /* @translators: menu on the top (verb) */

--- a/src/Template/Pages/index_for_guests.ctp
+++ b/src/Template/Pages/index_for_guests.ctp
@@ -44,6 +44,7 @@ $registerUrl = $this->Url->build(
 <div layout="column">
     <md-toolbar class="md-hue-2">
         <div class="md-toolbar-tools">
+            <?php /* @translators: random sentence block header on the home page for guests */ ?>
             <h2><?= __('Random sentence'); ?></h2>
         </div>
     </md-toolbar>

--- a/webroot/css/pages/index.css
+++ b/webroot/css/pages/index.css
@@ -168,6 +168,10 @@
     padding: 2px 16px;
 }
 
+.stats .content .md-button {
+    line-height: 0;
+}
+
 .join-us p {
     padding: 0px 16px;
 }


### PR DESCRIPTION
This PR implements the suggested enhancement in #2156.

Block for logged-in users:
![image](https://user-images.githubusercontent.com/5107734/79830658-7b1e9d80-83d8-11ea-91a5-af39ed067557.png)

Block for guests:
![image](https://user-images.githubusercontent.com/5107734/79830688-896cb980-83d8-11ea-841f-6b5e1c038453.png)

Don’t forget to run `rm tmp/cache/tatoeba_stats_element_homepage_stats_*` if you want to see the result of this change.