### PR TITLE
Report Manticore errors

### DIFF
--- a/src/Controller/Component/ErrorComponent.php
+++ b/src/Controller/Component/ErrorComponent.php
@@ -29,4 +29,18 @@ class ErrorComponent extends Component
             return $message;
         }
     }
+
+    protected function generateNewCode() {
+        return uniqid();
+    }
+
+    public function traceError($message, $code = null) {
+        if (is_null($code)) {
+            $code = $this->generateNewCode();
+        }
+        $message = $this->format("[$code] $message");
+        $this->_registry->getController()->log($message);
+
+        return $code;
+    }
 }

--- a/src/Controller/Component/ErrorComponent.php
+++ b/src/Controller/Component/ErrorComponent.php
@@ -1,0 +1,33 @@
+<?php
+namespace App\Controller\Component;
+
+use Cake\Controller\Component;
+use Psr\Log\LogLevel;
+
+class ErrorComponent extends Component
+{
+    private function infoLine($infoKey, $infoValue) {
+        $info = '';
+        if ($infoValue) {
+            $info = "$infoKey: $infoValue\n";
+        }
+        return $info;
+    }
+
+    public function log($message, $level = LogLevel::ERROR, $context = []) {
+        if (strlen($message)) {
+            $message .= "\nRequest URL: " . $this->request->getRequestTarget() . "\n";
+
+            $referer = $this->request->getEnv('HTTP_REFERER');
+            $message .= $this->infoLine('Referer URL', $referer);
+
+            $clientIp = $this->request->clientIp();
+            $message .= $this->infoLine('Client IP', $clientIp);
+
+            $agent = $this->request->getEnv('HTTP_USER_AGENT');
+            $message .= $this->infoLine('User Agent', $agent);
+
+            return parent::log($message);
+        }
+    }
+}

--- a/src/Controller/Component/ErrorComponent.php
+++ b/src/Controller/Component/ErrorComponent.php
@@ -2,7 +2,6 @@
 namespace App\Controller\Component;
 
 use Cake\Controller\Component;
-use Psr\Log\LogLevel;
 
 class ErrorComponent extends Component
 {
@@ -14,7 +13,7 @@ class ErrorComponent extends Component
         return $info;
     }
 
-    public function log($message, $level = LogLevel::ERROR, $context = []) {
+    public function format($message) {
         if (strlen($message)) {
             $message .= "\nRequest URL: " . $this->request->getRequestTarget() . "\n";
 
@@ -27,7 +26,7 @@ class ErrorComponent extends Component
             $agent = $this->request->getEnv('HTTP_USER_AGENT');
             $message .= $this->infoLine('User Agent', $agent);
 
-            return parent::log($message);
+            return $message;
         }
     }
 }

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -534,6 +534,8 @@ class SentencesController extends AppController
             $results = $this->Sentences->addHighlightMarkers($results);
         } catch (Exception $e) {
             $syntax_error = strpos($e->getMessage(), 'syntax error,') !== FALSE;
+            $this->loadComponent('Error');
+            $this->Error->log('Search error: ' . $e->getMessage());
         }
 
         $strippedQuery = preg_replace('/"|=/', '', $search->getData('query'));

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -527,14 +527,16 @@ class SentencesController extends AppController
         ];
 
         $this->paginate = $pagination;
