### PR TITLE
Improve license validation

### DIFF
--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -159,6 +159,18 @@ class SentencesTable extends Table
             'licenseCheck'
         );
 
+        $rules->addCreate(
+            function ($entity, $options) {
+                if (!empty($entity->license)) {
+                    return CurrentUser::getSetting('can_switch_license') ||
+                           $entity->license == CurrentUser::getSetting('default_license');
+                } else {
+                    return true;
+                }
+            },
+            'hasCorrectLicense'
+        );
+
         return $rules;
     }
 

--- a/tests/Fixture/UsersLanguagesFixture.php
+++ b/tests/Fixture/UsersLanguagesFixture.php
@@ -71,5 +71,15 @@ class UsersLanguagesFixture extends TestFixture {
 			'created' => '2018-10-31 00:00:00',
 			'modified' => '2018-10-31 00:00:00'
 		),
+		array(
+			'id' => 6,
+			'of_user_id' => 2,
+			'by_user_id' => 2,
+			'language_code' => 'jpn',
+			'level' => 3,
+			'details' => '',
+			'created' => '2017-10-31 00:00:00',
+			'modified' => '2017-10-31 00:00:00'
+		),
 	);
 }


### PR DESCRIPTION
I've added a new application rule which should improve license validation for new sentences. A user who cannot switch licenses is only allowed to add sentences under `CC BY 2.0 FR`.