### PR TITLE
Properly separate paramerters by slashes in createFilterByLangMod

### DIFF
--- a/src/View/Helper/CommonModulesHelper.php
+++ b/src/View/Helper/CommonModulesHelper.php
@@ -81,7 +81,7 @@ class CommonModulesHelper extends AppHelper
             }
 
             for ($i = 0; $i < $paramsWithoutLang; $i++) {
-                $path .= $params[$i] .'/';
+                $path .= '/'.$params[$i];
             }
 
             $lang = 'und' ;


### PR DESCRIPTION
While working on #2532, I noticed that the language filter on `sentences/of_user/<user>/<lang>` was actually broken, because when constructing the URL for a new language, the slashes were put after the parameters like so: `sentences/of_user<user>//<lang>`.