### PR TITLE
Tag event dispatch

### DIFF
--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -108,17 +108,17 @@ class TagsTable extends Table
             function ($entity) use ($newTag) { return $newTag; }
         );
 
-        if ($tag && !isset($tag->nbrOfSentences)) {
+        if ($tag) {
             $event = new Event('Model.Tag.tagAdded', $this, ['tagName' => $tag->name]);
             $this->getEventManager()->dispatch($event);
-        }
 
-        if ($tag && $sentenceId != null) {
-            $tag->link = $this->TagsSentences->tagSentence(
-                $sentenceId,
-                $tag->id,
-                $userId
-            );
+            if ($sentenceId != null) {
+                $tag->link = $this->TagsSentences->tagSentence(
+                    $sentenceId,
+                    $tag->id,
+                    $userId
+                );
+            }
         }
 
         return $tag;

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -5,7 +5,7 @@ use App\Model\Table\TagsTable;
 use App\Test\TestCase\Model\Table\TatoebaTableTestTrait;
 use Cake\TestSuite\TestCase;
 use Cake\ORM\TableRegistry;
-use Cake\Event\Event;
+use Cake\Event\EventList;
 use Cake\I18n\I18n;
 
 class TagsTableTest extends TestCase {
@@ -22,6 +22,7 @@ class TagsTableTest extends TestCase {
     public function setUp() {
         parent::setUp();
         $this->Tag = TableRegistry::getTableLocator()->get('Tags');
+        $this->Tag->getEventManager()->setEventList(new EventList());
     }
 
     public function tearDown() {
@@ -42,27 +43,28 @@ class TagsTableTest extends TestCase {
         $this->assertEquals(4, $tag->id);
     }
 
-    public function testAddTagFiresEvent() {
-        $contributorId = 4;
-        $sentenceId = 1;
-        $expectedTagName = '@needs_native_check';
-
-        $dispatched = false;
-        $model = $this->Tag;
-        $model->getEventManager()->on(
-            'Model.Tag.tagAdded',
-            function (Event $event) use ($model, &$dispatched, $expectedTagName) {
-                $this->assertSame($model, $event->getSubject());
-                extract($event->getData()); // $tagName
-                $this->assertEquals($expectedTagName, $tagName);
-                $dispatched = true;
-            }
-        );
-
-        $this->Tag->addTag('@needs_native_check', $contributorId, $sentenceId);
-
-        $this->assertTrue($dispatched);
+    public function eventTestProvider() {
+        return [
+            'existing tag' => ['OK', 4, 1],
+            'new tag' => ['new tag', 4, 1],
+        ];
     }
+
+    /**
+     * @dataProvider eventTestProvider
+     */
+    public function testAddTagFiresEvent($tagName, $userId, $sentenceId) {
+        $this->Tag->addTag($tagName, $userId, $sentenceId);
+
+        $this->assertEventFiredWith(
+            'Model.Tag.tagAdded',
+            'tagName',
+            $tagName,
+            $this->Tag->getEventManager()
+        );
+    }
+
+
 
     public function testAddTag_tagAlreadyAdded() {
         $result = $this->Tag->addTag('OK', 1, 2);


### PR DESCRIPTION
Unfortunately I've introduced a bug in 3842e94591b47bd02c07a3c2f7d1c5e9b2a8d1b3 so that only new tags dispatched the event to notify `suggestd`. :facepalm: 

(My lame excuse is that the test for event dispatching was incomplete and only tested the case when a new tag was added.)