### PR TITLE
Blank page when no vocabulary items are found

### DIFF
--- a/src/Template/Vocabulary/add_sentences.ctp
+++ b/src/Template/Vocabulary/add_sentences.ctp
@@ -27,9 +27,14 @@
 ?>
 <?php
 $this->Html->script('/js/vocabulary/add-sentences.ctrl.js', ['block' => 'scriptBottom']);
-
-$title = __('Vocabulary that needs sentences');
-
+if (empty($langFilter)) {
+    $title = __('Vocabulary that needs sentences');
+} else {
+    $title = format(
+        __('Vocabulary that needs sentences in {language}'),
+        array('language' => $this->Languages->codeToNameToFormat($langFilter))
+    );
+}
 $this->set('title_for_layout', $this->Pages->formatTitle($title));
 ?>
 
@@ -55,6 +60,12 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
             )
             ?>
         </div>
+        <?php
+            if ($vocabulary->count() == 0) {
+                $noRequestsMessage = __("There are no requests.");
+                echo "<div class='empty-info-text'> $noRequestsMessage </div>";
+            }
+        ?>
 
         <?php
         $this->Pagination->display();

--- a/webroot/css/vocabulary/add_sentences.css
+++ b/webroot/css/vocabulary/add_sentences.css
@@ -42,3 +42,10 @@ md-input-container .md-errors-spacer {
 .new-sentences {
     margin-bottom: 5px;
 }
+
+.empty-info-text {
+    text-align: center;
+    font-size: 2em;
+    color: #666666;
+    margin: 50px 0 50px 0;
+}


### PR DESCRIPTION
This pull request addresses issue #2273 - when filtering by language, there is no indication why the page is blank when there are no vocabulary items found.