### PR TITLE
Fix multiline tooltip

### DIFF
--- a/webroot/css/sentences/advanced_search.css
+++ b/webroot/css/sentences/advanced_search.css
@@ -33,9 +33,6 @@
 md-tooltip.multiline {
     /* Only wrap tooltip if it takes more than 20% of page width. */
     max-width: 20%;
-}
-
-md-tooltip.multiline .md-content {
     height: auto;
     white-space: normal;
     /* The original md-tooltip use line-height to pad, but we want a nice


### PR DESCRIPTION
This PR fixes #2491.

After upgrading AngularJS Material to 1.1.5, the tooltip isn't wrapped in an element with class `md-content` anymore.

(I think the change was introduced in [1.1.2](https://github.com/angular/material/commit/6d06188#diff-ed639b2137be9bfbcd646c77b5074665).)