### PR TITLE
Fix HTML in translation files

### DIFF
--- a/src/Locale/br/default.po
+++ b/src/Locale/br/default.po
@@ -2653,7 +2653,7 @@ msgid ""
 "<b>IBAN transfer.</b> This is probably the cheapest way to donate. Tatoeba's"
 " bank is based in France, so if you are from an EU country, it is likely "
 "that the transfer will be free of charge."
-msgstr "<B>Treuzkasadenn IBAN.</ B> Gellout a rafe bezañ \nan doare gwellañ da reiñ arc'hant. Ti-bank Tatoeba a zo e Bro-Frañs setu ma vezit o tont eus ur vro eus an UE, posupl-tre eo e vefe digoust an dreuzkasadenn arc'hant."
+msgstr "<b>Treuzkasadenn IBAN.</b> Gellout a rafe bezañ an doare gwellañ da reiñ arc'hant. Ti-bank Tatoeba a zo e Bro-Frañs setu ma vezit o tont eus ur vro eus an UE, posupl-tre eo e vefe digoust an dreuzkasadenn arc'hant."
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Template/Pages/donate.ctp#L76
 msgid ""

--- a/src/Locale/cs/default.po
+++ b/src/Locale/cs/default.po
@@ -2802,7 +2802,7 @@ msgid ""
 "If you simply want sentences that you can use to learn a language, check out"
 " the <a href=\"{}\">sentence lists</a>. You can build your own, or view the "
 "ones that others have created. The lists can be downloaded and printed."
-msgstr "Pokud chcete jednoduše věty použitelné při výuce jazyka, vyzkoušejte <a href=\"{}\">seznamy vět<a/>. Můžete si sestavovat své vlastní nebo prohlížet ty vytvořené jinými uživateli. Seznamy lze stahovat i&nbsp;tisknout."
+msgstr "Pokud chcete jednoduše věty použitelné při výuce jazyka, vyzkoušejte <a href=\"{}\">seznamy vět</a>. Můžete si sestavovat své vlastní nebo prohlížet ty vytvořené jinými uživateli. Seznamy lze stahovat i&nbsp;tisknout."
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Template/Pages/downloads.ctp#L127
 msgid "General information about the files"
@@ -3062,7 +3062,7 @@ msgstr ""
 msgid ""
 "By creating a new <a href=\"{}\">list</a>, and going to the edit page for "
 "that list."
-msgstr "Vytvořením nového < a href=\"{}\">seznamu</a> a&nbsp;upravováním jeho stránky."
+msgstr "Vytvořením nového <a href=\"{}\">seznamu</a> a&nbsp;upravováním jeho stránky."
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Template/Pages/help.ctp#L170
 msgid ""
@@ -4049,7 +4049,7 @@ msgid ""
 "with much more complete data files. If you're interested in his work, you "
 "can check his project page <a href='{1}'>here</a>. Without him, the "
 "Shanghainese sentences wouldn't have such a complete IPA."
-msgstr "Chceme vzdát veliký dík <a href=\"'{0}'>Kellenu Parkerovi</a>, který nás obdařil mnoha dalšími datovými soubory. Pokud vás zajímá jeho práce, podívejte se na stránku jeho projektu <a href='{1}'>zde</a>. Bez něj by šanghajské věty tak kompletní přepisy do IPA neměly."
+msgstr "Chceme vzdát veliký dík <a href='{0}'>Kellenu Parkerovi</a>, který nás obdařil mnoha dalšími datovými soubory. Pokud vás zajímá jeho práce, podívejte se na stránku jeho projektu <a href='{1}'>zde</a>. Bez něj by šanghajské věty tak kompletní přepisy do IPA neměly."
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Template/Tools/shanghainese_to_ipa.ctp#L90
 msgid "Enter a text in shanghainese dialect"

--- a/src/Locale/el/default.po
+++ b/src/Locale/el/default.po
@@ -3129,13 +3129,13 @@ msgid ""
 "You can create lists of sentences in Tatoeba. By default the list is "
 "<strong>personal</strong>, which means it can only be edited by the person "
 "who created it (but it is still visible to everyone)."
-msgstr "Μπορείτε να δημιουργήσετε λίστες προτάσεων στο Tatoeba. Από προεπιλογή, η λίστα είναι <strong>προσωπική</ strong>, που σημαίνει ότι μπορει να την επεξεργαστει μόνο το πρόσωπο που την δημιούργησε (αλλά εξακολουθεί να είναι ορατή για όλους)."
+msgstr "Μπορείτε να δημιουργήσετε λίστες προτάσεων στο Tatoeba. Από προεπιλογή, η λίστα είναι <strong>προσωπική</strong>, που σημαίνει ότι μπορει να την επεξεργαστει μόνο το πρόσωπο που την δημιούργησε (αλλά εξακολουθεί να είναι ορατή για όλους)."
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Template/Pages/help.ctp#L285
 msgid ""
 "However it is also possible to let any member in Tatoeba add and remove "
 "sentences by setting a list as <strong>collaborative</strong>."
-msgstr "Ωστόσο, είναι επίσης δυνατό να αφήνετε μέλοι στο Tatoeba να  προσθέτουν και να αφαιρούν φράσεις από την λίστα ως \n<strong>συνεργατική</ strong>."
+msgstr "Ωστόσο, είναι επίσης δυνατό να αφήνετε μέλοι στο Tatoeba να  προσθέτουν και να αφαιρούν φράσεις από την λίστα ως <strong>συνεργατική</strong>."
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Template/Pages/index.ctp#L30
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Template/Pages/index_for_guests.ctp#L29

