### PR TITLE
Fix reindexing of new, changed and deleted sentences

### DIFF
--- a/config/Migrations/20200702192521_AddTypeToReindexFlags.php
+++ b/config/Migrations/20200702192521_AddTypeToReindexFlags.php
@@ -1,0 +1,22 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddTypeToReindexFlags extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('reindex_flags');
+        $table->addColumn('type', 'enum', [
+            'values' => ['change', 'removal'],
+            'null' => false,
+        ]);
+        $table->update();
+    }
+}

--- a/src/Shell/SphinxConfShell.php
+++ b/src/Shell/SphinxConfShell.php
@@ -584,7 +584,11 @@ EOT;
 
                 $delta_join = ($type == 'main') ?
                     '' :
-                    'join reindex_flags on reindex_flags.sentence_id = sent_start.id and reindex_flags.indexed = 1';
+                    "join reindex_flags rf on rf.sentence_id = sent_start.id and rf.indexed = 1 and rf.type = 'change'";
+                $kill_list_query = ($type == 'main') ?
+                    '' :
+                    "sql_query_killlist = select sentence_id from reindex_flags \
+                        where lang = '$lang' and indexed = 1 and type = 'removal'";
                 $conf .= "
         sql_query_range = select min(id), max(id) from sentences
         sql_range_step = 100000
@@ -639,6 +643,7 @@ EOT;
             left join \
                 sentences_sentences_lists lists on lists.sentence_id = r.id \
             group by id
+        $kill_list_query
 
         sql_attr_timestamp = created
         sql_attr_timestamp = modified
@@ -676,7 +681,7 @@ EOT;
                     }
                 } else {
                     $conf .= "
-        killlist_target = ${lang}_main_index:id";
+        killlist_target = ${lang}_main_index";
                 }
                 $conf .= "
     }

--- a/tests/Fixture/ReindexFlagsFixture.php
+++ b/tests/Fixture/ReindexFlagsFixture.php
@@ -4,5 +4,21 @@ namespace App\Test\Fixture;
 use Cake\TestSuite\Fixture\TestFixture;
 
 class ReindexFlagsFixture extends TestFixture {
-    public $import = ['model' => 'ReindexFlags'];
+	public $name = 'ReindexFlag';
+
+	public $fields = array(
+		'id' => ['type' => 'integer', 'null' => false, 'default' => null],
+		'sentence_id' => ['type' => 'integer', 'null' => false, 'default' => null],
+		'lang' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 4],
+		'indexed' => ['type' => 'boolean', 'null' => false, 'default' => '0'],
+		'type' => ['type' => 'string', 'null' => false],
+		'_indexes' => [
+			'idx_sentence_id' => ['type' => 'index', 'columns' => ['sentence_id'], 'length' => []],
+		],
+		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+		'_options' => ['charset' => 'latin1', 'collate' => 'latin1_swedish_ci', 'engine' => 'InnoDB']
+	);
+
+	public $records = array(
+	);
 }

--- a/tests/Fixture/ReindexFlagsFixture.php
+++ b/tests/Fixture/ReindexFlagsFixture.php
@@ -1,23 +1,8 @@
 <?php
-/* ReindexFlag Fixture generated on: 2015-11-27 23:54:27 : 1448668467 */
 namespace App\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 
 class ReindexFlagsFixture extends TestFixture {
-	public $name = 'ReindexFlag';
-
-	public $fields = array(
-		'id' => ['type' => 'integer', 'null' => false, 'default' => null],
-		'sentence_id' => ['type' => 'integer', 'null' => false, 'default' => null],
-		'lang' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 4],
-		'_indexes' => [
-			'idx_sentence_id' => ['type' => 'index', 'columns' => ['sentence_id'], 'length' => []],
-		],
-		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
-		'_options' => ['charset' => 'latin1', 'collate' => 'latin1_swedish_ci', 'engine' => 'InnoDB']
-	);
-
-	public $records = array(
-	);
+    public $import = ['model' => 'ReindexFlags'];
 }

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -734,46 +734,72 @@ class SentencesTableTest extends TestCase {
 		$this->assertFalse($result);
 	}
 
