### PR TITLE
Make add_sentences fit according to what's being typed

### DIFF
--- a/src/Template/Element/sentences/add_sentences_jquery.ctp
+++ b/src/Template/Element/sentences/add_sentences_jquery.ctp
@@ -71,9 +71,9 @@ $this->Html->script(JS_PATH . 'sentences.contribute.js', ['block' => 'scriptBott
 
             <md-input-container flex>
                 <label><?= __('Sentence'); ?></label>
-                <input id="SentenceText" type="text" ng-model="ctrl.data.text"
+                <textarea  id="SentenceText" type="text" ng-model="ctrl.data.text">
                         autocomplete="off"
-                        ng-disabled="ctrl.isAdding">
+                        ng-disabled="ctrl.isAdding"> </textarea>
             </md-input-container>
 
             <div layout="row" layout-align="center center">


### PR DESCRIPTION
This PR is adressed to #1462

It makes [Add sentences page](https://tatoeba.org/eng/sentences/add) fit its box for what's being typed (no matter how big it is) and so, make the whole text visible to the user

![image](https://user-images.githubusercontent.com/7658430/82735037-25018a80-9cf5-11ea-82a9-613efe40106a.png)
