### PR TITLE
Improve error output for development environments

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -79,38 +79,35 @@ try {
  */
 Configure::load('app_local', 'default');
 
-/*
- * When debug = true the metadata cache should only last
- * for a short time.
- */
 if (Configure::read('debug')) {
+    /*
+     * When debug = true the metadata cache should only last
+     * for a short time.
+     */
     Configure::write('Cache._cake_model_.duration', '+2 minutes');
     Configure::write('Cache._cake_core_.duration', '+2 minutes');
     // disable router cache during development
     Configure::write('Cache._cake_routes_.duration', '+2 seconds');
-}
 
-/**
- * In debug mode errors and warnings will be displayed in the browser. But whenever the output
- * contains {{ the app will crash because they will be interpreted by the AngularJS compiler.
- * We can prevent the crash if we modify the template string by adding the ng-non-bindable
- * directive. Unfortunately the template string isn't easily accessible so we need to use
- * PHP's Reflection feature.
- */
-if (Configure::read('debug')) {
+    /**
+     * In debug mode errors and warnings will be displayed in the browser.
+     * But whenever the output contains {{ the app will crash because they
+     * will be interpreted by the AngularJS compiler.
+     * We can prevent the crash if we modify the template string by adding
+     * the ng-non-bindable directive. Unfortunately the template string
+     * isn't easily accessible so we need to use PHP's Reflection feature.
+     */
     $debugger = new ReflectionClass('Cake\Error\Debugger');
     $templates = $debugger->getProperty('_templates');
     $templates->setAccessible(true);
     $error = $templates->getValue(Debugger::getInstance())['js']['error'];
     $error = preg_replace('/>/', ' ng-non-bindable>', $error, 1);
     Debugger::addFormat('js', ['error' => $error]);
-}
 
-/*
- * Make cache files world-writable on dev environments
- * to ease file permissions setup.
- */
-if (Configure::read('debug')) {
+    /*
+     * Make cache files world-writable on dev environments
+     * to ease file permissions setup.
+     */
     $confCache = Configure::read('Cache');
     foreach ($confCache as $cache => $config) {
         if (Configure::read('debug')) {


### PR DESCRIPTION
This PR prevents a crash in the development environment (`debug = true`) whenever an error or warning output contains `{{`. See also the discussion on #2420.

Since AngularJS shouldn't interpret the error messages, one possible solution is to add `ng-non-bindable` to the HTML element created by CakePHP's error handler. Unfortunately the template string for the error message isn't easily readable so we need to use PHP's Reflection API in order to access it.