### PR TITLE
Fix wrong usage of asort in tests

### DIFF
--- a/tests/TestCase/Model/Table/SentencesListsTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesListsTableTest.php
@@ -441,16 +441,18 @@ class SentencesListsTableTest extends TestCase {
         CurrentUser::store(['id' => null]);
         $lists = $this->SentencesList->getSearchableLists();
         $result = Hash::extract($lists, '{n}.id');
-        $expected = [2, 5];
-        $this->assertEquals(asort($expected), asort($result));
+        sort($result);
+        $expected = [2, 5, 6];
+        $this->assertEquals($expected, $result);
     }
 
     function testGetSearchableLists_asMember() {
         CurrentUser::store(['id' => 7]);
         $lists = $this->SentencesList->getSearchableLists();
         $result = Hash::extract($lists, '{n}.id');
-        $expected = [1, 3, 2, 5];
-        $this->assertEquals(asort($expected), asort($result));
+        sort($result);
+        $expected = [1, 2, 3, 5, 6];
+        $this->assertEquals($expected, $result);
     }
 
     function testGetNameForListWithId() {


### PR DESCRIPTION
Some tests used the return value of `asort` in the assertions. But `asort` sorts the array in place and just returns a boolean that indicates succes/failure. Thus these tests always succeeded although they should have failed with the current code version.

While here I've also refactored the test for `Sentences::findFilteredTranslations`.