### PR TITLE
Add new edit_licenses command

### DIFF
--- a/src/Command/EditLicensesCommand.php
+++ b/src/Command/EditLicensesCommand.php
@@ -1,0 +1,130 @@
+<?php
+namespace App\Command;
+
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Console\Command;
+use Cake\Collection\Collection;
+use Cake\Datasource\Exception\RecordNotFoundException;
+use App\Model\CurrentUser;
+use App\Lib\Licenses;
+
+class EditLicensesCommand extends Command
+{
+    protected $log;
+    const DEFAULT_USER = 'admin';
+
+    public function initialize() {
+        parent::initialize();
+        $this->loadModel('Sentences');
+        $this->loadModel('Users');
+    }
+
+    protected function buildOptionParser(ConsoleOptionParser $parser) {
+        $parser
+            ->setDescription('Change sentence licenses.')
+            ->addArgument('file', [
+                'help' => 'Name of the file that contains the sentence ids whose ' .
+                          'license should be changed. ("stdin" will read from ' .
+                          'standard input.)',
+                'required' => true,
+            ])
+            ->addArgument('license', [
+                'help' => 'New license.',
+                'choices' => array_keys(Licenses::getSentenceLicenses())
+            ])
+            ->addOption('dry-run', [
+                'help' => 'Do everything except saving any changes.',
+                'short' => 'n',
+                'boolean' => true
+            ])
+            ->addOption('user', [
+                'help' => 'Do all the work as given user.',
+                'short' => 'u',
+                'default' => self::DEFAULT_USER
+            ]);
+        return $parser;
+    }
+
+    protected function editLicense($ids, $options) {
+        extract($options);
+        foreach ($ids as $id) {
+            $this->Sentences->getConnection()->transactional(
+                function ($conn) use ($id, $newLicense, $dryRun) {
+                    try {
+                        $sentence = $this->Sentences->get($id);
+                    } catch (RecordNotFoundException $e) {
+                        $this->log[] = ["$id ignored: Record not found"];
+                        return false;
+                    }
+                    $oldLicense = $sentence->license;
+                    if ($oldLicense != $newLicense) {
+                        $newSentence = $this->Sentences->patchEntity(
+                            $sentence,
+                            ['license' => $newLicense]
+                        );
+                        if ($newSentence->hasErrors()) {
+                            $this->log[] = ["$id ignored: Cannot change license"];
+                            return false;
+                        } else {
+                            $this->log[] = [$id, $oldLicense, $newLicense];
+                            if (!$dryRun) {
+                                return $this->Sentences->save($newSentence);
+                            }
+                        }
+                    } else {
+                        $this->log[] = ["$id ignored: License is already $oldLicense"];
+                        return true;
+                    }
+                }
+            );
+        }
+    }
+
+    public function execute(Arguments $args, ConsoleIo $io) {
+        $input = $args->getArgument('file');
+        if ($input === 'stdin') {
+            $input = 'php://stdin';
+        } elseif ($input && !file_exists($input)) {
+            $io->error(format('{path} does not exist!', ['path' => $input]));
+            $this->abort();
+        }
+
+        $newLicense = $args->getArgument('license') ?? '';
+        $dryRun = $args->getOption('dry-run');
+        $username = $args->getOption('user');
+        $userId = $this->Users->getIdFromUsername($username);
+        if (!$userId) {
+            $io->error(format('User "{user}" does not exist!', ['user' => $username]));
+            $this->abort();
+        } else {
+            CurrentUser::store($this->Users->get($userId));
+        }
+
+        $this->log = [];
+
+        $ids = collection(file($input, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES))
+               ->filter(function ($v) { return preg_match('/^\d+$/', $v); });
+        $total = $ids->count();
+
+        $this->editLicense($ids, compact('newLicense', 'dryRun', 'io'));
+
+        if ($dryRun) {
+            $io->out('<info>This is a dry run! No changes to the database were committed!</info>');
+        }
+
+        if (empty($this->log)) {
+            $io->out('There was nothing to do.');
+        } else {
+            $io->out("$total rows proceeded:");
+            array_walk($this->log, function ($value, $index) use ($io) {
+                if (count($value) == 1) {
+                    $io->out($value);
+                } else {
+                    $io->out("id $value[0] - license changed from $value[1] to $value[2]");
+                }
+            });
+        }
+    }
+}

