### PR TITLE
Store unsubmitted form data in session storage

### DIFF
--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -63,3 +63,8 @@ files[] = sentences.collapse.js
 files[] = clipboard.min.js
 files[] = angular/ngclipboard.min.js
 files[] = directives/sentence-and-translations.dir.js
+
+[wall.js]
+files[] = services/storage.srv.js
+files[] = directives/resumable.dir.js
+files[] = wall/wall.ctrl.js

--- a/src/Controller/WallController.php
+++ b/src/Controller/WallController.php
@@ -31,6 +31,7 @@ use App\Event\NotificationListener;
 use Cake\Event\Event;
 use App\Model\CurrentUser;
 use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\Http\Cookie\Cookie;
 
 /**
  * Controller for the wall.
@@ -142,6 +143,12 @@ class WallController extends AppController
             }
         }
 
+        $submittedCookie = new Cookie(
+            'submitted',
+            'new-message@wall/index',
+        );
+        $this->response = $this->response->withCookie($submittedCookie);
+
         $this->redirect(
             array('action'=>'index')
         );
@@ -198,6 +205,11 @@ class WallController extends AppController
             $savedMessage = $this->Wall->save($message);
             if ($savedMessage) {
                 $this->Flash->set(__('Message saved.'));
+                $submittedCookie = new Cookie(
+                    'submitted',
+                    "edit-message-{$messageId}@wall/edit/{$messageId}",
+                );
+                $this->response = $this->response->withCookie($submittedCookie);
                 $this->redirect([
                     'action' => 'show_message',
                     $messageId,

--- a/src/Template/Element/wall/add_form.ctp
+++ b/src/Template/Element/wall/add_form.ctp
@@ -35,9 +35,11 @@ $avatar = $user['image'];
 
         <?php
         echo $this->Form->textarea('content', [
+            'id' => 'new-message',
             'label'=> '',
             'lang' => '',
             'dir' => 'auto',
+            'resumable' => '',
         ]);
         ?>
 

--- a/src/Template/Element/wall/edit_form.ctp
+++ b/src/Template/Element/wall/edit_form.ctp
@@ -1,4 +1,6 @@
 <?php
+echo $this->Html->script('services/storage.srv.js', ['block' => 'scriptBottom']);
+echo $this->Html->script('directives/resumable.dir.js', ['block' => 'scriptBottom']);
 $user = $message->user;
 $username = $user['username'];
 $avatar = $user['image'];
@@ -37,7 +39,10 @@ $cancelUrl = $this->Url->build([
         <?php
         $message->content = $this->safeForAngular($message->content);
         echo $this->Form->create($message);
-        echo $this->Form->textarea('content');
+        echo $this->Form->textarea('content', [
+            'id' => "edit-message-{$message->id}",
+            'resumable' => '',
+        ]);
         ?>
 
         <div layout="row" layout-align="end center" layout-padding>

--- a/src/Template/Element/wall/edit_form.ctp
+++ b/src/Template/Element/wall/edit_form.ctp
@@ -1,6 +1,4 @@
 <?php
-echo $this->Html->script('services/storage.srv.js', ['block' => 'scriptBottom']);
-echo $this->Html->script('directives/resumable.dir.js', ['block' => 'scriptBottom']);
 $user = $message->user;
 $username = $user['username'];
 $avatar = $user['image'];

--- a/src/Template/Element/wall/reply_form.ctp
+++ b/src/Template/Element/wall/reply_form.ctp
@@ -57,7 +57,8 @@ $editUrl = $this->Url->build([
             'label'=> '',
             'lang' => '',
             'dir' => 'auto',
-            'ng-model' => 'vm.replies['.$parentId.']'
+            'ng-model' => 'vm.replies['.$parentId.']',
+            'resumable' => '',
         ]);
         ?>
 

--- a/src/Template/Wall/edit.ctp
+++ b/src/Template/Wall/edit.ctp
@@ -24,7 +24,7 @@
  * @license  Affero General Public License
  * @link     https://tatoeba.org
  */
-
+$this->AssetCompress->script('wall.js', ['block' => 'scriptBottom']);
 $title = format(__("Edit message {number}"), array('number' => $message->id));
 $this->set('title_for_layout', $this->Pages->formatTitle($title));
 ?>

--- a/src/Template/Wall/index.ctp
+++ b/src/Template/Wall/index.ctp
@@ -38,6 +38,8 @@
 /* @translators: title of the Wall page */
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Wall')));
 
