### PR TITLE
Avoid unnecessary calls to the search engine

### DIFF
--- a/src/Model/Behavior/SphinxBehavior.php
+++ b/src/Model/Behavior/SphinxBehavior.php
@@ -63,7 +63,12 @@ class SphinxBehavior extends Behavior
      */
     function beforeFind($event, $query, $options, $primary)
     {
-        if (empty($options['sphinx'])) {
+        /* CakePHP's paginator makes two calls to the database: the first for the actual
+         * query and the second for the total count. But when we use the search engine
+         * we already get the total count with the first call. The 'withSphinx' finder
+         * from the model will use the cached count so we don't need to do anything
+         * when this callback gets called the second time. */
+        if (empty($options['sphinx']) || $this->_cached_result) {
             return true;
         }
 


### PR DESCRIPTION
CakePHP's paginator sends two queries to the database: the first for getting the items of a page and the second for the total count.

But when we use the search engine we get the total count already with the first call. The `withSphinx` finder from the `Sentences` model already uses the cached result for the total count but we still queried the search engine twice in the `Sphinx` behavior.