### PR TITLE
Improve AngularJS performance a little bit

### DIFF
--- a/webroot/js/responsive/app.module.js
+++ b/webroot/js/responsive/app.module.js
@@ -3,9 +3,13 @@
 
     angular
         .module('app', ['ngMaterial', 'ngMessages', 'ngCookies', 'ngSanitize'])
-        .config(['$mdThemingProvider', '$mdIconProvider', '$httpProvider', '$cookiesProvider', function(
-            $mdThemingProvider, $mdIconProvider, $httpProvider, $cookiesProvider
+        .config(['$mdThemingProvider', '$mdIconProvider', '$httpProvider', '$cookiesProvider',
+                 '$compileProvider', function(
+            $mdThemingProvider, $mdIconProvider, $httpProvider, $cookiesProvider, $compileProvider
         ) {
+            $compileProvider.debugInfoEnabled(false);
+            $compileProvider.commentDirectivesEnabled(false);
+            $compileProvider.cssClassDirectivesEnabled(false);
             $mdThemingProvider.theme('default')
                 .primaryPalette('green')
                 .accentPalette('grey')


### PR DESCRIPTION
According to the [docs](https://docs.angularjs.org/guide/production) disabling debug info and comment and CSS class directives should improve the perfomance a little bit.