### PR TITLE
Encode tag suggestion query before sending it to the server

### DIFF
--- a/webroot/js/autocompletion.js
+++ b/webroot/js/autocompletion.js
@@ -51,7 +51,7 @@ function sendToAutocomplete() {
     var rootUrl = get_tatoeba_root_url();
     if ( tag != previousText) {
         $.get(
-            rootUrl + "/tags/autocomplete/" + tag,
+            rootUrl + "/tags/autocomplete/" + encodeURIComponent(tag),
             function(data) {
                 suggestShowResults(data);
             }


### PR DESCRIPTION
`#` and `?` at the start of a tag query need to be encoded in order to not interpret them as fragment or query string respectively.