### PR TITLE
Add tooltips to #n log links

### DIFF
--- a/src/Controller/ContributionsController.php
+++ b/src/Controller/ContributionsController.php
@@ -157,13 +157,19 @@ class ContributionsController extends AppController
 
         $this->paginate = [
             'conditions' => [
-                'user_id' => $userId,
-                'type !=' => 'license'
+                'Contributions.user_id' => $userId,
+                'Contributions.type !=' => 'license'
             ],
             'contain' => [
                 'Users' => [
                     'fields' => ['username', 'image']
-                ]
+                ],
+                'Sentences' => [
+                    'fields' => ['text'],
+                ],
+                'Translations' => [
+                    'fields' => ['text'],
+                ],
             ],
             'limit' => 200,
             'order' => ['Contributions.id' => 'DESC'],

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -163,6 +163,7 @@ class SentencesController extends AppController
         $this->helpers[] = 'Lists';
         $this->helpers[] = 'Members';
         $this->helpers[] = 'Audio';
+        $this->helpers[] = 'ClickableLinks';
 
         if ($id == "random" || $id == null || $id == "" ) {
             $id = $this->request->getSession()->read('random_lang_selected');

--- a/src/Model/Table/ContributionsTable.php
+++ b/src/Model/Table/ContributionsTable.php
@@ -54,6 +54,7 @@ class ContributionsTable extends Table
     {
         $this->belongsTo('Users');
         $this->belongsTo('Sentences');
+        $this->belongsTo('Translations');
     }
 
     public function logSentence($event) {
@@ -166,11 +167,15 @@ class ContributionsTable extends Table
                 'Contributions.type',
                 'Users.username',
                 'Users.id',
+                'Translations.text',
             ])
             ->where(['Contributions.sentence_id' => $sentenceId])
-            ->contain(['Users' => function ($q) {
-                return $q->select(['username', 'id']);
-            }])
+            ->contain([
+                'Users' => function ($q) {
+                    return $q->select(['username', 'id']);
+                },
+                'Translations',
+            ])
             ->order('datetime');
 
         return $query->all();

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -81,6 +81,14 @@ class SentencesTable extends Table
         ]);
         $this->hasMany('SentenceComments');
         $this->hasMany('SentenceAnnotations');
+        $this->hasOne(
+            'Base',
+            [
+                'className' => 'Sentences',
+                'foreignKey' => 'id',
+                'bindingKey' => 'based_on_id',
+            ]
+        )->setConditions(['Sentences.based_on_id >' => '0']);
 
         $this->addBehavior('Duplicate');
         $this->addBehavior('Timestamp');
@@ -700,6 +708,7 @@ class SentencesTable extends Table
         if (isset($what['sentenceDetails'])) {
             $contain['Audios']['Users']['fields'][] = 'audio_license';
             $contain['Audios']['Users']['fields'][] = 'audio_attribution_url';
+            $contain['Base']['fields'] = ['text'];
         }
 
         return $contain;