-        $syntax_error = false;
         try {
             $results = $this->paginate($model);
             $real_total = $this->Sentences->getRealTotal();
             $results = $this->Sentences->addHighlightMarkers($results);
+            $this->set(compact('results', 'real_total'));
         } catch (Exception $e) {
             $syntax_error = strpos($e->getMessage(), 'syntax error,') !== FALSE;
-            if (!$syntax_error) {
+            if ($syntax_error) {
+                $this->set('syntax_error', true);
+            } else {
                 $this->loadComponent('Error');
                 $error_code = $this->Error->traceError('Search error: ' . $e->getMessage());
                 $this->set('error_code', $error_code);
@@ -549,8 +551,7 @@ class SentencesController extends AppController
         $ignored = $search->getIgnoredFields();
 
         $this->set($search->getData());
-        $this->set(compact('real_total', 'ignored', 'results',
-                           'syntax_error', 'searchableLists', 'vocabulary'));
+        $this->set(compact('ignored', 'searchableLists', 'vocabulary'));
         $this->set(
             'is_advanced_search',
             !is_null($this->request->getQuery('trans_to'))

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -535,7 +535,7 @@ class SentencesController extends AppController
         } catch (Exception $e) {
             $syntax_error = strpos($e->getMessage(), 'syntax error,') !== FALSE;
             $this->loadComponent('Error');
-            $this->Error->log('Search error: ' . $e->getMessage());
+            $this->log($this->Error->format('Search error: ' . $e->getMessage()));
         }
 
         $strippedQuery = preg_replace('/"|=/', '', $search->getData('query'));

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -534,8 +534,11 @@ class SentencesController extends AppController
             $results = $this->Sentences->addHighlightMarkers($results);
         } catch (Exception $e) {
             $syntax_error = strpos($e->getMessage(), 'syntax error,') !== FALSE;
-            $this->loadComponent('Error');
-            $this->log($this->Error->format('Search error: ' . $e->getMessage()));
+            if (!$syntax_error) {
+                $this->loadComponent('Error');
+                $error_code = $this->Error->traceError('Search error: ' . $e->getMessage());
+                $this->set('error_code', $error_code);
+            }
         }
 
         $strippedQuery = preg_replace('/"|=/', '', $search->getData('query'));

--- a/src/Template/Sentences/search.ctp
+++ b/src/Template/Sentences/search.ctp
@@ -86,10 +86,9 @@ if ($ignored) {
 
 <section class="md-whiteframe-1dp">   
 <?php
-if (!isset($results)) {
-    ?><div class="section"><?php
     if ($syntax_error) {
-    ?>
+?>
+    <div class="section">
         <h2><?php echo __('Search error'); ?></h2>
         <p><?php
             echo format(
@@ -100,22 +99,27 @@ if (!isset($results)) {
                 'http://en.wiki.tatoeba.org/articles/show/text-search'
             );
         ?></p>
-    <?php
-    } else {
-    ?>
-    <h2><?php echo __('Search error'); ?></h2>
-    <p><?php
-        echo format(
-            __(
-                'An error occurred while performing the search. '.
-                'If the problem persists, please '.
-                '<a href="{}">let us know</a>.', true),
-            $this->Url->build(array('controller' => 'pages', 'action' => 'contact'))
-        );
-    ?></p>
-    <?php
-    }
-    ?></div><?php
+    </div>
+<?php
+    } elseif (isset($error_code)) {
+?>
+    <div class="section">
+        <h2><?php echo __('Search error'); ?></h2>
+        <p><?php
+            echo format(
+                __(
+                    'An error occurred while performing the search. '.
+                    'If the problem persists, please '.
+                    '<a href="{us}">let us know</a> and include the '.
+                    'error code "{errorCode}" in your message.'),
+                    [
+                        'us' => $this->Url->build(['controller' => 'pages', 'action' => 'contact']),
+                        'errorCode' => $error_code,
+                    ]
+            );
+        ?></p>
+    </div>
+<?php
 } elseif (count($results) > 0) {
     if (!$is_advanced_search && !empty($query)) {
         $keywords = $this->Languages->tagWithLang(

--- a/src/Template/Sentences/search.ctp
+++ b/src/Template/Sentences/search.ctp
@@ -86,7 +86,7 @@ if ($ignored) {
 
 <section class="md-whiteframe-1dp">   
 <?php
-    if ($syntax_error) {
+    if (isset($syntax_error)) {
 ?>
     <div class="section">
         <h2><?php echo __('Search error'); ?></h2>

--- a/tests/TestCase/Controller/Component/ErrorComponentTest.php
+++ b/tests/TestCase/Controller/Component/ErrorComponentTest.php
@@ -12,26 +12,6 @@ use Cake\TestSuite\TestCase;
 class ErrorComponentTest extends TestCase
 {
     private $Error;
-    private $testErrorLog = 'test-error';
-    private $logFilePath;
-    private $originalConfig;
-
-    private function eraseTestLog() {
-        @unlink($this->logFilePath);
-    }
-
-    private function setupTestErrorLogFile() {
-        $config = $this->originalConfig = Log::getConfig('error');
-        $config['file'] = $this->testErrorLog;
-        Log::drop('error');
-        Log::setConfig('error', $config);
-        $this->logFilePath = LOGS . $this->testErrorLog . '.log';
-    }
-
-    private function restoreErrorLogFile() {
-        Log::drop('error');
-        Log::setConfig('error', $this->originalConfig);
-    }
 
     private function buildTestErrorComponent() {
         $request = new ServerRequest([
@@ -49,36 +29,27 @@ class ErrorComponentTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-
-        $this->setupTestErrorLogFile();
-        $this->eraseTestLog();
         $this->Error = $this->buildTestErrorComponent();
     }
 
     public function tearDown()
     {
         unset($this->Error);
-        $this->restoreErrorLogFile();
-        $this->eraseTestLog();
-
         parent::tearDown();
     }
 
-    public function testLog()
+    public function testFormat()
     {
-        $date = ''; //date('Y-m-d H:i:s'); // can't test this part
         $expectedLog = <<<END_OF_LOG
-$date Error: ouch!
+ouch!
 Request URL: /here/and/there
 Referer URL: https://example.com/to/tatoeba
 Client IP: 93.184.216.340
 
-
 END_OF_LOG;
 
-        $this->Error->log('ouch!');
+        $result = $this->Error->format('ouch!');
 
-        $result = file_get_contents($this->logFilePath);
-        $this->assertContains($expectedLog, $result);
+        $this->assertEquals($expectedLog, $result);
     }
 }

--- a/tests/TestCase/Controller/Component/ErrorComponentTest.php
+++ b/tests/TestCase/Controller/Component/ErrorComponentTest.php
@@ -1,0 +1,84 @@
+<?php
+namespace App\Test\TestCase\Controller\Component;
+
+use App\Controller\Component\ErrorComponent;
+use Cake\Controller\ComponentRegistry;
+use Cake\Controller\Controller;
+use Cake\Core\Configure;
+use Cake\Http\ServerRequest;
+use Cake\Log\Log;
+use Cake\TestSuite\TestCase;
+
+class ErrorComponentTest extends TestCase
+{
+    private $Error;
+    private $testErrorLog = 'test-error';
+    private $logFilePath;
+    private $originalConfig;
+
+    private function eraseTestLog() {
+        @unlink($this->logFilePath);
+    }
+
+    private function setupTestErrorLogFile() {
+        $config = $this->originalConfig = Log::getConfig('error');
+        $config['file'] = $this->testErrorLog;
+        Log::drop('error');
+        Log::setConfig('error', $config);
+        $this->logFilePath = LOGS . $this->testErrorLog . '.log';
+    }
+
+    private function restoreErrorLogFile() {
+        Log::drop('error');
+        Log::setConfig('error', $this->originalConfig);
+    }
+
+    private function buildTestErrorComponent() {
+        $request = new ServerRequest([
+            'environment' => [
+                'REMOTE_ADDR' => '93.184.216.340',
+                'HTTP_REFERER' => 'https://example.com/to/tatoeba',
+            ],
+            'url' => '/here/and/there',
+        ]);
+        $controller = new Controller($request);
+        $registry = new ComponentRegistry($controller);
+        return new ErrorComponent($registry);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->setupTestErrorLogFile();
+        $this->eraseTestLog();
+        $this->Error = $this->buildTestErrorComponent();
+    }
+
+    public function tearDown()
+    {
+        unset($this->Error);
+        $this->restoreErrorLogFile();
+        $this->eraseTestLog();
+
+        parent::tearDown();
+    }
+
+    public function testLog()
+    {
+        $date = ''; //date('Y-m-d H:i:s'); // can't test this part
+        $expectedLog = <<<END_OF_LOG
+$date Error: ouch!
+Request URL: /here/and/there
+Referer URL: https://example.com/to/tatoeba
+Client IP: 93.184.216.340
+
+
+END_OF_LOG;
+
+        $this->Error->log('ouch!');
+
+        $result = file_get_contents($this->logFilePath);
+        $this->assertContains($expectedLog, $result);
+    }
+}

--- a/tests/TestCase/Controller/Component/ErrorComponentTest.php
+++ b/tests/TestCase/Controller/Component/ErrorComponentTest.php
@@ -12,8 +12,11 @@ use Cake\TestSuite\TestCase;
 class ErrorComponentTest extends TestCase
 {
     private $Error;
+    private $controller;
 
-    private function buildTestErrorComponent() {
+    public function setUp()
+    {
+        parent::setUp();
         $request = new ServerRequest([
             'environment' => [
                 'REMOTE_ADDR' => '93.184.216.340',
@@ -21,15 +24,16 @@ class ErrorComponentTest extends TestCase
             ],
             'url' => '/here/and/there',
         ]);
-        $controller = new Controller($request);
-        $registry = new ComponentRegistry($controller);
-        return new ErrorComponent($registry);
-    }
 
-    public function setUp()
-    {
-        parent::setUp();
-        $this->Error = $this->buildTestErrorComponent();
+        $this->controller = $this->getMockBuilder(Controller::class)
+            ->setConstructorArgs([$request])
+            ->setMethods(['log'])
+            ->getMock();
+        $registry = new ComponentRegistry($this->controller);
+        $this->Error = $this->getMockBuilder(ErrorComponent::class)
+            ->setConstructorArgs([$registry])
+            ->setMethods(['generateNewCode'])
+            ->getMock();
     }
 
     public function tearDown()
@@ -51,5 +55,40 @@ END_OF_LOG;
         $result = $this->Error->format('ouch!');
 
         $this->assertEquals($expectedLog, $result);
+    }
+
+    public function testTraceErrorWithoutCode_returnsNewCode()
+    {
+        $code = '2a001c1de4a97';
+        $this->Error
+            ->expects($this->any())
+            ->method('generateNewCode')
+            ->will($this->returnValue($code));
+
+        $returned = $this->Error->traceError('ouch!');
+
+        $this->assertEquals($code, $returned);
+    }
+
+    public function testTraceErrorWithCode_returnsPassedCode()
+    {
+        $code = '3852764736a9b';
+        $returned = $this->Error->traceError('ouch!', $code);
+        $this->assertEquals($code, $returned);
+    }
+
+    public function testTraceError_logsWithErrorCode()
+    {
+        $code = '4c8e2f91e946c';
+        $this->Error
+            ->expects($this->any())
+            ->method('generateNewCode')
+            ->will($this->returnValue($code));
+        $this->controller
+            ->expects($this->once())
+            ->method('log')
+            ->with($this->stringContains($code));
+
+        $this->Error->traceError('ouch!');
     }
 }


### PR DESCRIPTION
Currently, when Manticore returns a search error, there is no way to see the actual error message. The search error page just shows a generic error, and the logs do not contain the error. Setting debug to true doesn’t help.

This pull request adds a new component to log Manticore search errors into `logs/error.log`, along with context information.