+echo $this->Html->script('services/storage.srv.js', ['block' => 'scriptBottom']);
+echo $this->Html->script('directives/resumable.dir.js', ['block' => 'scriptBottom']);
 echo $this->Html->script('wall/wall.ctrl.js', ['block' => 'scriptBottom']);
 
 ?>

--- a/src/Template/Wall/index.ctp
+++ b/src/Template/Wall/index.ctp
@@ -35,7 +35,7 @@
  * @link     https://tatoeba.org
  */
 
-echo $this->AssetCompress->script('wall.js', ['block' => 'scriptBottom']);
+$this->AssetCompress->script('wall.js', ['block' => 'scriptBottom']);
 /* @translators: title of the Wall page */
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Wall')));
 ?>

--- a/src/Template/Wall/index.ctp
+++ b/src/Template/Wall/index.ctp
@@ -35,13 +35,9 @@
  * @link     https://tatoeba.org
  */
 
+echo $this->AssetCompress->script('wall.js', ['block' => 'scriptBottom']);
 /* @translators: title of the Wall page */
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Wall')));
-
-echo $this->Html->script('services/storage.srv.js', ['block' => 'scriptBottom']);
-echo $this->Html->script('directives/resumable.dir.js', ['block' => 'scriptBottom']);
-echo $this->Html->script('wall/wall.ctrl.js', ['block' => 'scriptBottom']);
-
 ?>
 
 <h2>

--- a/src/Template/Wall/show_message.ctp
+++ b/src/Template/Wall/show_message.ctp
@@ -35,13 +35,10 @@
  * @link     https://tatoeba.org
  */
 
+echo $this->AssetCompress->script('wall.js', ['block' => 'scriptBottom']);
 $this->set('title_for_layout', $this->Pages->formatTitle(
     format(__('Thread #{number}'), array('number' => $message->id))
 ));
-
-echo $this->Html->script('services/storage.srv.js', ['block' => 'scriptBottom']);
-echo $this->Html->script('directives/resumable.dir.js', ['block' => 'scriptBottom']);
-echo $this->Html->script('wall/wall.ctrl.js', ['block' => 'scriptBottom']);
 ?>
 <div id="annexe_content">
     <div class="module">

--- a/src/Template/Wall/show_message.ctp
+++ b/src/Template/Wall/show_message.ctp
@@ -39,6 +39,8 @@ $this->set('title_for_layout', $this->Pages->formatTitle(
     format(__('Thread #{number}'), array('number' => $message->id))
 ));
 
+echo $this->Html->script('services/storage.srv.js', ['block' => 'scriptBottom']);
+echo $this->Html->script('directives/resumable.dir.js', ['block' => 'scriptBottom']);
 echo $this->Html->script('wall/wall.ctrl.js', ['block' => 'scriptBottom']);
 ?>
 <div id="annexe_content">

--- a/src/Template/Wall/show_message.ctp
+++ b/src/Template/Wall/show_message.ctp
@@ -35,7 +35,7 @@
  * @link     https://tatoeba.org
  */
 
-echo $this->AssetCompress->script('wall.js', ['block' => 'scriptBottom']);
+$this->AssetCompress->script('wall.js', ['block' => 'scriptBottom']);
 $this->set('title_for_layout', $this->Pages->formatTitle(
     format(__('Thread #{number}'), array('number' => $message->id))
 ));

--- a/webroot/js/directives/resumable.dir.js
+++ b/webroot/js/directives/resumable.dir.js
@@ -1,0 +1,31 @@
+(function() {
+    'use strict';
+
+    angular
+        .module('app')
+        .directive('resumable', ['storageService', resumable]);
+
+    function resumable(storageService) {
+        return {
+            restrict: 'A',
+            require: '?ngModel',
+            link: link,
+        }
+
+        function link(scope, element, attrs, ngModel) {
+            var key = attrs.id;
+
+            element.on('change', function(event) {
+                storageService.store(key, event.target.value);
+            });
+
+            let storedValue = storageService.get(key);
+            if (storedValue) {
+                element.val(storedValue);
+                if (ngModel) {
+                    ngModel.$setViewValue(storedValue);
+                }
+            }
+        }
+    }
+})();