--- a/src/Template/Element/logs/log_text.ctp
+++ b/src/Template/Element/logs/log_text.ctp
@@ -9,14 +9,7 @@ if (isset($log->type)) {
 $sentenceLink = '';
 if ($log->sentence_id) {
     $sentenceId = $log->sentence_id;
-    $sentenceLink = $this->Html->link(
-        '#'.$sentenceId,
-        array(
-            'controller' => 'sentences',
-            'action' => 'show',
-            $sentenceId
-        )
-    );
+    $sentenceLink = $this->ClickableLinks->buildSentenceLink($sentenceId, $log->text);
 }
 
 $sentenceText = $log->text;
@@ -25,22 +18,15 @@ $sentenceScript = $log->script;
 $translationLink = null;
 if ($log->translation_id) {
     $translationId = $log->translation_id;
-    $translationLink = $this->Html->link(
-        '#'.$translationId,
-        array(
-            'controller' => 'sentences',
-            'action' => 'show',
-            $translationId
-        )
-    );
+    $translationLink = $this->ClickableLinks->buildSentenceLink($translationId);
 }
-
-$langCode = $log->sentence_lang;
 
 $action = $log->action;
 $username = $log->user ? $log->user->username : null;
 $sentenceDate = $log->datetime;
 $infoLabel = $this->Logs->getInfoLabel($type, $action, $username, $sentenceDate);
+
+$langCode = $log->sentence_lang;
 
 ?>
 <div class="md-list-item-text" layout="column">

--- a/src/Template/Element/logs/log_text.ctp
+++ b/src/Template/Element/logs/log_text.ctp
@@ -9,7 +9,8 @@ if (isset($log->type)) {
 $sentenceLink = '';
 if ($log->sentence_id) {
     $sentenceId = $log->sentence_id;
-    $sentenceLink = $this->ClickableLinks->buildSentenceLink($sentenceId, $log->text);
+    $sentenceText = $log->text ? $log->text : ($log->sentence ? $log->sentence->text : null);
+    $sentenceLink = $this->ClickableLinks->buildSentenceLink($sentenceId, $sentenceText);
 }
 
 $sentenceText = $log->text;
@@ -18,7 +19,8 @@ $sentenceScript = $log->script;
 $translationLink = null;
 if ($log->translation_id) {
     $translationId = $log->translation_id;
-    $translationLink = $this->ClickableLinks->buildSentenceLink($translationId);
+    $translationText = $log->translation ? $log->translation->text : null;
+    $translationLink = $this->ClickableLinks->buildSentenceLink($translationId, $translationText);
 }
 
 $action = $log->action;

--- a/src/View/Helper/ClickableLinksHelper.php
+++ b/src/View/Helper/ClickableLinksHelper.php
@@ -190,7 +190,7 @@ class ClickableLinksHelper extends AppHelper
                 'action' => 'show',
                 $sentenceId
             ),
-            ['title' => $sentenceText]
+            ['title' => $this->_View->safeForAngular($sentenceText)]
         );
     }
 }

--- a/src/View/Helper/ClickableLinksHelper.php
+++ b/src/View/Helper/ClickableLinksHelper.php
@@ -177,6 +177,11 @@ class ClickableLinksHelper extends AppHelper
      */
     public function buildSentenceLink($sentenceId, $sentenceText = null)
     {
+        $tooltipTag = $this->Html->tag(
+            'md-tooltip',
+            $this->_View->safeForAngular($sentenceText),
+            ['ng-cloak']
+        );
         $linkText = format(
             __(
                 /* @translators: You can translate the sharp in the link to a sentence
@@ -184,13 +189,13 @@ class ClickableLinksHelper extends AppHelper
                 '#{sentenceId}'),
             array('sentenceId' => $sentenceId));
         return $this->Html->link(
-            $linkText,
+            h($linkText).$tooltipTag,
             array(
                 'controller' => 'sentences',
                 'action' => 'show',
                 $sentenceId
             ),
-            ['title' => $this->_View->safeForAngular($sentenceText)]
+            ['escape' => false]
         );
     }
 }

--- a/src/View/Helper/ClickableLinksHelper.php
+++ b/src/View/Helper/ClickableLinksHelper.php
@@ -166,5 +166,35 @@ class ClickableLinksHelper extends AppHelper
         return false;
     }
 
+
+    /**
+     * Build #n links where n is a sentence ID.
+     *
+     * @param int $sentenceId the ID of the sentence linked
+     * @param string $sentenceText the text of the sentence linked
+     *
+     * @return string an HTML link whose title attribute is the text of the sentence
+     */
+    public function buildSentenceLink($sentenceId, $sentenceText = null)
+    {
+
+        $linkText = format(
+            __(
+                /* @translators: You can translate the sharp in the link to a sentence
+                that appears in logs to a more natural character  */
+                '#{sentenceId}'),
+            array('sentenceId' => $sentenceId));
+        $model = TableRegistry::getTableLocator()->get('Sentences');
+        return $this->Html->link(
+            $linkText,
+            array(
+                'controller' => 'sentences',
+                'action' => 'show',
+                $sentenceId
+            ),
+            // $sentenceText could come as the empty string
+            array('title' => $sentenceText != null ? $sentenceText : $model->getSentenceTextForId($sentenceId))
+        );
+    }
 }
 ?>

--- a/src/View/Helper/ClickableLinksHelper.php
+++ b/src/View/Helper/ClickableLinksHelper.php
@@ -183,7 +183,6 @@ class ClickableLinksHelper extends AppHelper
                 that appears in logs to a more natural character  */
                 '#{sentenceId}'),
             array('sentenceId' => $sentenceId));
