### PR TITLE
Add language filter to Reviews page

### DIFF
--- a/src/Controller/ReviewsController.php
+++ b/src/Controller/ReviewsController.php
@@ -111,6 +111,10 @@ class ReviewsController extends AppController
      */
     public function of($username, $correctnessLabel = null, $lang = null)
     {
+        if (empty($correctnessLabel)) {
+            return $this->redirect([$username, 'all'], 301);
+        }
+
         $this->helpers[] = 'Pagination';
 
         $this->loadModel('Users');

--- a/src/Controller/ReviewsController.php
+++ b/src/Controller/ReviewsController.php
@@ -111,8 +111,8 @@ class ReviewsController extends AppController
      */
     public function of($username, $correctnessLabel = null, $lang = null)
     {
-        if (empty($correctnessLabel)) {
-            return $this->redirect([$username, 'all'], 301);
+        if (!in_array($correctnessLabel, ['ok', 'unsure', 'not-ok', 'all', 'outdated'])) {
+            return $this->redirect([$username, 'all', $lang], 301);
         }
 
         $this->helpers[] = 'Pagination';

--- a/src/Template/Element/space.ctp
+++ b/src/Template/Element/space.ctp
@@ -123,7 +123,7 @@ $menuPositionMode = $htmlDir == 'rtl' ? 'target target' : 'target-right target';
                 </a>
             </div>
             <div class="item">
-                <a href="<?= $this->Url->build(['controller' => 'reviews', 'action' => 'of', $username]) ?>">
+                <a href="<?= $this->Url->build(['controller' => 'reviews', 'action' => 'of', $username, 'all']) ?>">
                     <span>
                     <?php
                     /* @ŧranslators: top-right user menu item to list your reviews */

--- a/src/Template/Element/users_menu.ctp
+++ b/src/Template/Element/users_menu.ctp
@@ -61,7 +61,8 @@ $menu = [
         'url' => [
             'controller' => 'reviews',
             'action' => 'of',
-            $username
+            $username,
+            'all',
         ]
     ],
     [

--- a/src/Template/Reviews/of.ctp
+++ b/src/Template/Reviews/of.ctp
@@ -87,6 +87,8 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
         }
         ?>
     </md-list>
+
+    <?php $this->CommonModules->createFilterByLangMod(3); ?>
 </div>
 <?php endif; ?>
 

--- a/src/Template/Reviews/of.ctp
+++ b/src/Template/Reviews/of.ctp
@@ -34,8 +34,19 @@ $categories = array(
     'outdated' => ['keyboard_arrow_right', __("Outdated reviews")]
 );
 
-if (empty($correctnessLabel) || !in_array($correctnessLabel, $categories)) {
-    $category = $categories['all'][1];
+$categoriesWithLang = [
+    'ok' => __('Sentences in {language} marked as "OK"'),
+    'unsure' => __('Sentences in {language} marked as "unsure"'),
+    'not-ok' => __('Sentences in {language} marked as "not OK"'),
+    'all' => __('All sentences in {language}'),
+    'outdated' => __('Outdated reviews for sentences in {language}')
+];
+
+if ($lang) {
+    $category = format(
+        $categoriesWithLang[$correctnessLabel],
+        ['language' => $this->Languages->codeToNameToFormat($lang)]
+    );
 } else {
     $category = $categories[$correctnessLabel][1];
 }

--- a/tests/TestCase/Controller/ReviewsControllerTest.php
+++ b/tests/TestCase/Controller/ReviewsControllerTest.php
@@ -27,6 +27,8 @@ class ReviewsControllerTest extends IntegrationTestCase
             [ '/eng/reviews/of/admin/ok', 'contributor', true ],
             [ '/eng/reviews/of/admin/ok/cmn', null, true ],
             [ '/eng/reviews/of/admin/ok/cmn', 'contributor', true ],
+            [ '/eng/reviews/of/admin/foobar', null, '/eng/reviews/of/admin/all' ],
+            [ '/eng/reviews/of/admin/foobar/eng', null, '/eng/reviews/of/admin/all/eng' ],
         ];
     }
 

--- a/tests/TestCase/Controller/ReviewsControllerTest.php
+++ b/tests/TestCase/Controller/ReviewsControllerTest.php
@@ -19,8 +19,10 @@ class ReviewsControllerTest extends IntegrationTestCase
     public function accessesProvider() {
         return [
             // url; user; is accessible or redirection url
-            [ '/eng/reviews/of/admin', null, true ],
-            [ '/eng/reviews/of/admin', 'contributor', true ],
+            [ '/eng/reviews/of/admin', null, '/eng/reviews/of/admin/all' ],
+            [ '/eng/reviews/of/admin', 'contributor', '/eng/reviews/of/admin/all' ],
+            [ '/eng/reviews/of/admin/all', null, true ],
+            [ '/eng/reviews/of/admin/all', 'contributor', true ],
             [ '/eng/reviews/of/admin/ok', null, true ],
             [ '/eng/reviews/of/admin/ok', 'contributor', true ],
             [ '/eng/reviews/of/admin/ok/cmn', null, true ],


### PR DESCRIPTION
This PR closes #806.

Like on other pages I've added the language filter module.

There was a small complication because `ReviewsController::of()` had two optional parameters (`$correctnessLabel` and `$lang`) and the language filter expects that the language is the last parameter. So `$correctnessLabel` always needs to be set (`reviews/of/user/eng` doesn't work).