### PR TITLE
Make randomly-sorted result sets consistent over pages

### DIFF
--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -36,6 +36,7 @@ use App\Lib\Licenses;
 use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Event\Event;
+use Cake\Routing\Router;
 use Cake\Utility\Hash;
 use Cake\View\ViewBuilder;
 use Exception;
@@ -500,6 +501,11 @@ class SentencesController extends AppController
         /* Apply search criteria and sort */
         $search = new SentencesSearchForm();
         $search->setData($this->request->getQueryParams());
+
+        /* Control input */
+        if ($search->generateRandomSeedIfNeeded()) {
+            return $this->redirect(Router::url($search->getData()));
+        }
         $search->checkUnwantedCombinations();
 
         /* Session variables for search bar */

--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -44,6 +44,8 @@ class SentencesSearchForm extends Form
         'rand_seed' => '',
     ];
 
+    private $paramsOrder = [];
+
     public function __construct(EventManager $eventManager = null) {
         parent::__construct($eventManager);
         $this->search = new Search();
@@ -277,6 +279,9 @@ class SentencesSearchForm extends Form
 
     public function setData(array $data)
     {
+        /* Remember params order */
+        $this->paramsOrder = array_keys($data);
+
         /* Convert simple search to advanced search parameters */
         if (isset($data['to']) && !isset($data['trans_to'])) {
             $data['trans_to'] = $data['to'];
@@ -300,6 +305,24 @@ class SentencesSearchForm extends Form
             $setter = "setData$keyCamel";
             $this->_data[$key] = $this->$setter($value);
         }
+    }
+
+    private function paramIndex($param) {
+        $index = array_search($param, $this->paramsOrder);
+        if ($index === FALSE) {
+            $index = PHP_INT_MAX;
+        }
+        return $index;
+    }
+
+    public function getData($field = null) {
+        $data = parent::getData($field);
+        if (is_null($field)) {
+            uksort($data, function($a, $b) {
+                return $this->paramIndex($a) <=> $this->paramIndex($b);
+            });
+        }
+        return $data;
     }
 
     public function generateRandomSeedIfNeeded() {

--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -41,6 +41,7 @@ class SentencesSearchForm extends Form
         'trans_filter' => 'limit',
         'sort' => 'relevance',
         'sort_reverse' => '',
+        'rand_seed' => '',
     ];
 
     public function __construct(EventManager $eventManager = null) {
@@ -239,6 +240,33 @@ class SentencesSearchForm extends Form
     protected function setDataSortReverse(string $sort_reverse) {
         $sort_reverse = $this->search->reverseSort($sort_reverse === 'yes');
         return $sort_reverse ? 'yes' : '';
+    }
+
+    private function _encodeSeed($seed) {
+        $result = '';
+        if (is_int($seed)) {
+            $seed = base64_encode(pack('V', $seed));
+            $seed = substr($seed, 0, 4);
+            $result = str_replace(['+','/'], ['-','_'], $seed);
+        }
+        return $result;
+    }
+
+    private function _decodeSeed(string $seed) {
+        $result = null;
+        if (strlen($seed) >= 4) {
+            $seed = str_replace(['-','_'], ['+','/'], $seed);
+            $seed = substr($seed, 0, 4).'AA';
+            $result = @unpack('V', base64_decode($seed))[1];
+        }
+        return $result;
+    }
+
+    protected function setDataRandSeed(string $seed_b64) {
+        $seed_int = $this->_decodeSeed($seed_b64);
+        $seed_int = $this->search->setRandSeed($seed_int);
+        $seed_b64 = $this->_encodeSeed($seed_int);
+        return $seed_b64;
     }
 
     public function setData(array $data)

--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -242,6 +242,12 @@ class SentencesSearchForm extends Form
         return $sort_reverse ? 'yes' : '';
     }
 
+    private function _newSeed() {
+        /* Only use 24 bits of randomness */
+        $pseudoRand = mt_rand(0, (2<<23)-1);
+        return $this->_encodeSeed($pseudoRand);
+    }
+
     private function _encodeSeed($seed) {
         $result = '';
         if (is_int($seed)) {
@@ -293,6 +299,15 @@ class SentencesSearchForm extends Form
             $keyCamel = Inflector::camelize($key);
             $setter = "setData$keyCamel";
             $this->_data[$key] = $this->$setter($value);
+        }
+    }
+
+    public function generateRandomSeedIfNeeded() {
+        if ($this->_data['sort'] == 'random' && empty($this->_data['rand_seed'])) {
+            $this->_data['rand_seed'] = $this->_newSeed();
+            return true;
+        } else {
+            return false;
         }
     }
 

--- a/src/Model/Search.php
+++ b/src/Model/Search.php
@@ -157,6 +157,9 @@ class Search {
                     $rankingExpr = $randomExpr;
                 }
             }
