### PR TITLE
Blank page no vocabulary items are found

### DIFF
--- a/src/Template/Vocabulary/add_sentences.ctp
+++ b/src/Template/Vocabulary/add_sentences.ctp
@@ -27,10 +27,15 @@
 ?>
 <?php
 $this->Html->script('/js/vocabulary/add-sentences.ctrl.js', ['block' => 'scriptBottom']);
-
-$title = __('Vocabulary that needs sentences');
-
-$this->set('title_for_layout', $this->Pages->formatTitle($title));
+    if (empty($langFilter)) {
+        $title = __('Vocabulary that needs sentences');
+        $this->set('title_for_layout', $this->Pages->formatTitle($title));
+    } else {
+        $title = format(
+            __('Vocabulary that needs sentences in {language}'),
+            array('language' => $this->Languages->codeToNameToFormat($langFilter))
+        );
+    }
 ?>
 
 <div ng-cloak id="annexe_content">
@@ -53,6 +58,13 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
                 'Only vocabulary items that match fewer than 10 sentences are '.
                 'displayed here.'
             )
+            ?>
+        </div>
+        <div class="empty-info-text">
+            <?php
+                if ($vocabulary->count() == 0) {
+                    echo "There are no requests. ";
+                }
             ?>
         </div>
 

--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -796,3 +796,10 @@ html[dir="rtl"] .md-button-right .md-button {
     left: -8px;
     right: initial;
 }
+
+.empty-info-text {
+    text-align: center;
+    font-size: 2em;
+    color: #666666;
+    margin: 50px 0 50px 0;
+}


### PR DESCRIPTION
This pull request addresses issue Tatoeba#2273 - when filtering by language, there is no indication why the page is blank when there are no vocabulary items found.