### PR TITLE
Replace CSS property "box-shadow" under language icons with "filter: drop-shadow"

### DIFF
--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -723,7 +723,7 @@ rt {
  }
 
 .language-icon {
-    box-shadow: 1px 1px 3px 0px rgba(204,204,204,1);
+    filter: drop-shadow(1px 1px 3px rgba(204,204,204,1));
 }
 
 


### PR DESCRIPTION
This pull request addresses issue #2046 - use filter: drop-shadow