### PR TITLE
Tag selection using the keyboard

### DIFF
--- a/src/View/Helper/TagsHelper.php
+++ b/src/View/Helper/TagsHelper.php
@@ -206,6 +206,7 @@ class TagsHelper extends AppHelper
             'label' => '',
             'lang' => '',
             'dir' => 'auto',
+            'autocomplete' => 'off'
         ]);
         echo $this->Form->hidden('sentence_id', [
             'value' => $sentenceId

--- a/webroot/js/autocompletion.js
+++ b/webroot/js/autocompletion.js
@@ -152,14 +152,4 @@ $(document).ready(function()
         }
  
     });
-
-    $("#TagAddTagPostForm").submit(function(){
-        if (isSuggestListActive) {
-            var text = $("#suggestedItem"+currentSuggestPosition).html()
-            $("#TagTagName").val(text);
-            removeSuggestList(); 
-            return false;
-        }
-    });
-       
 });

--- a/webroot/js/autocompletion.js
+++ b/webroot/js/autocompletion.js
@@ -120,13 +120,6 @@ function removeSuggestList() {
 
 $(document).ready(function()
 {
-
-
-    // it desactivates browsers autocompletion
-    // TODO: it's not something in the standard, so if you 
-    // know a standard way to do this ...
-    $("#TagTagName").attr("autocomplete","off");
-
     $("#TagTagName").blur(function() {
         setTimeout(function() {
         removeSuggestList()},

--- a/webroot/js/autocompletion.js
+++ b/webroot/js/autocompletion.js
@@ -85,7 +85,9 @@ function suggestShowResults(suggestions) {
     $("#autocompletionDiv").append(ul);
     suggestions.allTags.forEach(function(suggestion, index) {
         var li = document.createElement("li");
-        li.innerHTML = "<a id='suggestedItem" + index + "' onclick='suggestSelect(" + '"' + suggestion.name + '"' + ")' style='color:black';>"+ suggestion.name + " (" + suggestion.nbrOfSentences + ")</a>"; 
+        li.innerHTML = "<a id='suggestedItem" + index + "' onclick='suggestSelect(this.dataset.tagName)' " +
+            "data-tag-name='" + suggestion.name + "' style='color:black';>" + suggestion.name +
+            " (" + suggestion.nbrOfSentences + ")</a>";
         ul.appendChild(li);
     });
 }
@@ -102,7 +104,7 @@ function changeActiveSuggestion(offset) {
     var selectedItem = $("#suggestedItem"+currentSuggestPosition);
     if (selectedItem.length > 0) {
         selectedItem.addClass("selected");
-        suggestSelect(selectedItem[0].innerHTML);
+        suggestSelect(selectedItem[0].dataset.tagName);
     }
 } 
 

--- a/webroot/js/autocompletion.js
+++ b/webroot/js/autocompletion.js
@@ -78,6 +78,7 @@ function suggestShowResults(suggestions) {
         return;
     }
 
+    suggestLength = suggestions.allTags.length;
     isSuggestListActive = true;
 
     var ul = document.createElement("ul");
@@ -93,14 +94,16 @@ function suggestShowResults(suggestions) {
  *
  */
 function changeActiveSuggestion(offset) {
-    $("#suggestItem"+currentSuggestPosition % suggestLength).removeClass("selected");
-    currentSuggestPosition += offset;
+    $("#suggestedItem"+currentSuggestPosition).removeClass("selected");
+    currentSuggestPosition = (currentSuggestPosition + offset) % suggestLength;
     if (currentSuggestPosition < 0) {
         currentSuggestPosition = suggestLength - 1;
     }
-    var selectedItem = $("#suggestItem"+currentSuggestPosition % suggestLength);
-    selectedItem.addClass("selected");
-    suggestSelect(selectedItem[0].innerHTML);
+    var selectedItem = $("#suggestedItem"+currentSuggestPosition);
+    if (selectedItem.length > 0) {
+        selectedItem.addClass("selected");
+        suggestSelect(selectedItem[0].innerHTML);
+    }
 } 
 
 /**
@@ -132,12 +135,18 @@ $(document).ready(function()
     $("#TagTagName").keyup(function(e){
         switch(e.keyCode) {
             case 38: //up
-                changeActiveSuggestion(-1);
+                if (isSuggestListActive) {
+                    changeActiveSuggestion(-1);
+                }
                 break;
             case 40://down
-                changeActiveSuggestion(1);
+                if (isSuggestListActive) {
+                    changeActiveSuggestion(1);
+                }
                 break;
             case 27: //escape
+            case 37: //left
+            case 39: //right
                 removeSuggestList();
                 break;
             default: 
@@ -151,7 +160,7 @@ $(document).ready(function()
 
     $("#TagAddTagPostForm").submit(function(){
         if (isSuggestListActive) {
-            var text = $("#suggestItem"+currentSuggestPosition).html()
+            var text = $("#suggestedItem"+currentSuggestPosition).html()
             $("#TagTagName").val(text);
             removeSuggestList(); 
             return false;


### PR DESCRIPTION
After 143cb20d2adb74906bf5e63695809cad4cbafc0b we've lost the abilitiy to select one of the suggested tags using the keyboard.

This also fixes some out-of-bounds accesses, sets "autocomplete" off in the template instead of in the Javascript code and removes an unused event handler.