### PR TITLE
Fix language count on "Browse by language" page

### DIFF
--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -115,7 +115,8 @@ class SentencesController extends AppController
         $this->loadModel('Languages');
         $milestones = [ 100000, 10000, 1000, 100, 10, 1, 0 ];
         $stats = $this->Languages->getMilestonedStatistics($milestones);
-        $this->set('stats', $stats);
+        $nbrLanguages = count(LanguagesLib::languagesInTatoeba());
+        $this->set(compact('stats', 'nbrLanguages'));
     }
 
     /**

--- a/src/Template/Sentences/index.ctp
+++ b/src/Template/Sentences/index.ctp
@@ -5,14 +5,13 @@ use App\Model\CurrentUser;
 $this->Html->script('/js/sentences/index.ctrl.js', ['block' => 'scriptBottom']);
 $title = __('Language index');
 $this->set('title_for_layout', $this->Pages->formatTitle($title));
-$n = count($stats, COUNT_RECURSIVE);
 $header = format(
   __n(
        'There is {n} language on Tatoeba',
        'There are {n} languages on Tatoeba',
-       $n
+       $nbrLanguages
   ),
-  compact('n')
+  ['n' => $nbrLanguages]
 );
 $top10 = $this->ShowAll->extractTopTen($stats);
 $profileLangs = $this->ShowAll->extractLanguageProfiles($stats);


### PR DESCRIPTION
The language count on the "Browse by language" page was too high because it used the recursive mode of `count()` which also includes the elements on a higher level if the array is a multidimensional array, i.e.
`count([[1, 2], [3, 4]], COUNT_RECURSIVE)` will return 6 and not 4.