### PR TITLE
Added Bulgarian as a User Interface (UI) language

### DIFF
--- a/config/app_local.php.template
+++ b/config/app_local.php.template
@@ -155,6 +155,7 @@ return [
             ['bel', null, 'Беларуская'],
             ['ben', null, 'বাংলা'],
             ['bre', null, 'Brezhoneg'],
+            ['bul', null, 'Български'],
             ['cat', null, 'Català'],
             ['ces', null, 'Čeština'],
             ['cmn', 'Hans', '中文', ['chi']],


### PR DESCRIPTION
This PR enables Bulgarian as a language interface on Tatoeba.
The translator asked me to enable it on dev Tatoeba to make sure how his translations are rendering and make his job easier.
He's aware that Bulgarian will be added on prod once it gets more translations.