### PR TITLE
Add cleanup section to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,4 +28,9 @@ pipeline {
       }
     }
   }
+  post {
+    always {
+      deleteDir()
+    }
+  }
 }


### PR DESCRIPTION
This should cleanup the workspace after running the tests and therefore should prevent filling up the disk on the dev server.