### PR TITLE
Rewrite tag deletion

### DIFF
--- a/src/Model/Table/TagsSentencesTable.php
+++ b/src/Model/Table/TagsSentencesTable.php
@@ -85,11 +85,23 @@ class TagsSentencesTable extends Table
             ->toList();
     }
 
-    public function removeTagFromSentence($tagId,$sentenceId) {
-        $this->deleteAll([
-            'tag_id' => $tagId,
-            'sentence_id' => $sentenceId
-        ]);
+    /**
+     * Remove a tag from a sentence
+     *
+     * @param int $tagId       Id of the tag
+     * @param int $sentenceId  Id of the sentence
+     *
+     * @return boolean
+     */
+    public function removeTagFromSentence($tagId, $sentenceId) {
+        $entity = $this->find()
+                       ->where(['tag_id' => $tagId, 'sentence_id' => $sentenceId])
+                       ->first();
+        if ($entity) {
+            return $this->delete($entity);
+        } else {
+            return false;
+        }
     }
 
 

--- a/src/Model/Table/TagsSentencesTable.php
+++ b/src/Model/Table/TagsSentencesTable.php
@@ -94,14 +94,16 @@ class TagsSentencesTable extends Table
      * @return boolean
      */
     public function removeTagFromSentence($tagId, $sentenceId) {
-        $entity = $this->find()
-                       ->where(['tag_id' => $tagId, 'sentence_id' => $sentenceId])
-                       ->first();
-        if ($entity) {
+        // Due to a bug in Horus there may be more than one tagId-sentenceId pair
+        $entities = $this->find()
+                         ->where([
+                             'tag_id' => $tagId,
+                             'sentence_id' => $sentenceId
+                         ])
+                         ->all();
+        return $entities->every(function($entity) {
             return $this->delete($entity);
-        } else {
-            return false;
-        }
+        });
     }
 
 

--- a/tests/TestCase/Model/Table/TagsSentencesTableTest.php
+++ b/tests/TestCase/Model/Table/TagsSentencesTableTest.php
@@ -52,4 +52,19 @@ class TagsSentencesTableTest extends TestCase {
 
         I18n::setLocale($prevLocale);
     }
+
+    function testRemoveTagFromSentence_succeeds() {
+        $entity = $this->TagsSentences->get(1);
+        $rv = $this->TagsSentences->removeTagFromSentence(
+            $entity->tag_id,
+            $entity->sentence_id
+        );
+        $this->assertTrue($rv);
+        $this->assertNull($this->TagsSentences->findById(1)->first());
+    }
+
+    function testRemoveTagFromSentence_fails() {
+        $rv = $this->TagsSentences->removeTagFromSentence(9999, 9999);
+        $this->assertFalse($rv);
+    }
 }

--- a/tests/TestCase/Model/Table/TagsSentencesTableTest.php
+++ b/tests/TestCase/Model/Table/TagsSentencesTableTest.php
@@ -63,8 +63,16 @@ class TagsSentencesTableTest extends TestCase {
         $this->assertNull($this->TagsSentences->findById(1)->first());
     }
 
-    function testRemoveTagFromSentence_fails() {
-        $rv = $this->TagsSentences->removeTagFromSentence(9999, 9999);
-        $this->assertFalse($rv);
+    function testRemoveTagFromSentence_worksWithDuplicates() {
+        $this->TagsSentences->getConnection()->insert('tags_sentences',
+            [
+                'tag_id' => 1,
+                'user_id' => 4,
+                'sentence_id' => 8,
+                'added_time' => '2018-04-05 22:20:12',
+            ]);
+        $rv = $this->TagsSentences->removeTagFromSentence(1, 8);
+        $this->assertTrue($rv);
+        $this->assertFalse($this->TagsSentences->exists(['tag_id' => 1, 'sentence_id' => 8]));
     }
 }


### PR DESCRIPTION
This PR closes #2563.

The problem was that the table method for removing a tag used `deleteAll()` which doesn't trigger the `afterDelete` event. But we use this event to update the attributes of the search index.