### PR TITLE
Fix licences bug in add sentence form (new design)

### DIFF
--- a/webroot/js/sentences/add.ctrl.js
+++ b/webroot/js/sentences/add.ctrl.js
@@ -33,7 +33,6 @@
                 vm.newSentence.lang = vm.showAutoDetect ? 'auto' : langCodes[0];
             }
             vm.licenses = licenses;
-            vm.newSentence.license = Object.keys(vm.licenses)[0];
         }
 
         function addSentence() {


### PR DESCRIPTION
There is a bug in the form for adding a new sentence in the new design:

1) Create a new user or log in as a user who cannot switch the license. The default license should be `CC BY 2.0 FR`.
2) Set the new design in the settings.
3) Add a new sentence using the form on `sentences/add`.

=> The new sentence will be stored with the CC0 license.

The reason: 
https://github.com/Tatoeba/tatoeba2/blob/2dd631f83a255d4817c409f678b0ce60c64ec557/webroot/js/sentences/add.ctrl.js#L36
The first entry in `vm.licenses` isn't `CC BY 2.0 FR`.

My fix simply removes the line because 
* Users who cannot switch the license will submit an empty license and thus the license will be set to the user's default license in the model.
* Users who can switch the license will have a select control where the user's default license is preselected.