### PR TITLE
Allow users to set default license

### DIFF
--- a/src/Template/User/settings.ctp
+++ b/src/Template/User/settings.ctp
@@ -235,6 +235,15 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                     'label' => ''
                 )); ?>
             </md-list-item>
+            <?php if ($userSettings->settings['can_switch_license']) : ?>
+                <md-list-item>
+                    <p><?= __('Default license for original sentences'); ?></p>
+                    <?= $this->Form->input('settings.default_license', [
+                        'options' => $this->SentenceLicense->getLicenseOptions(),
+                        'label' => ''
+                    ]); ?>
+                </md-list-item>
+            <?php endif; ?>
         </md-list>
         <br>
 


### PR DESCRIPTION
Add a select control to the settings page for users who can switch license.

This was requested [on the wall](https://tatoeba.org/eng/wall/show_message/34688#message_34688) and also [in a related issue](https://github.com/Tatoeba/tatoeba2/issues/1858#issuecomment-480433240).