### PR TITLE
Updated README file by deleting the entries for acl and archives

### DIFF
--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -15,16 +15,6 @@ Version used on the prod server: 5.5.38-0+wheezy1 (Debian)
 Folders content
 ------------------
 
-### acl
-
-Contains the cake console commands to run in order to fill the `aros`, `acos` 
-and `aros_acos` table. They define permissions for users. You can search "CakePHP ACL" 
-for more information about how this works.
-
-### archives
-
-Doesn't have anything you need. Files in here can probably be deleted.
-
 ### import
 
 Contains scripts to fill the tables with initial data.


### PR DESCRIPTION
The folders for acl and archives were deleted, but the README.md file still had entries for those two folders. My task is to delete those two entries from the README file.