--- a/webroot/js/services/storage.srv.js
+++ b/webroot/js/services/storage.srv.js
@@ -1,0 +1,106 @@
+(function() {
+    'use strict';
+
+    angular
+        .module('app')
+        .service('storageService', ['$window', '$cookies', storageService]);
+
+    function storageService($window, $cookies) {
+        var storage = null;
+        /* Remove language prefix from URL path */
+        var currentPage = $window.location.pathname.replace(/^\/\w+\//, '');
+
+        init();
+
+        return {
+            store: store,
+            get: get,
+            remove: remove,
+        }
+
+        /**
+         * Initialize the service
+         */
+        function init() {
+            try {
+                storage = $window.sessionStorage;
+                const test = '__tatoeba_storage_test__';
+                storage.setItem(test, test);
+                storage.removeItem(test);
+            } catch(e) {
+                /* sessionStorage not available */
+                storage = null;
+            }
+
+            /**
+             * Remove stored value when form was succesfully submitted.
+             * The controller should set a cookie with key "submitted" and
+             * value "<form-id>@<path> where <form-id> is the "id" attribute
+             * of the form and <path> the URL path without the language prefix
+             * and without the initial "/".
+             */
+            let submitted = $cookies.get('submitted');
+            if (submitted) {
+                let parts = submitted.split('@');
+                let key = parts[0];
+                let pageKey = parts[1];
+                remove(key, pageKey);
+                $cookies.remove('submitted');
+            }
+        }
+
+        /**
+         * Store a value
+         *
+         * key:                Key
+         * value:              Value
+         * pageKey [optional]: Either the path for the page or the current page
+         *                     when not given
+         */
+        function store(key, value, pageKey) {
+            if (storage) {
+                if (pageKey === undefined) { pageKey = currentPage; }
+                let items = JSON.parse(storage.getItem(pageKey)) || Object.create(null);
+                items[key] = value;
+                storage.setItem(pageKey, JSON.stringify(items));
+            }
+        }
+
+        /**
+         * Retrieve a value
+         *
+         * key:                Key
+         * pageKey [optional]: Either the path for the page or the current page
+         *                     when not given
+         */
+        function get(key, pageKey) {
+            if (storage) {
+                if (pageKey === undefined) { pageKey = currentPage; }
+                let items = JSON.parse(storage.getItem(pageKey));
+                return items ? items[key] : '';
+            } else {
+                return '';
+            }
+        }
+
+        /**
+         * Remove a value
+         *
+         * key:                Key
+         * pageKey [optional]: Either the path for the page or the current page
+         *                     when not given
+         */
+        function remove(key, pageKey) {
+            if (storage) {
+                if (pageKey === undefined) { pageKey = currentPage; }
+                let items = JSON.parse(storage.getItem(pageKey));
+                delete items[key];
+                if (Object.entries(items).length > 0) {
+                    storage.setItem(pageKey, JSON.stringify(items));
+                } else {
+                    storage.removeItem(pageKey);
+                }
+            }
+        }
+    }
+})();

--- a/webroot/js/wall/wall.ctrl.js
+++ b/webroot/js/wall/wall.ctrl.js
@@ -4,10 +4,11 @@
     angular
         .module('app')
         .controller('WallController', [
-            '$http', '$location', '$anchorScroll', WallController
+            '$http', '$location', '$anchorScroll', 'storageService',
+            WallController
         ]);
 
-    function WallController($http, $location, $anchorScroll) {
+    function WallController($http, $location, $anchorScroll, storageService) {
         var vm = this;
 
         vm.showForm = showForm;
@@ -55,6 +56,7 @@
                 function(response) {
                     vm.isSaving[id] = false;
                     vm.savedReplies[id] = response.data;
+                    storageService.remove('reply-input-' + id);
                 }
             );
         }


### PR DESCRIPTION
This PR closes #293 and #458.

This approach uses the browser's session storage to save unsubmitted form data.

It adds an AngularJS service (`storageService`) that manages the session storage and an attribute directive (`resumable`; I'm open for a better name) that marks an input control as resumable, i.e. whenever the input control is shown, it is pre-filled with the last known value in the session storage. The session storage is updated after each change to the input control.

When the server succesfuly saved the data, the data is removed from the storage. For AJAX-calls this is done in the success callback. For traditional forms the server should send back a cookie named `submitted` whose value is the key for the session storage. Whenever the `storageService` is initialized, it looks for such a cookie, removes the key from the session storage and removes the cookie.

For a start, I made the Wall "resumable", i.e. the forms for adding a new message, editing a message and adding a response will keep their value.

If this approach is ok, I will make the other forms mentioned in the issues "resumable"