-	function testNeedsReindex() {
-		$reindex = array(2, 3);
-		$this->Sentence->needsReindex($reindex);
-		$result = $this->Sentence->ReindexFlags->find('all')
-			->where(['sentence_id' => $reindex], ['sentence_id' => 'integer[]'])
-			->count();
-		$this->assertEquals(2, $result);
+    function testNeedsReindex() {
+        $reindex = array(2, 3);
+        $this->Sentence->needsReindex($reindex);
+        $result = $this->Sentence->ReindexFlags->find('all')
+            ->where(['sentence_id' => $reindex], ['sentence_id' => 'integer[]']);
+        $this->assertEquals(2, $result->count());
+        $this->assertTrue($result->every(function ($entity) {
+            return $entity->type == 'change' && $entity->indexed === false;
+        }));
 	}
+
+    function testNeedsReindex_ExcludeUnknownLanguage() {
+        $ids = [6, 7, 9, 57];
+        $this->Sentence->needsReindex($ids);
+        $result = $this->Sentence->ReindexFlags->find('all')
+            ->where(['sentence_id' => $ids], ['sentence_id' => 'integer[]'])
+            ->select('sentence_id')
+            ->disableHydration()
+            ->toList();
+        $this->assertNotContains(9, $result);
+        $this->assertCount(3, $result);
+    }
 
 	function testModifiedSentenceNeedsReindex() {
 		$id = 1;
 		$sentence = $this->Sentence->get($id);
 		$sentence->text = 'Changed!';
 		$this->Sentence->save($sentence);
-		$result = $this->Sentence->ReindexFlags->findBySentenceId($id);
-		$this->assertTrue((bool)$result);
+		$result = $this->Sentence->ReindexFlags->findBySentenceId($id)->first();
+		$this->assertEquals('change', $result->type);
 	}
 
-	function testModifiedSentenceNeedsTranslationsReindex() {
-		$expected = array(1, 2, 4, 5);
-		$sentence = $this->Sentence->get(5);
-		$sentence->user_id = 0;
-		$this->Sentence->save($sentence);
-		$result = $this->Sentence->ReindexFlags->find('all')
-			->order(['sentence_id'])
-			->toList();
-		$result = Hash::extract($result, '{n}.sentence_id');
-		$this->assertEquals($expected, $result);
-	}
+    function testModifiedSentenceInUnknownDoesNotNeedReindex() {
+        $id = 9;
+        $sentence = $this->Sentence->get($id);
+        $sentence->text = 'Changed!';
+        $this->Sentence->save($sentence);
+        $result = $this->Sentence->ReindexFlags->findBySentenceId($id)->First();
+        $this->assertNull($result);
+    }
 
-	function testRemovedSentenceNeedsItselfAndTranslationsReindex() {
-		$expected = array(1, 2, 4, 5);
-		$sentence = $this->Sentence->get(5);
-		$this->Sentence->delete($sentence);
-		$result = $this->Sentence->ReindexFlags->find('all')
-			->order(['sentence_id'])
-			->toList();
-		$result = Hash::extract($result, '{n}.sentence_id');
-		$this->assertEquals($expected, $result);
-	}
+    function testModifiedSentenceNeedsTranslationsReindex() {
+        $expected = array(1, 2, 4, 5);
+        $sentence = $this->Sentence->get(5);
+        $sentence->user_id = 0;
+        $this->Sentence->save($sentence);
+        $result = $this->Sentence->ReindexFlags->find('all')
+            ->order(['sentence_id']);
+        $ids = $result->extract('sentence_id')->toList();
+        $this->assertEquals($expected, $ids);
+        $counts = $result->countBy('type')->toArray();
+        $this->assertEquals(4, $counts['change']);
+    }
+
+    function testRemovedSentenceNeedsItselfAndTranslationsReindex() {
+        $expected = array(1, 2, 4, 5);
+        $sentence = $this->Sentence->get(5);
+        $this->Sentence->delete($sentence);
+        $result = $this->Sentence->ReindexFlags->find('all')
+            ->order(['sentence_id']);
+        $ids = $result->extract('sentence_id')->toList();
+        $this->assertEquals($expected, $ids);
+        $types = $result->groupBy('type')->toArray();
+        $this->assertCount(1, $types['removal']);
+        $this->assertCount(3, $types['change']);
+    }
 
 	function testSentenceLoosesOKTagOnEdition() {
 		$sentenceId = 2;
@@ -1021,6 +1047,27 @@ class SentencesTableTest extends TestCase {
 		}
 	}
 
+    function testDeleteSentence_EntryInReindexFlags() {
+        CurrentUser::store($this->Sentence->Users->get(1));
+        $id = 1;
+        $this->Sentence->deleteSentence($id);
+        $result = $this->Sentence->ReindexFlags->findBySentenceId($id)->first();
+        $expected = [
+            'sentence_id' => 1,
+            'lang' => 'eng',
+            'indexed' => false,
+            'type' => 'removal'
+        ];
+        $this->assertArraySubset($expected, $result->toArray());
+    }
+
+    function testDeleteSentene_NoEntryInReindexFlagsForUnknownLanguage() {
+        CurrentUser::store($this->Sentence->Users->get(1));
+        $id = 9;
+        $this->Sentence->deleteSentence($id);
+        $result = $this->Sentence->ReindexFlags->findBySentenceId($id)->first();
+        $this->assertNull($result);
+    }
 
 	function testNumberOfSentencesOwnedBy() {
 		$result = $this->Sentence->numberOfSentencesOwnedBy(7);
@@ -1076,6 +1123,35 @@ class SentencesTableTest extends TestCase {
 		$result = $this->Sentence->changeLanguage(3, 'eng');
 		$this->assertEquals('spa', $result);
 	}
+
+    function testChangeLanguage_correctEntriesInReindexFlags() {
+        CurrentUser::store($this->Sentence->Users->get(2));
+        $this->Sentence->changeLanguage(53, 'rus');
+        $changes = $this->Sentence->ReindexFlags->findBySentenceId(53)
+            ->select(['lang', 'type'])
+            ->disableHydration()
+            ->all();
+        $this->assertContains(['lang' => 'rus', 'type' => 'change'], $changes);
+        $this->assertContains(['lang' => 'eng', 'type' => 'removal'], $changes);
+    }
+
+    function testChangeLanguage_noEntryInReindexFlagsForUnknownPreviousLanguage() {
+        CurrentUser::store($this->Sentence->Users->get(3));
+        $this->Sentence->changeLanguage(9, 'eng');
+        $changes = $this->Sentence->ReindexFlags->findBySentenceId(9)
+            ->where(['type' => 'removal'])
+            ->first();
+        $this->assertNull($changes);
+    }
+
+    function testChangeLanguage_noEntryInReindexFlagsForUnknownNewLanguage() {
+        CurrentUser::store($this->Sentence->Users->get(7));
+        $this->Sentence->changeLanguage(8, '');
+        $changes = $this->Sentence->ReindexFlags->findBySentenceId(8)
+            ->where(['type' => 'change'])
+            ->first();
+        $this->assertNull($changes);
+    }
 
 	function testSetOwner_succeeds() {
 		$id = 14;

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -770,8 +770,9 @@ class SentencesTableTest extends TestCase {
         $id = 9;
         $sentence = $this->Sentence->get($id);
         $sentence->text = 'Changed!';
-        $this->Sentence->save($sentence);
-        $result = $this->Sentence->ReindexFlags->findBySentenceId($id)->First();
+        $result = $this->Sentence->save($sentence);
+        $this->assertTrue((bool)$result);
+        $result = $this->Sentence->ReindexFlags->findBySentenceId($id)->first();
         $this->assertNull($result);
     }
 
@@ -1005,8 +1006,9 @@ class SentencesTableTest extends TestCase {
             'value' => 'This sentences purposely misses its flag.'
         ];
 
-        $this->Sentence->editSentence($data);
-        $row = $this->Sentence->ReindexFlags->findBySentenceId(9)
+        $sentence = $this->Sentence->editSentence($data);
+        $this->assertTrue((bool)$sentence);
+        $row = $this->Sentence->ReindexFlags->findBySentenceId($sentence->id)
             ->where(['type' => 'removal'])
             ->first();
         $this->assertNull($row);
@@ -1018,8 +1020,9 @@ class SentencesTableTest extends TestCase {
             'id' => '_7',
             'value' => 'This is a lonely sentence.'
         ];
-        $this->Sentence->editSentence($data);
-        $row = $this->Sentence->ReindexFlags->findBySentenceId(8)
+        $sentence = $this->Sentence->editSentence($data);
+        $this->assertTrue((bool)$sentence);
+        $row = $this->Sentence->ReindexFlags->findBySentenceId($sentence->id)
             ->where(['type' => 'change'])
             ->first();
         $this->assertNull($row);
@@ -1180,8 +1183,10 @@ class SentencesTableTest extends TestCase {
 
     function testChangeLanguage_noEntryInReindexFlagsForUnknownPreviousLanguage() {
         CurrentUser::store($this->Sentence->Users->get(3));
-        $this->Sentence->changeLanguage(9, 'eng');
-        $changes = $this->Sentence->ReindexFlags->findBySentenceId(9)
+        $sentenceId = 9;
+        $result = $this->Sentence->changeLanguage($sentenceId, 'eng');
+        $this->assertEquals('eng', $result);
+        $changes = $this->Sentence->ReindexFlags->findBySentenceId($sentenceId)
             ->where(['type' => 'removal'])
             ->first();
         $this->assertNull($changes);
@@ -1189,8 +1194,10 @@ class SentencesTableTest extends TestCase {
 
     function testChangeLanguage_noEntryInReindexFlagsForUnknownNewLanguage() {
         CurrentUser::store($this->Sentence->Users->get(7));
-        $this->Sentence->changeLanguage(8, '');
-        $changes = $this->Sentence->ReindexFlags->findBySentenceId(8)
+        $sentenceId = 8;
+        $result = $this->Sentence->changeLanguage($sentenceId, '');
+        $this->assertEquals('', $result);
+        $changes = $this->Sentence->ReindexFlags->findBySentenceId($sentenceId)
             ->where(['type' => 'change'])
             ->first();
         $this->assertNull($changes);


### PR DESCRIPTION
This PR closes #2226.

Implemented changes:
- Added a `type` column to `ReindexFlags`. As explained in a [comment on the issue](https://github.com/Tatoeba/tatoeba2/issues/2226#issuecomment-650343660) that column is necessary for distinguishing between inserts/updates and removals. But instead of needing just three states we actually need four: `not indexed/changed`, `not indexed/removed`, `indexed/changed` and `indexed/removed`.
- Rewrote the parts which add entries to `ReindexFlags`. A sentence with an unknown language will never be added to that table because we do not index sentences in an unknown language.
- Modified the shell for building `manticore.conf`
- Fixed a hidden bug in the edition of a sentence in the new design. A language change was never registered in `ReindexFlags` and other tables.
- Added/Updated tests.

Besides the tests (which ensure that `ReindexFlags` is correctly updated) there is also the (updated) demo as described in [another comment on the issue](https://github.com/Tatoeba/tatoeba2/issues/2226#issuecomment-652025764) which shows that this approach should work.

In addition I did some manual testing where I've monitored the contents of `sentences`, `reindex_flags` and the `main_index` and `delta_index` for 3 different languages after each insert/update/removal of a sentence, updating delta or merging delta into main. I haven't found any issues yet.
For automatic testing we would need to start a new VM and run a script similar to the one of the demo so that's probably not doable.

(After merging this PR reindexing the whole database is necessary to start with a clean state.)