### PR TITLE
Escape sentence text in tooltip of sentence ID link

### DIFF
--- a/src/View/Helper/ClickableLinksHelper.php
+++ b/src/View/Helper/ClickableLinksHelper.php
@@ -179,7 +179,7 @@ class ClickableLinksHelper extends AppHelper
     {
         $tooltipTag = $this->Html->tag(
             'md-tooltip',
-            $this->_View->safeForAngular($sentenceText),
+            $this->_View->safeForAngular(h($sentenceText)),
             ['ng-cloak']
         );
         $linkText = format(


### PR DESCRIPTION
The sentence text was sanitized for Angular but for HTML.

Example on dev: https://dev.tatoeba.org/eng/sentences/show/7842001

The tooltip only shows `Test` instead of `Test <test>`.