### PR TITLE
Fixed naming for Show Transcriptions on Settings (issue 2353)

### DIFF
--- a/src/Template/User/settings.ctp
+++ b/src/Template/User/settings.ctp
@@ -159,7 +159,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                     ng-init="showTranscriptions = <?= $showTranscriptions ?>"
                     class="md-primary">
                 </md-checkbox>
-                <p><?php echo __('Always show transcriptions and alternative scripts') ?> </p>
+                <p><?php echo __('Always show unreviewed transcriptions and alternative scripts') ?> </p>
                 <div ng-hide="true">
                 <?php
                     echo $this->Form->input(


### PR DESCRIPTION
This PR resolves #2353 by replacing "Always show transcriptions and alternative scripts" to "Always show unreviewed transcriptions and alternative scripts".