### PR TITLE
Concatenate multiline strings

### DIFF
--- a/src/Template/Element/announcement.ctp
+++ b/src/Template/Element/announcement.ctp
@@ -48,9 +48,9 @@ if (!CurrentUser::hasAcceptedNewTermsOfUse()) {
     ?>
     <p>
     <?= format(
-        __('We have updated our <a href="{termsOfUse}">Terms of Use</a>.
-        By closing this announcement, you agree with the new Terms of Use.
-        If you have any question, feel free to <a href="{contact}">contact us</a>.'),
+        __('We have updated our <a href="{termsOfUse}">Terms of Use</a>. ' .
+           'By closing this announcement, you agree with the new Terms of Use. ' .
+           'If you have any question, feel free to <a href="{contact}">contact us</a>.'),
         ['termsOfUse' => $termsOfUseUrl, 'contact' => $contactUrl]
     ) ?>
     </p>

--- a/src/Template/PrivateMessages/write.ctp
+++ b/src/Template/PrivateMessages/write.ctp
@@ -26,7 +26,10 @@
  */
 
 $this->set('title_for_layout', __('New message') . __(' - Tatoeba'));
-
+$message_limit = __(
+    'To help keep Tatoeba free of spam and other malicious messages ' .
+    'new users can send only 5 messages per day.'
+);
 ?>
 <md-toolbar class="md-hue-2">
     <div class="md-toolbar-tools">
@@ -43,9 +46,7 @@ $this->set('title_for_layout', __('New message') . __(' - Tatoeba'));
             ?>
             <div class="section md-whiteframe-1dp">
             <h2><?= __('You have reached your message limit for today') ?></h2>
-            <p>
-                <?= __("To help keep Tatoeba free of spam and other malicious messages new users can send only 5 messages per day.") ?>
-            </p>
+            <p><?= $message_limit ?></p>
             <p>
                 <?= __("Please wait until you can send more messages.") ?>
             </p>
@@ -60,10 +61,7 @@ $this->set('title_for_layout', __('New message') . __(' - Tatoeba'));
         } else if ($isNewUser) {
             ?>
             <div class="section md-whiteframe-1dp">
-            <p><?= __(
-                "To help keep Tatoeba free of spam and other malicious messages
-                new users can send only 5 messages per day."
-            ); ?></p>
+            <p><?= $message_limit ?></p>
 
             <p><?= format(
                 __n(


### PR DESCRIPTION
Two multiline strings used "implicit" newlines instead of concatenating. As a consequence one of them appeared twice in `default.pot`.

If the intention really was to start a new line we would need to us the `br` tag because the newline character (i.e. `\n`) is ignored by browsers.

@jiru Since this change would require translators to unnecessarily "retranslate" the strings should I just remove the newline characters instead? (Some translators [kept](https://github.com/Tatoeba/tatoeba2/blob/0fe0273fcd5fee6d2be334e7e9708f534f9dd264/src/Locale/fr/default.po#L1222) the newline characters, some [removed](https://github.com/Tatoeba/tatoeba2/blob/0fe0273fcd5fee6d2be334e7e9708f534f9dd264/src/Locale/de/default.po#L1221) them.)