### PR TITLE
Prevent adding sentences without profile language

### DIFF
--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -313,7 +313,7 @@ class SentencesController extends AppController
     {
         // Users without a profile language should not be able to add sentences
         if (empty(CurrentUser::getProfileLanguages())) {
-            throw new \Cake\Http\Exception\ForbiddenException;
+            return;
         }
 
         $userId = $this->Auth->user('id');
@@ -325,8 +325,7 @@ class SentencesController extends AppController
         $sentenceLang = $this->request->getData('selectedLang');
         $sentenceText = $this->request->getData('value');
 
-        if (is_null($sentenceText) || is_null($sentenceLang)) {
-            //TODO add error handling
+        if (empty($sentenceText) || empty($sentenceLang)) {
             return;
         }
 

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -311,6 +311,11 @@ class SentencesController extends AppController
      */
     public function add_an_other_sentence()
     {
+        // Users without a profile language should not be able to add sentences
+        if (empty(CurrentUser::getProfileLanguages())) {
+            throw new \Cake\Http\Exception\ForbiddenException;
+        }
+
         $userId = $this->Auth->user('id');
         $userLevel = $this->Sentences->Users->getLevelOfUser($userId);
         if ($userLevel < 0) {

--- a/tests/TestCase/Controller/SentencesControllerTest.php
+++ b/tests/TestCase/Controller/SentencesControllerTest.php
@@ -153,6 +153,15 @@ class SentencesControllerTest extends IntegrationTestCase {
         $this->assertResponseOk();
     }
 
+    public function testAddSentence_UserWithoutProfileLanguage() {
+        $this->logInAs('advanced_contributor');
+        $this->ajaxPost('/eng/sentences/add_an_other_sentence', [
+            'value' => 'SPAM',
+            'selectedLang' => 'eng',
+        ]);
+        $this->assertResponseCode(403);
+    }
+
     public function testEditSentence_doesntWorkForUnknownSentence() {
         $this->logInAs('contributor');
         $this->ajaxPost('/jpn/sentences/edit_sentence', [

--- a/tests/TestCase/Controller/SentencesControllerTest.php
+++ b/tests/TestCase/Controller/SentencesControllerTest.php
@@ -126,40 +126,60 @@ class SentencesControllerTest extends IntegrationTestCase {
         $this->assertAjaxAccessUrlAs($url, $user, $response);
     }
 
-    public function testAddSentence_asGuest() {
-        $this->ajaxPost('/jpn/sentences/add_an_other_sentence', [
-            'value' => 'Here is another sentences for you!',
-            'selectedLang' => 'eng',
-        ]);
-        $this->assertResponseError();
+    public function addSentenceProvider () {
+        return [
+            'as guest' => [
+                null,
+                ['value' => 'test', 'selectedLang' => 'eng'],
+                'assertResponseError'
+            ],
+            'as member' => [
+                'contributor',
+                ['value' => 'test', 'selectedLang' => 'eng'],
+                'assertResponseOk'
+            ],
+            'with license' => [
+                'contributor',
+                ['value' => 'test', 'selectedLang' => 'eng', 'sentenceLicense' => 'CC BY 2.0 FR'],
+                'assertResponseOk'
+            ],
+            'user without profile language' => [
+                'advanced_contributor',
+                ['value' => 'SPAM', 'selectedLang' => 'eng'],
+                'assertResponseEmpty'
+            ],
+            'as member but no value' => [
+                'contributor',
+                ['selectedLang' => 'eng'],
+                'assertResponseEmpty'
+            ],
+            'as member but empty value' => [
+                'contributor',
+                ['value' => '', 'selectedLang' => 'eng'],
+                'assertResponseEmpty'
+            ],
+            'as member but no selectedLang' => [
+                'contributor',
+                ['value' => 'test'],
+                'assertResponseEmpty'
+            ],
+            'as member but empty selectedLang' => [
+                'contributor',
+                ['value' => 'test', 'selectedLang' => ''],
+                'assertResponseEmpty'
+            ],
+        ];
     }
 
-    public function testAddSentence_asMember() {
-        $this->logInAs('contributor');
-        $this->ajaxPost('/jpn/sentences/add_an_other_sentence', [
-            'value' => 'Here is another sentences for you!',
-            'selectedLang' => 'eng',
-        ]);
-        $this->assertResponseOk();
-    }
-
-    public function testAddSentence_WithLicense() {
-        $this->logInAs('contributor');
-        $this->ajaxPost('/jpn/sentences/add_an_other_sentence', [
-            'value' => 'Here is another sentences for you!',
-            'selectedLang' => 'eng',
-            'sentenceLicense' => 'CC BY 2.0 FR',
-        ]);
-        $this->assertResponseOk();
-    }
-
-    public function testAddSentence_UserWithoutProfileLanguage() {
-        $this->logInAs('advanced_contributor');
-        $this->ajaxPost('/eng/sentences/add_an_other_sentence', [
-            'value' => 'SPAM',
-            'selectedLang' => 'eng',
-        ]);
-        $this->assertResponseCode(403);
+    /**
+     * @dataProvider addSentenceProvider
+     */
+    public function testAddSentence($user, $data, $assertion) {
+        if ($user) {
+            $this->logInAs($user);
+        }
+        $this->ajaxPost('/jpn/sentences/add_an_other_sentence', $data);
+        $this->$assertion();
     }
 
     public function testEditSentence_doesntWorkForUnknownSentence() {


### PR DESCRIPTION
While the UI prevents users without any profile language to add a sentence, it was still possible to bypass this rule by sending a direct POST request to `/sentences/add_an_other_sentence`.