### PR TITLE
Fix wrong license for translations

### DIFF
--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -191,7 +191,7 @@ class SentencesTable extends Table
                 $user = $this->Users->get($entity->user_id);
                 if ($user) {
                     $userDefaultLicense = $user->settings['default_license'];
-                    $entity->license = $entity->based_on_id == 0 ?
+                    $entity->license = $entity->based_on_id === 0 ?
                                        $userDefaultLicense :
                                        'CC BY 2.0 FR';
                 }

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -191,7 +191,9 @@ class SentencesTable extends Table
                 $user = $this->Users->get($entity->user_id);
                 if ($user) {
                     $userDefaultLicense = $user->settings['default_license'];
-                    $entity->license = $userDefaultLicense;
+                    $entity->license = $entity->based_on_id == 0 ?
+                                       $userDefaultLicense :
+                                       'CC BY 2.0 FR';
                 }
             }
         }
@@ -929,7 +931,8 @@ class SentencesTable extends Table
             $translationLang,
             $userId,
             $translationCorrectness,
-            $sentenceId
+            $sentenceId,
+            'CC BY 2.0 FR'
         );
 
         // saving links

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -298,14 +298,15 @@ class SentencesTableTest extends TestCase {
 		$this->assertFalse((bool)$result);
 	}
 
-	function testSave_setsDefaultLicenseSettingOnCreation() {
-		$data = $this->Sentence->newEntity([
-			'text' => 'This sentence should get a default licence.',
-			'user_id' => 7,
-		]);
-		$savedSentence = $this->Sentence->save($data);
-		$this->assertEquals('CC0 1.0', $savedSentence->license);
-	}
+    function testSave_setsDefaultLicenseSettingOnCreation() {
+        $data = $this->Sentence->saveNewSentence(
+            "User 7's default license is CC0 1.0",
+            'eng',
+            7
+        );
+        $savedSentence = $this->Sentence->save($data);
+        $this->assertEquals('CC0 1.0', $savedSentence->license);
+    }
 
 	function testSave_doesNotChangeLicenseOnUpdate() {
 		$data = $this->Sentence->newEntity([

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -1392,4 +1392,16 @@ class SentencesTableTest extends TestCase {
         $stored = $this->Sentence->get($sentence->id)->text;
         $this->assertEquals($expected, $stored);
     }
+
+    function testSaveTranslation_licenseIsCCBY() {
+        // 'contributor', default license: CC BY
+        CurrentUser::store($this->Sentence->Users->get(4));
+        $translation = $this->Sentence->saveTranslation(1, 'eng', 'Lorem ipsum', 'lat');
+        $this->assertEquals('CC BY 2.0 FR', $translation->license);
+
+        // 'kazuki', default license: CC0
+        CurrentUser::store($this->Sentence->Users->get(7));
+        $translation = $this->Sentence->saveTranslation(2, 'cmn', 'Lorem ipsum', 'lat');
+        $this->assertEquals('CC BY 2.0 FR', $translation->license);
+    }
 }


### PR DESCRIPTION
This PR closes #2533.

The license for a translation was never explicitly set and so it was set in `SentencesTable::beforeSave` to the user's default license which in the past was always `CC BY`.

But c5191c87e124079dfb3b27fe2989029ba27c3f72 enabled users to change their default license in the settings. So when a user changed their default license to `CC0`, the license of a translation was always incorrectly set to that license.

In addition to setting the license explicitly in `SentencesTable::saveTranslation` I've also added a check in `SentencesTable::beforeSave`.