### PR TITLE
Improve sphinx shell

### DIFF
--- a/config/bootstrap_cli.php
+++ b/config/bootstrap_cli.php
@@ -14,6 +14,7 @@
  */
 use Cake\Core\Configure;
 use Cake\Core\Exception\MissingPluginException;
+use Cake\I18n\I18n;
 use Cake\Core\Plugin;
 
 /**
@@ -29,3 +30,7 @@ use Cake\Core\Plugin;
 Configure::write('Log.debug.file', 'cli-debug');
 Configure::write('Log.error.file', 'cli-error');
 Configure::write('Log.queries.file', 'cli-queries');
+
+// Use "en' locale for CLI so that we use the already cached
+// translations from the web UI
+I18n::setLocale('en');

--- a/docs/cron/merge_indexes.sh
+++ b/docs/cron/merge_indexes.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -e
 
-/var/www-prod/bin/cake sphinx_indexes merge >/dev/null 2>&1
+echo "Started at $(date -Iseconds)"
+/usr/bin/time -f "Duration: %E" /var/www-prod/bin/cake sphinx_indexes merge
+echo "Finished at $(date -Iseconds)\n"

--- a/docs/cron/refresh_delta.sh
+++ b/docs/cron/refresh_delta.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -e
 
-/usr/bin/time -p -a -o /tmp/sphinx.delta.update.log /var/www-prod/bin/cake sphinx_indexes update delta >/dev/null 2>&1
+echo "Started at $(date -Iseconds)"
+/usr/bin/time -f "Duration: %E" /var/www-prod/bin/cake sphinx_indexes update delta
+echo "Finished at $(date -Iseconds)\n"

--- a/src/Shell/SphinxIndexesShell.php
+++ b/src/Shell/SphinxIndexesShell.php
@@ -183,11 +183,13 @@ class SphinxIndexesShell extends Shell {
     }
 
     public function main() {
-        if (posix_getuid() !== 0) {
-            $this->_die("You need to run this command as the root user.\n");
-        }
         if (!posix_getpwnam($this->sphinx_user)) {
             $this->_die("No such user: {$this->sphinx_user}\n");
+        }
+
+        exec("sudo -u {$this->sphinx_user} indexer -h", $output, $return);
+        if ($return !== 0) {
+            $this->_die("You need to be able to run 'indexer' as user '{$this->sphinx_user}'.\n");
         }
 
         if (file_exists(LOCK_FILE)) {

--- a/src/Shell/SphinxIndexesShell.php
+++ b/src/Shell/SphinxIndexesShell.php
@@ -136,7 +136,13 @@ class SphinxIndexesShell extends Shell {
                 if (count($this->args)) {
                     $langs = $this->validate_langs($this->args);
                 } else {
-                    $langs = array_keys($this->tatoeba_languages);
+                    $this->loadModel('ReindexFlags');
+                    $langs = $this->ReindexFlags
+                         ->find('all')
+                         ->select('lang')
+                         ->where(['indexed' => 1])
+                         ->distinct('lang')
+                         ->extract('lang');
                 }
                 foreach ($langs as $lang) {
                     $this->merge_index($lang);

--- a/src/Shell/SphinxIndexesShell.php
+++ b/src/Shell/SphinxIndexesShell.php
@@ -21,7 +21,6 @@ namespace App\Shell;
 use App\Lib\LanguagesLib;
 use App\Model\ReindexFlag;
 use Cake\Console\Shell;
-use Cake\Core\Configure;
 
 
 define('LOCK_FILE', sys_get_temp_dir() . DS . basename(__FILE__) . '.lock');
@@ -33,7 +32,6 @@ class SphinxIndexesShell extends Shell {
     private $tatoeba_languages;
 
     private function get_tatoeba_languages() {
-        Configure::write('Config.language', 'eng');
         $this->tatoeba_languages = LanguagesLib::languagesInTatoeba();
     }
 

--- a/src/Shell/SphinxIndexesShell.php
+++ b/src/Shell/SphinxIndexesShell.php
@@ -94,7 +94,7 @@ class SphinxIndexesShell extends Shell {
                 $langs
             ));
             system(
-                "sudo -u {$this->sphinx_user} indexer --sighup-each --rotate $indexes",
+                "sudo -u {$this->sphinx_user} indexer --quiet --sighup-each --rotate $indexes",
                 $return_value
             );
             echo ($return_value == 0) ? "OK.\n" : "Failed.\n";

--- a/src/Shell/SphinxIndexesShell.php
+++ b/src/Shell/SphinxIndexesShell.php
@@ -76,7 +76,7 @@ class SphinxIndexesShell extends Shell {
                 $langs = $this->ReindexFlags
                      ->find('list', ['valueField' => 'lang'])
                      ->select(['lang'])
-                     ->where(['lang is not' => null])
+                     ->where(['indexed' => 0])
                      ->group('lang')
                      ->all()
                      ->toArray();


### PR DESCRIPTION
I've noticed that the delta index update shell always tries to update all languages that were changed since the last merge even if there was no change in the last 15 minutes (i.e. since the delta update before the current one). Last sunday evening (CEST) the script even ran longer than 15 minutes, so that the next scheduled run had no chance to do its work.
Similar, the merging also tried to merge the indexes for every language, even for languages that had no change in the last 24 hours.

While here, I've also changed some more stuff, that I found a little bit annoying:
- The old version changed the user very early and run everything as `manticore`. This caused problems with file permissions in some directories (see also https://github.com/Tatoeba/imouto/issues/71). Running only the `indexer` command as `manticore` (i.e. `sudo -u manticore indexer ...`) on the one hand avoids these problems and on the other hand allows non-root users to execute the shell as long as they have the `sudo` permissions (e.g. in the dev environment, the `vagrant` user can now run the shell commands).
- The output/logs from the cron jobs weren't really useful (just a sequence of timing results in the `/tmp` directory without further information). After the changes get merged I would redirect the output into files in the `/var/log` directory on the servers and put them under logrotation as we do with most of the other log files.
- All our CakePHP CLI utilities run with the default locale `en_US` but in the Web UI we use as default locale `en`. Thus whenever a CLI tool would have to use cached translation files it would create new ones although the cached translations for `en` would have been already there. As a solution I propose to set the locale to `en` for CLI utilities too.