### PR TITLE
Correctly initialize navigation controller (fixes #2557)

### DIFF
--- a/src/Template/Element/sentences/navigation.ctp
+++ b/src/Template/Element/sentences/navigation.ctp
@@ -14,7 +14,7 @@ $sentenceUrl = $this->Url->build([
 ]);
 ?>
 <div ng-app="app" ng-controller="SentencesNavigationController as vm" 
-     ng-init="vm.init(<?= $selectedLanguage ?>, <?= $currentId ?>, <?= $prev ?>, <?= $next ?>)" 
+     ng-init="vm.init('<?= $selectedLanguage ?>', <?= $currentId ?>, <?= $prev ?>, <?= $next ?>)" 
      class="navigation" layout="row" ng-cloak>
 
     <div layout="row" layout-align="space-around center" layout-margin flex>


### PR DESCRIPTION
#2557 was caused by missing quotes in the initializer expression for the navigation controller: instead of calling `vm.init('rus', 248008, 248009)` it would call `vm.init(rus, 248008, 248009)`, which is the same as `vm.init(undefined, 248008, 248009)`, so the sentence language was unset after clicking the random sentence button twice.