### PR TITLE
Add Slovak as UI language

### DIFF
--- a/config/app_local.php.template
+++ b/config/app_local.php.template
@@ -194,6 +194,7 @@ return [
             ['por', 'BR', 'Português (Brasil)', ['pt_BR']],
             ['ron', null, 'Română'],
             ['rus', null, 'Русский'],
+            ['slk', null, 'Slovenčina'],
             ['spa', null, 'Español'],
             ['srp', null, 'српски'],
             ['swe', null, 'Svenska'],


### PR DESCRIPTION
This PR adds Slovak (slk) as UI language on Tatoeba.
It has been requested from the translators since they can't check how their translations are rendering.