### PR TITLE
Add Tagalog to charset_table

### DIFF
--- a/src/Shell/SphinxConfShell.php
+++ b/src/Shell/SphinxConfShell.php
@@ -258,6 +258,8 @@ class SphinxConfShell extends Shell {
         'U+1810..U+1819', 'U+1820..U+1878', 'U+1880..U+18AA',
         # Phoenician alphabet
         'U+10900..U+1091B',
+        # Tagalog (tgl)
+        'U+1700..U+1714',
     );
 
     public $scriptsWithoutWordBoundaries = array(


### PR DESCRIPTION
Someone added Tagalog sentences using the traditional script instead of Latin characters, e.g. [#8603745](https://tatoeba.org/cmn/sentences/show/8603745). This PR adds the necessary support for the script.

Unicode Block: https://www.unicode.org/charts/PDF/U1700.pdf

See issue #1970, section "Other Unsearchable Characters".