--- a/tests/TestCase/Command/EditLicensesCommandTest.php
+++ b/tests/TestCase/Command/EditLicensesCommandTest.php
@@ -1,0 +1,145 @@
+<?php
+namespace App\Test\TestCase\Command;
+
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+use Cake\ORM\TableRegistry;
+use Cake\Console\Command;
+use Cake\Filesystem\Folder;
+use Cake\Filesystem\File;
+
+class EditLicensesCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    public $fixtures = [
+        'app.sentences',
+        'app.reindex_flags',
+        'app.transcriptions',
+        'app.contributions',
+        'app.tags',
+        'app.tags_sentences',
+        'app.users',
+        'app.users_languages',
+    ];
+
+    const TESTDIR = TMP . 'edit_licenses_tests' . DS;
+
+    public static function setUpBeforeClass() {
+        mkdir(self::TESTDIR, 0755, true);
+    }
+
+    public static function tearDownAfterClass() {
+        $folder = new Folder(self::TESTDIR);
+        $folder->delete();
+    }
+
+    public function setUp() {
+        parent::setUp();
+        $this->UseCommandRunner();
+        $this->Sentences = TableRegistry::getTableLocator()->get('Sentences');
+        $this->Contributions = TableRegistry::getTableLocator()->get('Contributions');
+    }
+
+    private function create_test_file($ids) {
+        $path = self::TESTDIR . 'input_test';
+        $file = new File($path);
+        $file->write(implode("\n", $ids));
+        $file->close();
+        return $path;
+    }
+
+    public function testExecute_changesLicense() {
+        $path = $this->create_test_file([1, 2]);
+        $this->exec("edit_licenses $path");
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+
+        $sentence = $this->Sentences->get(1);
+        $this->assertEquals('', $sentence->license);
+
+        $conditions = [
+            'sentence_id' => 2,
+            'type' => 'license',
+            'action' => 'update'
+        ];
+        $contribution = $this->Contributions->find()->where($conditions)->last();
+        $this->assertEquals('', $sentence->license);
+    }
+
+    public function scenariosProvider() {
+        // username, license, ids, at least one change, ignored sentence
+        return [
+            'all ids changed to CC0 1.0' =>
+                ['', 'CC0 1.0', [23, 11, 9], true, false],
+            'some ids changed to CC BY 2.0 FR' =>
+                ['', 'CC BY 2.0 FR', [51, 52, 53], true, "53 ignored: License is already"],
+            'with wrong ids' =>
+                ['', 'CC0 1.0', [1, 99, 402, 5], true, "99 ignored: Record not found"],
+            'empty file' => ['', 'CC BY 2.0 FR', [], false, false],
+            'as non-admin' =>
+                ['contributor', 'CC0 1.0', [1, 2], false, "1 ignored: Cannot change license"],
+            'all ids changed to licensing issue' => ['', '', [1, 2, 3], true, false],
+        ];
+    }
+
+    /**
+     * @dataProvider scenariosProvider
+     **/
+    public function testExecute_severalScenarios($user, $newLicense, $ids, $hasOneChange, $containsIgnored) {
+        $path = $this->create_test_file($ids);
+
+        if (empty($user)) {
+            $this->exec("edit_licenses $path '$newLicense'");
+        } else {
+            $this->exec("edit_licenses -u $user $path '$newLicense'");
+        }
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+
+        $count = count($ids);
+        if ($count > 0) {
+            $this->assertOutputContains("$count rows proceeded:");
+        } else {
+            $this->assertOutputContains("There was nothing to do.");
+        }
+
+        if ($hasOneChange) {
+            $this->assertOutputContains("license changed from");
+        } else {
+            $this->assertOutputNotContains("license changed from");
+        }
+
+        if ($containsIgnored) {
+            $this->assertOutputContains($containsIgnored);
+        };
+    }
+
+    public function testExecute_withNonexistentFile() {
+        $this->exec('edit_licenses nonexistentfile');
+        $this->assertExitCode(Command::CODE_ERROR);
+    }
+
+    public function testExecute_withInvalidLicense() {
+        $path = $this->create_test_file([1, 2, 3]);
+        $this->exec("edit_licenses $path 'invalid'");
+        $this->assertExitCode(Command::CODE_ERROR);
+    }
+
+    public function testExecute_asUnknownUser() {
+        $path = $this->create_test_file([1, 2, 3]);
+        $this->exec("edit_licenses -u unknown_user $path 'CC BY 2.0 FR'");
+        $this->assertExitCode(Command::CODE_ERROR);
+    }
+
+    public function testExecute_dryRun() {
+        $path = $this->create_test_file([1]);
+        $sentenceBefore = $this->Sentences->get(1);
+        $contributionsBefore = $this->Contributions->find('all')->count();
+        $this->exec("edit_licenses -n $path");
+        $sentenceAfter = $this->Sentences->get(1);
+        $contributionsAfter = $this->Contributions->find('all')->count();
+        $this->assertEquals($sentenceBefore, $sentenceAfter);
+        $this->assertEquals($contributionsBefore, $contributionsAfter);
+    }
+}

--- a/tests/TestCase/Command/EditLicensesCommandTest.php
+++ b/tests/TestCase/Command/EditLicensesCommandTest.php
@@ -26,7 +26,7 @@ class EditLicensesCommandTest extends TestCase
     const TESTDIR = TMP . 'edit_licenses_tests' . DS;
 
     public static function setUpBeforeClass() {
-        mkdir(self::TESTDIR, 0755, true);
+        new Folder(self::TESTDIR, true, 0755);
     }
 
     public static function tearDownAfterClass() {


### PR DESCRIPTION
This PR addresses #2335.

The command itself should be self-explanatory.

Sample run:
````
vagrant@stretch:~/Tatoeba$ echo 'select id, license from sentences where id in (5,7);' |mysql tatoeba
id      license
5       CC BY 2.0 FR
7       CC BY 2.0 FR
vagrant@stretch:~/Tatoeba$ echo -e "5\n7" | cake edit_licenses stdin ''
2 rows proceeded:
id 5 - license changed from CC BY 2.0 FR to
id 7 - license changed from CC BY 2.0 FR to
vagrant@stretch:~/Tatoeba$ echo 'select id, license from sentences where id in (5,7);' |mysql tatoeba
id      license
5
7
````