### PR TITLE
Fix expand label when adding translations while no translations are displayed

### DIFF
--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -684,7 +684,7 @@ class SentencesTable extends Table
             ];
         }
 
-        if (isset($what['translations'])) {
+        if (isset($what['translations']) && $what['translations']) {
             $translationFields = [
                 'id', 'text', 'lang', 'correctness', 'script',
                 'SentencesTranslations.sentence_id'

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -1183,6 +1183,12 @@ class SentencesTableTest extends TestCase {
 		$this->assertFalse(isset($translationAudio->sentence_id));
 	}
 
+	function testGetSentenceWith_noTranslations() {
+		$sentence = $this->Sentence->getSentenceWith(1, ['translations' => false]);
+		$expected = [0 => [], 1 => []];
+		$this->assertEquals($expected, $sentence->translations);
+	}
+
     function testSaveNewSentence_correctDateUsingArabicLocale() {
         I18n::setLocale('ar');
         $added = $this->Sentence->saveNewSentence('test', 'eng', 1);


### PR DESCRIPTION
This PR fixes #2380.