### PR TITLE
Make Uyghur available as UI

### DIFF
--- a/config/app_local.php.template
+++ b/config/app_local.php.template
@@ -198,6 +198,7 @@ return [
             ['swe', null, 'Svenska'],
             ['tgl', null, 'Tagalog'],
             ['tur', null, 'Türkçe'],
+            ['uig', null, 'ئۇيغۇر'],
             ['ukr', null, 'Українська'],
             ['uzb', null, 'Oʻzbekcha'],
             ['vie', null, 'Tiếng Việt'],


### PR DESCRIPTION
This PR enables Uyghur as a language interface.
It has been requested to help translators to check how their translations on Transifex are rendering.