+            if ($this->sort == 'random') {
+                $sortOrder .= ', '.$this->orderby('id', $this->sortReversed);
+            }
             $sphinx['sortMode'] = [SPH_SORT_EXTENDED => $sortOrder];
             if (isset($rankingExpr)) {
                 $sphinx['rankingMode'] = [SPH_RANK_EXPR => $rankingExpr];

--- a/src/Model/Search.php
+++ b/src/Model/Search.php
@@ -21,6 +21,7 @@ class Search {
     private $native;
     private $sort;
     private $sortReversed = false;
+    private $randSeed;
 
     private $translationFilter;
     private $translationFilters = [];
@@ -132,13 +133,14 @@ class Search {
             $sphinx['filter'][] = ['filter', $filter];
         }
         if ($this->sort) {
-            if ($this->sort == 'random') {
-                $sortOrder = '@random';
-            } elseif (empty($this->query)) {
+            $randomExpr = "RAND({$this->randSeed})*16777216";
+            if (empty($this->query)) {
                 // When the query is empty, Manticore does not perform any
                 // ranking, so we need to rely on ordering instead
                 if ($this->sort == 'created' || $this->sort == 'modified') {
                     $sortOrder = $this->orderby($this->sort, $this->sortReversed);
+                } elseif ($this->sort == 'random') {
+                    $sortOrder = $this->orderby($randomExpr, $this->sortReversed);
                 } else {
                     $sortOrder = $this->orderby('text_len', !$this->sortReversed);
                 }
@@ -151,6 +153,8 @@ class Search {
                     $rankingExpr = '-text_len+top(lcs+exact_order*100)*100';
                 } elseif ($this->sort == 'created' || $this->sort == 'modified') {
                     $rankingExpr = $this->sort;
+                } elseif ($this->sort == 'random') {
+                    $rankingExpr = $randomExpr;
                 }
             }
             $sphinx['sortMode'] = [SPH_SORT_EXTENDED => $sortOrder];
@@ -296,5 +300,9 @@ class Search {
         $to = array('\\\\', '\(', '\)', '\|', '\-', '\!', '\@', '\~', '\"', '\&', '\/', '\^', '\$', '\=' );
         $escaped = str_replace($from, $to, $text);
         return '="'.$escaped.'"';
+    }
+
+    public function setRandSeed($seed) {
+        return $this->randSeed = $seed;
     }
 }

--- a/tests/TestCase/Controller/SentencesControllerTest.php
+++ b/tests/TestCase/Controller/SentencesControllerTest.php
@@ -57,6 +57,7 @@ class SentencesControllerTest extends IntegrationTestCase {
             [ '/jpn/sentences/search', null, true ],
             [ '/jpn/sentences/search', 'contributor', true ],
             [ '/jpn/sentences/search?query=hacer&from=spa&to=fra', null, true ],
+            [ '/jpn/sentences/search?query=hacer&from=spa&to=fra&sort=random', null, true ], // TODO no redirect because Search.enabled = false
             [ '/jpn/sentences/advanced_search', null, true ],
             [ '/jpn/sentences/advanced_search', 'contributor', true ],
             [ '/jpn/sentences/show_all_in/jpn/none', null, true ],

--- a/tests/TestCase/Form/SentencesSearchFormTest.php
+++ b/tests/TestCase/Form/SentencesSearchFormTest.php
@@ -45,6 +45,7 @@ class SentencesSearchFormTest extends TestCase
             'trans_user' => '',
             'sort' => 'relevance',
             'sort_reverse' => '',
+            'rand_seed' => '',
         ];
         $this->Form->setData([]);
         $this->assertEquals($expected, $this->Form->getData());
@@ -156,6 +157,13 @@ class SentencesSearchFormTest extends TestCase
             [ 'sort_reverse', 'yes',     ['reverseSort', true],  'yes' ],
             [ 'sort_reverse', '',        ['reverseSort', false], '' ],
             [ 'sort_reverse', 'invalid', ['reverseSort', false], '' ],
+
+            [ 'rand_seed', 'xrgU',          ['setRandSeed',  1358022], 'xrgU' ],
+            [ 'rand_seed', '3-_a',          ['setRandSeed', 14348255], '3-_a' ],
+            [ 'rand_seed', '',              ['setRandSeed',     null], ''     ],
+            [ 'rand_seed', 'longer string', ['setRandSeed', 14715286], 'long' ],
+            [ 'rand_seed', 'sml',           ['setRandSeed',     null], ''     ],
+            [ 'rand_seed', '.!"@',          ['setRandSeed',     null], ''     ],
         ];
     }
 

--- a/tests/TestCase/Form/SentencesSearchFormTest.php
+++ b/tests/TestCase/Form/SentencesSearchFormTest.php
@@ -406,4 +406,32 @@ class SentencesSearchFormTest extends TestCase
 
         $this->assertEquals($stuff, $result);
     }
