### PR TITLE
Add language to the database without specifying a list

### DIFF
--- a/docs/database/procedures/add_new_language.sql
+++ b/docs/database/procedures/add_new_language.sql
@@ -18,7 +18,7 @@ ThisProc: BEGIN
 
 SELECT COUNT(*) INTO @code_found FROM languages WHERE code = lang_iso_code;
 IF NOT (@code_found = 0) THEN
-    SELECT CONCAT('Language code ', lang_iso_code, ' has already been added.');
+    SELECT CONCAT('Language code ', lang_iso_code, ' has already been added.') AS Error;
 END IF;
 -- We know this will fail when the language already exists, but we want the exception
 -- to occur so the caller will catch it.
@@ -28,7 +28,7 @@ SELECT COUNT(*) INTO @sentences_in_list FROM sentences, sentences_sentences_list
     WHERE sentences_list_id = list_id_for_lang AND sentences.id = sentence_id;
 
 IF (@sentences_in_list = 0) THEN
-    select CONCAT('There are no sentences in list ', list_id_for_lang);
+    select CONCAT('There are no sentences in list ', list_id_for_lang) AS Warning;
     LEAVE ThisProc;
 END IF;
 

--- a/docs/database/procedures/add_new_language.sql
+++ b/docs/database/procedures/add_new_language.sql
@@ -16,10 +16,6 @@ DROP PROCEDURE IF EXISTS add_new_language |
 CREATE PROCEDURE add_new_language(IN lang_iso_code CHAR(4), IN list_id_for_lang INT)
 ThisProc: BEGIN
 
-SELECT COUNT(*) INTO @code_found FROM languages WHERE code = lang_iso_code;
-IF NOT (@code_found = 0) THEN
-    SELECT CONCAT('Language code ', lang_iso_code, ' has already been added.') AS Error;
-END IF;
 -- We know this will fail when the language already exists, but we want the exception
 -- to occur so the caller will catch it.
 INSERT INTO languages (code) VALUES (lang_iso_code);

--- a/docs/database/procedures/add_new_language.sql
+++ b/docs/database/procedures/add_new_language.sql
@@ -19,9 +19,10 @@ ThisProc: BEGIN
 SELECT COUNT(*) INTO @code_found FROM languages WHERE code = lang_iso_code;
 IF NOT (@code_found = 0) THEN
     SELECT CONCAT('Language code ', lang_iso_code, ' has already been added.');
-    -- We know this will fail, but we want the exception to occur so the caller will catch it.
-    INSERT INTO languages (code) VALUES (lang_iso_code);
 END IF;
+-- We know this will fail when the language already exists, but we want the exception
+-- to occur so the caller will catch it.
+INSERT INTO languages (code) VALUES (lang_iso_code);
 
 SELECT COUNT(*) INTO @sentences_in_list FROM sentences, sentences_sentences_lists
     WHERE sentences_list_id = list_id_for_lang AND sentences.id = sentence_id;
@@ -31,7 +32,6 @@ IF (@sentences_in_list = 0) THEN
     LEAVE ThisProc;
 END IF;
 
-INSERT INTO languages (code) VALUES (lang_iso_code);
 UPDATE sentences, sentences_sentences_lists
     SET lang = lang_iso_code
     WHERE sentences_list_id = list_id_for_lang


### PR DESCRIPTION
[Point 3](https://github.com/Tatoeba/tatoeba2/wiki/Adding-a-new-language#3-run-the-mysql-add_new_language-procedure) on the wiki page for adding a new language says that one should use the procedure `add_new_language()`. A comment in the script file mentions a way to [add a language without specifying a list](https://github.com/Tatoeba/tatoeba2/blob/109f993bd4d0286be94ac1aa68941eea2ccc9133/docs/database/procedures/add_new_language.sql#L9-L10).

But this currently doesn't work:
```sql
MariaDB [tatoeba]> call add_new_language('abcd', 0);
+-------------------------------------------------------------+
| CONCAT('There are no sentences in list ', list_id_for_lang) |
+-------------------------------------------------------------+
| There are no sentences in list 0                            |
+-------------------------------------------------------------+
1 row in set (0.035 sec)

Query OK, 2 rows affected (0.037 sec)

MariaDB [tatoeba]> select * from languages where code = 'abcd';
Empty set (0.023 sec)
```

Since that is a reasonable use case (especially in a development environment) this PR fixes the script.

In addition I've also implemented the following changes:
- Added a better label for the warning message when the list is empty.
- Avoid running the list-specific code when no valid list id is specified.
- Avoid checking for existence of the language since we call the insert statement anyways in order to pass the exception to the caller.