### PR TITLE
Fix vocabulary number

### DIFF
--- a/src/Controller/VocabularyController.php
+++ b/src/Controller/VocabularyController.php
@@ -141,23 +141,6 @@ class VocabularyController extends AppController
 
         $result = $this->Vocabulary->addItem($lang, $text);
 
-        $numSentences = $result['numSentences'];
-
-        if (is_null($numSentences)) {
-            $numSentencesLabel = __('Unknown number of sentences');
-        } else {
-            $numSentences = $numSentences == 1000 ? '1000+' : $numSentences;
-            $numSentencesLabel = format(
-                __n(
-                    '{number} sentence', '{number} sentences',
-                    $numSentences,
-                    true
-                ),
-                array('number' => $numSentences)
-            );
-        }
-        $result['numSentencesLabel'] = $numSentencesLabel;
-
         $this->set('result', $result);
         $this->viewBuilder()->setLayout('json');
     }

--- a/src/Template/Vocabulary/save.ctp
+++ b/src/Template/Vocabulary/save.ctp
@@ -1,3 +1,7 @@
 <?php
+if ($result) {
+    $numSentences = $result['numSentences'];
+    $result['numSentencesLabel'] = $this->Vocabulary->sentenceCountLabel($numSentences);
+}
 echo json_encode($result);
 ?>

--- a/src/View/Helper/VocabularyHelper.php
+++ b/src/View/Helper/VocabularyHelper.php
@@ -29,22 +29,28 @@ class VocabularyHelper extends AppHelper
         'Html', 'Url'
     );
 
+    /**
+     * Create the label for the link to the search page
+     *
+     * @param integer $numSentences Number of sentences containing the vocabulary item
+     *
+     * @return string
+     */
+    public function sentenceCountLabel($numSentences) {
+        if (is_null($numSentences)) {
+            return __('Unknown number of sentences');
+        } else {
+            return format(
+                __n('{number} sentence', '{number} sentences', $numSentences),
+                ['number' => $numSentences == 1000 ? "1000+" : $numSentences]
+            );
+        }
+    }
+
     public function vocabulary($vocab) {
         $lang = $vocab['lang'];
         $text = $this->_View->safeForAngular($vocab['text']);
-        $numSentences = $vocab['numSentences'];
-        if (is_null($numSentences)) {
-            $numSentencesLabel = __('Unknown number of sentences');
-        } else {
-            $numSentencesLabel = format(
-                __n(
-                    '{number} sentence', '{number} sentences',
-                    $numSentences,
-                    true
-                ),
-                array('number' => $numSentences == 1000 ? '1000+' : $numSentences)
-            );
-        }
+        $numSentencesLabel = $this->sentenceCountLabel($vocab['numSentences']);
         if (Configure::read('Search.enabled')) {
             $url = $this->Url->build(array(
                 'controller' => 'sentences',

--- a/src/View/Helper/VocabularyHelper.php
+++ b/src/View/Helper/VocabularyHelper.php
@@ -36,14 +36,13 @@ class VocabularyHelper extends AppHelper
         if (is_null($numSentences)) {
             $numSentencesLabel = __('Unknown number of sentences');
         } else {
-            $numSentences = $numSentences == 1000 ? '1000+' : $numSentences;
             $numSentencesLabel = format(
                 __n(
                     '{number} sentence', '{number} sentences',
                     $numSentences,
                     true
                 ),
-                array('number' => $numSentences)
+                array('number' => $numSentences == 1000 ? '1000+' : $numSentences)
             );
         }
         if (Configure::read('Search.enabled')) {

--- a/tests/TestCase/View/Helper/VocabularyHelperTest.php
+++ b/tests/TestCase/View/Helper/VocabularyHelperTest.php
@@ -1,0 +1,41 @@
+<?php
+namespace App\Test\TestCase\View\Helper;
+
+use App\View\Helper\VocabularyHelper;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+
+class VocabularyHelperTest extends TestCase
+{
+    public $Vocabulary;
+
+    public function setUp() {
+        parent::setUp();
+        $view = new View();
+        $this->Vocabulary = new VocabularyHelper($view);
+    }
+
+    public function tearDown() {
+        unset($this->Vocabulary);
+        parent::tearDown();
+    }
+
+    public function sentenceCountProvider() {
+        return [
+            ['Unknown number of sentences', null],
+            ['1 sentence', 1],
+            ['2 sentences', 2],
+            ['1000+ sentences', 1000],
+        ];
+    }
+
+    /**
+     * @dataProvider sentenceCountProvider
+     */
+    public function testSentenceCountLabel($expected, $count) {
+        $this->assertEquals(
+            $expected,
+            $this->Vocabulary->sentenceCountLabel($count)
+        );
+    }
+}


### PR DESCRIPTION
The primary reason for this PR (the first commit) is to get rid of a warning in the debug log:
```
2020-07-14 15:39:54 Notice: Notice (8): A non well formed numeric value encountered in [/var/www-prod-d6245ffc91bdc31f5b4b27199099359fc1920c4a/vendor/cakephp/cakephp/src/I18n/PluralRules.php, line 182]
Request URL: /pol/vocabulary/of/Amastan?page=2
```
The problem is that the third parameter of the translation helper function `__n()` should be a number but when the number of sentences containing a vocabulary item is equal to the total limit for a search query (currently 1000) we pass a string:
https://github.com/Tatoeba/tatoeba2/blob/d6245ffc91bdc31f5b4b27199099359fc1920c4a/src/View/Helper/VocabularyHelper.php#L39-L47
This affects mainly languages that have more than one plural form like Polish, Russian or Ukrainian because they use a different code path in `I18n/PluralRules.php`.

The other commits are some refactoring:
- Using a configuration option instead of a constant for the total limit
- Putting the constructing of the label string into its own function
- Moving code for building the request body from the controller to the view

I'm not sure about the test for `SentencesController::show_all_in()` because it depends strongly on the resulting HTML code. But if it is ok I could add similar tests for `SentenceCommentsController::index()` and `ContributionsController::of_user()`