+
+    private function assertSameKeyOrder(array $expected, array $tested) {
+        reset($expected);
+        reset($tested);
+        while (!is_null(key($expected))) {
+            $this->assertEquals(key($expected), key($tested));
+            next($tested);
+            next($expected);
+        }
+    }
+
+    public function testDataOrderIsPreserved() {
+        $expected = [
+            'native' => 'yes',
+            'user' => '',
+            'from' => 'und',
+            'orphans' => 'no',
+            'tags' => '',
+            'query' => 'order should be preserved',
+            'unapproved' => 'no',
+            'has_audio' => '',
+            'to' => 'und',
+            'list' => '',
+        ];
+        $this->Form->setData($expected);
+        $retreived = $this->Form->getData();
+        $this->assertSameKeyOrder($expected, $retreived);
+    }
 }

--- a/tests/TestCase/Form/SentencesSearchFormTest.php
+++ b/tests/TestCase/Form/SentencesSearchFormTest.php
@@ -259,6 +259,19 @@ class SentencesSearchFormTest extends TestCase
         $this->assertEquals('relevance', $this->Form->getData()['sort']);
     }
 
+    public function testGenerateRandomSeedIfNeeded_unneeded() {
+        $this->Form->setData(['sort' => 'created']);
+        $this->assertFalse($this->Form->generateRandomSeedIfNeeded());
+        $this->assertEmpty($this->Form->getData()['rand_seed']);
+    }
+
+    public function testGenerateRandomSeedIfNeeded_needed() {
+        mt_srand(42);
+        $this->Form->setData(['sort' => 'random']);
+        $this->assertTrue($this->Form->generateRandomSeedIfNeeded());
+        $this->assertEquals('Ztzh', $this->Form->getData()['rand_seed']);
+    }
+
     public function testGetSearchableLists_asGuest() {
         $searcher = null;
         $expected = [

--- a/tests/TestCase/Model/SearchTest.php
+++ b/tests/TestCase/Model/SearchTest.php
@@ -826,10 +826,69 @@ class SearchTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function testSortByRandom() {
+    public function testSortByRandom_withoutSeed_withEmptyQuery() {
         $this->Search->filterByQuery('');
+        $this->Search->setRandSeed(null);
         $this->assertEquals('random', $this->Search->sort('random'));
-        $this->assertSortBy('@random');
+        $this->assertSortBy('RAND()*16777216 DESC');
+    }
+
+    public function testSortByRandom_withoutSeed_withEmptyQuery_reversed() {
+        $this->Search->filterByQuery('');
+        $this->Search->setRandSeed(null);
+        $this->assertEquals('random', $this->Search->sort('random'));
+        $this->Search->reverseSort(true);
+        $this->assertSortBy('RAND()*16777216 ASC');
+    }
+
+    public function testSortByRandom_withoutSeed_withNonEmptyQuery() {
+        $this->Search->filterByQuery('comme ci comme ça');
+        $this->Search->setRandSeed(null);
+        $this->assertEquals('random', $this->Search->sort('random'));
+        $this->assertSortByRank('@rank DESC', 'RAND()*16777216');
+    }
+
+    public function testSortByRandom_withoutSeed_withNonEmptyQuery_reversed() {
+        $this->Search->filterByQuery('comme ci comme ça');
+        $this->Search->setRandSeed(null);
+        $this->Search->reverseSort(true);
+        $this->assertEquals('random', $this->Search->sort('random'));
+        $this->assertSortByRank('@rank ASC', 'RAND()*16777216');
+    }
+
+    public function testSortByRandom_withSeed_withEmptyQuery() {
+        $this->Search->filterByQuery('');
+        $this->Search->setRandSeed(123456789);
+        $this->assertEquals('random', $this->Search->sort('random'));
+        $this->assertSortBy('RAND(123456789)*16777216 DESC');
+    }
+
+    public function testSortByRandom_withSeed_withEmptyQuery_reversed() {
+        $this->Search->filterByQuery('');
+        $this->Search->setRandSeed(123456789);
+        $this->assertEquals('random', $this->Search->sort('random'));
+        $this->Search->reverseSort(true);
+        $this->assertSortBy('RAND(123456789)*16777216 ASC');
+    }
+
+    public function testSortByRandom_withSeed_withNonEmptyQuery() {
+        $this->Search->filterByQuery('comme ci comme ça');
+        $this->Search->setRandSeed(123456789);
+        $this->assertEquals('random', $this->Search->sort('random'));
+        $this->assertSortByRank('@rank DESC', 'RAND(123456789)*16777216');
+    }
+
+    public function testSortByRandom_withSeed_withNonEmptyQuery_reversed() {
+        $this->Search->filterByQuery('comme ci comme ça');
+        $this->Search->setRandSeed(123456789);
+        $this->assertEquals('random', $this->Search->sort('random'));
+        $this->Search->reverseSort(true);
+        $this->assertSortByRank('@rank ASC', 'RAND(123456789)*16777216');
+    }
+
+    public function testRandSeed_resets() {
+        $this->Search->setRandSeed(12345);
+        $this->testSortByRandom_withoutSeed_withEmptyQuery();
     }
 
     public function testSortByInvalid() {

--- a/tests/TestCase/Model/SearchTest.php
+++ b/tests/TestCase/Model/SearchTest.php
@@ -830,7 +830,7 @@ class SearchTest extends TestCase
         $this->Search->filterByQuery('');
         $this->Search->setRandSeed(null);
         $this->assertEquals('random', $this->Search->sort('random'));
-        $this->assertSortBy('RAND()*16777216 DESC');
+        $this->assertSortBy('RAND()*16777216 DESC, id DESC');
     }
 
     public function testSortByRandom_withoutSeed_withEmptyQuery_reversed() {
@@ -838,14 +838,14 @@ class SearchTest extends TestCase
         $this->Search->setRandSeed(null);
         $this->assertEquals('random', $this->Search->sort('random'));
         $this->Search->reverseSort(true);
-        $this->assertSortBy('RAND()*16777216 ASC');
+        $this->assertSortBy('RAND()*16777216 ASC, id ASC');
     }
 
     public function testSortByRandom_withoutSeed_withNonEmptyQuery() {
         $this->Search->filterByQuery('comme ci comme ça');
         $this->Search->setRandSeed(null);
         $this->assertEquals('random', $this->Search->sort('random'));
-        $this->assertSortByRank('@rank DESC', 'RAND()*16777216');
+        $this->assertSortByRank('@rank DESC, id DESC', 'RAND()*16777216');
     }
 
     public function testSortByRandom_withoutSeed_withNonEmptyQuery_reversed() {
@@ -853,14 +853,14 @@ class SearchTest extends TestCase
         $this->Search->setRandSeed(null);
         $this->Search->reverseSort(true);
         $this->assertEquals('random', $this->Search->sort('random'));
-        $this->assertSortByRank('@rank ASC', 'RAND()*16777216');
+        $this->assertSortByRank('@rank ASC, id ASC', 'RAND()*16777216');
     }
 
     public function testSortByRandom_withSeed_withEmptyQuery() {
         $this->Search->filterByQuery('');
         $this->Search->setRandSeed(123456789);
         $this->assertEquals('random', $this->Search->sort('random'));
-        $this->assertSortBy('RAND(123456789)*16777216 DESC');
+        $this->assertSortBy('RAND(123456789)*16777216 DESC, id DESC');
     }
 
     public function testSortByRandom_withSeed_withEmptyQuery_reversed() {
@@ -868,14 +868,14 @@ class SearchTest extends TestCase
         $this->Search->setRandSeed(123456789);
         $this->assertEquals('random', $this->Search->sort('random'));
         $this->Search->reverseSort(true);
-        $this->assertSortBy('RAND(123456789)*16777216 ASC');
+        $this->assertSortBy('RAND(123456789)*16777216 ASC, id ASC');
     }
 
     public function testSortByRandom_withSeed_withNonEmptyQuery() {
         $this->Search->filterByQuery('comme ci comme ça');
         $this->Search->setRandSeed(123456789);
         $this->assertEquals('random', $this->Search->sort('random'));
-        $this->assertSortByRank('@rank DESC', 'RAND(123456789)*16777216');
+        $this->assertSortByRank('@rank DESC, id DESC', 'RAND(123456789)*16777216');
     }
 
     public function testSortByRandom_withSeed_withNonEmptyQuery_reversed() {
@@ -883,7 +883,7 @@ class SearchTest extends TestCase
         $this->Search->setRandSeed(123456789);
         $this->assertEquals('random', $this->Search->sort('random'));
         $this->Search->reverseSort(true);
-        $this->assertSortByRank('@rank ASC', 'RAND(123456789)*16777216');
+        $this->assertSortByRank('@rank ASC, id ASC', 'RAND(123456789)*16777216');
     }
 
     public function testRandSeed_resets() {


### PR DESCRIPTION
This PR solves #1667 by adding a random seed value mechanism to keep randomly-sorted result sets consistent over pages.

New behaviour: when a search is performed with random order, a seed value is randomly generated and the request is redirected to the same URL with an additional `rand_seed` GET parameter containing the seed value encoded in base64. This seed value will stick on other pages of the result. Reloading the page won’t show a different order any more; only clicking the Search button again will. This change might confuse some users.

Random searches will be slower (to some extent) because of the redirection, but I think this implementation is simpler and more solid.