-        $model = TableRegistry::getTableLocator()->get('Sentences');
         return $this->Html->link(
             $linkText,
             array(
@@ -191,8 +190,7 @@ class ClickableLinksHelper extends AppHelper
                 'action' => 'show',
                 $sentenceId
             ),
-            // $sentenceText could come as the empty string
-            array('title' => $sentenceText != null ? $sentenceText : $model->getSentenceTextForId($sentenceId))
+            ['title' => $sentenceText]
         );
     }
 }

--- a/src/View/Helper/ClickableLinksHelper.php
+++ b/src/View/Helper/ClickableLinksHelper.php
@@ -177,7 +177,6 @@ class ClickableLinksHelper extends AppHelper
      */
     public function buildSentenceLink($sentenceId, $sentenceText = null)
     {
-
         $linkText = format(
             __(
                 /* @translators: You can translate the sharp in the link to a sentence

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -69,6 +69,7 @@ class SentencesHelper extends AppHelper
         'Search',
         'Number',
         'SentenceLicense',
+        'ClickableLinks',
     );
 
 
@@ -828,18 +829,10 @@ class SentencesHelper extends AppHelper
             $msg = __('This sentence is original and '
                      .'was not derived from translation.');
         } elseif ($baseId > 0) {
-            $baseLink = $this->Html->link(
-                $baseId,
-                array(
-                    'controller' => 'sentences',
-                    'action' => 'show',
-                    $baseId
-                )
-            );
             $msg = format(
                 __('This sentence was initially added as a '
-                  .'translation of sentence #{n}.'),
-                array('n' => $baseLink)
+                  .'translation of sentence {numberWithNumberSign}.'),
+                array('numberWithNumberSign' => $this->ClickableLinks->buildSentenceLink($baseId))
             );
         } else {
             $msg = __('We cannot determine yet whether this sentence was '

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -831,8 +831,8 @@ class SentencesHelper extends AppHelper
         } elseif ($baseId > 0) {
             $msg = format(
                 __('This sentence was initially added as a '
-                  .'translation of sentence {numberWithNumberSign}.'),
-                array('numberWithNumberSign' => $this->ClickableLinks->buildSentenceLink($baseId))
+                  .'translation of sentence {sentenceIdWithIdSign}.'),
+                array('sentenceIdWithIdSign' => $this->ClickableLinks->buildSentenceLink($baseId))
             );
         } else {
             $msg = __('We cannot determine yet whether this sentence was '

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -829,10 +829,11 @@ class SentencesHelper extends AppHelper
             $msg = __('This sentence is original and '
                      .'was not derived from translation.');
         } elseif ($baseId > 0) {
+            $baseText = $sentence->base ? $sentence->base->text : null;
             $msg = format(
                 __('This sentence was initially added as a '
                   .'translation of sentence {sentenceIdWithIdSign}.'),
-                array('sentenceIdWithIdSign' => $this->ClickableLinks->buildSentenceLink($baseId))
+                array('sentenceIdWithIdSign' => $this->ClickableLinks->buildSentenceLink($baseId, $baseText))
             );
         } else {
             $msg = __('We cannot determine yet whether this sentence was '


### PR DESCRIPTION
This PR adds a tooltip containing the target sentence text to `#n` links that appear in logs. It addresses #2293.

I factorized the code of the logs a little bit.  
I would also like to simplify the return statement of the following piece of code but I'm not sure how I should correct the corresponding tests
https://github.com/Tatoeba/tatoeba2/blob/70d6fc5200c9697d57f9f1db59096a3d78b44766/src/View/Helper/ClickableLinksHelper.php#L131-L138
Also, I'm not sure about how to add a note to translators so I tried to add it the same way I saw it somewhere else in the code.

PS: @jiru I didn't really understand your intention in your [comment about using view cells](https://github.com/Tatoeba/tatoeba2/issues/2293#issuecomment-627499720)