--- a/src/Locale/eo/default.po
+++ b/src/Locale/eo/default.po
@@ -1630,7 +1630,7 @@ msgid ""
 "The content of this message goes against <a href=\"{}\">our rules</a> and "
 "was therefore hidden. It is displayed only to admins and to the author of "
 "the message."
-msgstr "La enhavo de tiu mesaĝo kontraŭas <a href=\"{}\"> niajn regulojn </ a> kaj pro tio estas kaŝita. Ĝi aperas nur al administrantoj kaj la aŭtoro de la mesaĝo."
+msgstr "La enhavo de tiu mesaĝo kontraŭas <a href=\"{}\">niajn regulojn</a> kaj pro tio estas kaŝita. Ĝi aperas nur al administrantoj kaj la aŭtoro de la mesaĝo."
 
 #. cancel button of sentence comment edition form (verb)
 #. / cancel button of sentence text edition form (verb)
@@ -2553,7 +2553,7 @@ msgstr "OD"
 msgid ""
 "Please make sure to <a href=\"{}\">read the FAQ</a> before asking a "
 "question."
-msgstr "Bonvolu nepre <a href=\"{}\">legi la oftajn demandojn<a> antaŭ ol demandi ion."
+msgstr "Bonvolu nepre <a href=\"{}\">legi la oftajn demandojn</a> antaŭ ol demandi ion."
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Template/Pages/contact.ctp#L58
 msgid "Follow us"

--- a/src/Locale/es/default.po
+++ b/src/Locale/es/default.po
@@ -1640,7 +1640,7 @@ msgid ""
 "The content of this message goes against <a href=\"{}\">our rules</a> and "
 "was therefore hidden. It is displayed only to admins and to the author of "
 "the message."
-msgstr "El contenido de este mensaje va en contra de  <a href=\"{}\"> nuestras normas</ a> y por lo tanto se ha ocultado. Se muestra sólo a los administradores y al autor del mensaje."
+msgstr "El contenido de este mensaje va en contra de <a href=\"{}\">nuestras normas</a> y por lo tanto se ha ocultado. Se muestra sólo a los administradores y al autor del mensaje."
 
 #. cancel button of sentence comment edition form (verb)
 #. / cancel button of sentence text edition form (verb)

--- a/src/Locale/fi/default.po
+++ b/src/Locale/fi/default.po
@@ -2587,7 +2587,7 @@ msgid ""
 "We have an <strong>XMPP room</strong>: <a "
 "href=\"{room}\">tatoeba@chat.tatoeba.org</a>.  You can join with your "
 "favorite XMPP client or <a href=\"{webclient}\">from your browser</a>."
-msgstr "Meillä on <strong>XMPP-huone</strong>: <a href=\"{room}\">tatoeba@chat.tatoeba.org</a>. Voit liittyä haluamallasi XMPP-ohjelmalla tai <a href=\"{webclient}\">selaimellasi."
+msgstr "Meillä on <strong>XMPP-huone</strong>: <a href=\"{room}\">tatoeba@chat.tatoeba.org</a>. Voit liittyä haluamallasi XMPP-ohjelmalla tai <a href=\"{webclient}\">selaimellasi</a>."
 
 #. title of the Donate page
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Template/Pages/donate.ctp#L29

--- a/src/Locale/ja/default.po
+++ b/src/Locale/ja/default.po
@@ -2593,7 +2593,7 @@ msgid ""
 "in any other way than the ones mentioned here, you may contact either <a "
 "href=\"{trangEmail}\">Trang</a> or the entire <a "
 "href=\"{teamEmail}\">team</a>."
-msgstr "寄付に関してご不明な点がある方や、左記以外の方法による寄付を希望される方は、管理人の<a\r\nhref=\"{trangEmail}\">Trang</a>もしくは<a\r\nhref=\"{teamEmail}\">開発チーム</a>にお問い合わせください。"
+msgstr "寄付に関してご不明な点がある方や、左記以外の方法による寄付を希望される方は、管理人の<a href=\"{trangEmail}\">Trang</a>もしくは<a href=\"{teamEmail}\">開発チーム</a>にお問い合わせください。"
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Template/Pages/donate.ctp#L52
 msgid "All donations"

--- a/src/Locale/pt/default.po
+++ b/src/Locale/pt/default.po
@@ -2539,7 +2539,7 @@ msgid ""
 "sentences containing these words with their translations in the desired "
 "languages. The name Tatoeba (<em>for example</em> in Japanese) captures this"
 " concept."
-msgstr "O Tatoeba dispõe de uma ferramenta para que você veja exemplos de como as palavras são usadas no contexto de uma frase. Você especifica palavras que lhe interessam e ele retorna sentenças que as contenham com suas traduções nos idiomas desejados. O nome Tatoeba (<em>, por exemplo </ em> em japonês) captura esse conceito."
+msgstr "O Tatoeba dispõe de uma ferramenta para que você veja exemplos de como as palavras são usadas no contexto de uma frase. Você especifica palavras que lhe interessam e ele retorna sentenças que as contenham com suas traduções nos idiomas desejados. O nome Tatoeba (<em>, por exemplo</em> em japonês) captura esse conceito."
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Template/Pages/about.ctp#L64
 msgid ""


### PR DESCRIPTION
Some translation files contained HTML errors (e.g. unclosed tags, interrupting whitespace).

There is still one unclosed `a` tag in the Korean `default.po` but since I don't speak Korean I don't know where to put the closing tag:
https://github.com/Tatoeba/tatoeba2/blob/0fe0273fcd5fee6d2be334e7e9708f534f9dd264/src/Locale/ko/default.po#L631
