### PR TITLE
Ease search of sentences ending with question mark

### DIFF
--- a/src/Shell/SphinxConfShell.php
+++ b/src/Shell/SphinxConfShell.php
@@ -530,6 +530,7 @@ source default
 index common_index
 {
     index_field_lengths     = 1
+    blend_chars             = ?
     ignore_chars            = U+AD, U+5B0..U+5C5, U+5C7, U+640, U+64b..U+65f, U+670, U+6dc
 $regexp_filter
     charset_table           = $charset_table_opt


### PR DESCRIPTION
The question mark is a problematic character because it is both used as a question marker in many languages AND as a metacharacter in Manticore (meaning "match any (one) character"). A user performing a search and using '?' as a metacharacter is
happy, but a user using '?' as a question marker doesn’t get the expected results. For example, searching for "are you okay?" will return NO results because there is no such pattern.

This PR should make users who are unaware of the metacharacters (that is to say the majority of users, I guess) happy, without impacting metacharacter users. The downside is that more words will be "unnecessary" indexed: any question sentence will have both its last word ("okay") and its last word with a question marker ("okay?") indexed as matching the sentence. The index dictionary will grow with a lot of question-marked words variants.

Related thread: https://tatoeba.org/wall/show_message/35435