### PR TITLE
Add Chinese Jinyu as UI language

### DIFF
--- a/config/app_local.php.template
+++ b/config/app_local.php.template
@@ -159,6 +159,7 @@ return [
             ['bul', null, 'Български'],
             ['cat', null, 'Català'],
             ['ces', null, 'Čeština'],
+            ['cjy', null, '简体中文'],
             ['cmn', 'Hans', '中文', ['chi']],
             ['cym', null, 'Cymraeg'],
             ['dan', null, 'Dansk'],


### PR DESCRIPTION
This PR adds Chinese Jinyu on Tatoeba in order to help translators to check how their translations are rendering.