### PR TITLE
Revert removing jQuery from layout.js

### DIFF
--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -27,6 +27,7 @@ files[] = layouts/default.css
 files[] = layouts/elements.css
 
 [layout.js]
+files[] = jquery-1.11.3.min.js
 files[] = angular/angular.min.js
 files[] = angular/angular-animate.min.js
 files[] = angular/angular-aria.min.js
@@ -38,15 +39,13 @@ files[] = responsive/app.module.js
 files[] = generic_functions.js
 files[] = elements/search-bar.ctrl.js
 files[] = directives/language-dropdown.dir.js
-
+files[] = watch.js
 
 [sentences-block-for-members.js]
-files[] = jquery-1.11.3.min.js
 files[] = jquery.jeditable.js
 ; Source: https://github.com/jonathantneal/svg4everybody
 ; This is needed to make "fill: currentColor" work on every browser.
 files[] = svg4everybody.min.js
-files[] = watch.js
 files[] = sentences.edit_in_place.js
 files[] = sentences.add_translation.js
 files[] = favorites.add.js
@@ -59,8 +58,6 @@ files[] = links.add_and_delete.js
 files[] = reviews.add_remove.js
 files[] = transcriptions.js
 files[] = sentences.collapse.js
-files[] = clipboard.min.js
-files[] = sentences.copy.js
 
 [sentence-component.js]
 files[] = clipboard.min.js

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -729,6 +729,9 @@ class SentencesHelper extends AppHelper
 
         // defined in config/asset_compress.ini
         $this->AssetCompress->script('sentences-block-for-members.js', $options);
+        $this->Html->script('clipboard.min.js', $options);
+        $this->Html->script('sentences.copy.js', $options);
+        $this->Html->script('sentences.play_audio.js', $options);
     }
 
 

--- a/webroot/js/sentences.play_audio.js
+++ b/webroot/js/sentences.play_audio.js
@@ -1,0 +1,28 @@
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2010  HO Ngoc Phuong Trang <tranglich@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+$(document).ready(function () {
+  $(document).watch('addrule', function () {
+    $('.audioAvailable').off();
+    $('.audioAvailable').click(function () {
+      var audioURL = $(this).attr('href');
+      var audio = new Audio(audioURL);
+      audio.play();
+    });
+  });
+});


### PR DESCRIPTION
This PR closes #2497.

dcdab7f was to optimistic in the assumption that jQuery is only needed for displaying the full sentence block (with all the menu buttons). But we have still pages where we display a sentence in a minimal version of
the old design (just the sentence + the copy and audio button). These pages (e.g. all the audio pages) still require jQuery (and `watch.js`) so we need to load it even if we don't need `sentences-block-for-members.js`

There were attempts to fix the regressions caused by dcdab7f but they were all not succesful:
- Both 1df8c35 and 0b25a32 just caused further regressions
- c8cc8aa88fd62dc55d814fae1e16650f2635f966 was incomplete because the copy button in the old design still doesn't work on pages like `audios/index`, i.e. pages that display a minimum version of the sentence block.

In addition there is an undocumented regression on the `My favorites` page where the remove button doesn't work any more.

So all in all I think we still cannot remove jQuery from `layout.js` and I suggest to revert the changes.