### PR TITLE
Add Filipino (fil) as UI language

### DIFF
--- a/config/app_local.php.template
+++ b/config/app_local.php.template
@@ -166,6 +166,7 @@ return [
             ['epo', null, 'Esperanto'],
             ['est', null, 'Eesti'],
             ['eus', null, 'Euskara'],
+            ['fil', null, 'Filipino'],
             ['fin', null, 'Suomi'],
             ['fra', null, 'Français', ['fre']],
             ['fry', null, 'Frysk'],


### PR DESCRIPTION
This PR adds Filipino as a UI language.
It has been asked from Filipino translators to check how their translations render online.
