### PR TITLE
Add Egyptian Hieroglyphs to ngram_chars

### DIFF
--- a/src/Shell/SphinxConfShell.php
+++ b/src/Shell/SphinxConfShell.php
@@ -294,6 +294,8 @@ class SphinxConfShell extends Shell {
         'U+A980..U+A9C0', 'U+A9CF..U+A9D9',
         # Cuneiform, used by Sumerian (sux):
         'U+12000..U+12399', 'U+12400..U+1246E', 'U+12480..U+12543',
+        # Egyptian Hieroglyphs (egy)
+        'U+13000..U+1342E',
     );
 
     public $regexpFilter = array(


### PR DESCRIPTION
Someone added a few sentences using Egyptian hieroglyphs, e.g. [#8678698](https://tatoeba.org/eng/sentences/show/8678698). They created a [list with language code `egy`](https://tatoeba.org/eng/sentences_lists/show/9930), but apparently didn't request Egyptian to be added so far. I guess it can't hurt to add support for the script beforehand.

Unicode Block: https://www.unicode.org/charts/PDF/U13000.pdf

See issue #1970, section "Other Unsearchable Characters".