### PR TITLE
Fix warnings in debug log

### DIFF
--- a/src/Controller/Component/PermissionsComponent.php
+++ b/src/Controller/Component/PermissionsComponent.php
@@ -146,7 +146,7 @@ class PermissionsComponent extends Component
             }
 
             $commentPermissions = $this->getCommentOptions(
-                $comment['user_id']
+                $comment->user->id ?? null
             );
             array_push($commentsPermissions, $commentPermissions);
         }
@@ -248,7 +248,7 @@ class PermissionsComponent extends Component
             $lastInThread = empty($message->children);
             $messages[$i]['Permissions'] = $this->getWallMessageOptions(
                 $lastInThread,
-                $message->owner,
+                $message->user->id ?? null,
                 $currentUserId
             );
 

--- a/src/Controller/Component/PermissionsComponent.php
+++ b/src/Controller/Component/PermissionsComponent.php
@@ -154,8 +154,7 @@ class PermissionsComponent extends Component
     }
 
     /**
-     * Check which options user can access to and returns
-     * data that is needed for the comments menu.
+     * Get comment permissions for the current user
      *
      * @param int   $ownerId          Id of the comment owner.
      *
@@ -184,7 +183,7 @@ class PermissionsComponent extends Component
             $rightsOnComment['canEdit'] = true;
         }
 
-        if (CurrentUser::get('id') != $ownerId) {
+        if ($ownerId && CurrentUser::get('id') != $ownerId) {
             $rightsOnComment['canPM'] = true;
         }
 

--- a/src/Template/Element/sentence_comments/comment.ctp
+++ b/src/Template/Element/sentence_comments/comment.ctp
@@ -117,7 +117,7 @@ if ($sentenceOwnerLink) {
                 <a href="<?= $userProfileUrl ?>"><?= $username ?></a>
             </span>
         <?php else: ?>
-            <i><?= __('Former member') ?></i>
+            <i><?= h(__('Former member')) ?></i>
         <?php endif; ?>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>

--- a/src/Template/Element/sentence_comments/comment.ctp
+++ b/src/Template/Element/sentence_comments/comment.ctp
@@ -2,8 +2,15 @@
 use App\Lib\LanguagesLib;
 use App\Model\CurrentUser;
 
-$username = $comment->user->username;
-$avatar = $comment->user->image;
+$username = $comment->user->username ?? null;
+if ($username) {
+    $userProfileUrl = $this->Url->build(array(
+        'controller' => 'user',
+        'action' => 'profile',
+        $username
+    ));
+}
+$avatar = $comment->user->image ?? null;
 $createdDate = $comment->created;
 $modifiedDate = $comment->modified;
 $commentId = $comment->id;
@@ -60,11 +67,6 @@ $labelText = __x('sentence comment', '{createdDate}, edited {modifiedDate}');
 $dateLabel = $this->Date->getDateLabel($labelText, $createdDate, $modifiedDate);
 $dateTooltip = $this->Date->getDateLabel($labelText, $createdDate, $modifiedDate, true);
 $canViewContent = CurrentUser::isAdmin() || CurrentUser::get('id') == $authorId;
-$userProfileUrl = $this->Url->build(array(
-    'controller' => 'user',
-    'action' => 'profile',
-    $username
-));
 if ($sentenceOwnerLink) {
     $sentenceInfoLabel = __('Sentence {number} — belongs to {username}');
 } else {
@@ -110,9 +112,13 @@ if ($sentenceOwnerLink) {
             <?= $this->Members->image($username, $avatar, array('class' => 'md-user-avatar')); ?>
         </md-card-avatar>
         <md-card-header-text>
+        <?php if ($username): ?>
             <span class="md-title">
                 <a href="<?= $userProfileUrl ?>"><?= $username ?></a>
             </span>
+        <?php else: ?>
+            <i><?= __('Former member') ?></i>
+        <?php endif; ?>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>
                 <md-tooltip ng-cloak><?= $dateTooltip ?></md-tooltip>

--- a/src/Template/Element/wall/message.ctp
+++ b/src/Template/Element/wall/message.ctp
@@ -2,8 +2,8 @@
 use App\Lib\LanguagesLib;
 use App\Model\CurrentUser;
 
-$username = isset($message->user) ? $message->user->username : CurrentUser::get('username');
-$avatar = isset($message->user) ? $message->user->image : CurrentUser::get('image');
+$username = $message->user->username ?? null;
+$avatar = $message->user->image ?? null;
 $createdDate = $message->date;
 $modifiedDate = $message->modified;
 $messageId = $message->id;
@@ -23,11 +23,13 @@ $labelText = __x('wall message', '{createdDate}, edited {modifiedDate}');
 $dateLabel = $this->Date->getDateLabel($labelText, $createdDate, $modifiedDate);
 $dateTooltip = $this->Date->getDateLabel($labelText, $createdDate, $modifiedDate, true);
 $canViewContent = CurrentUser::isAdmin() || CurrentUser::get('id') == $authorId;
-$userProfileUrl = $this->Url->build(array(
-    'controller' => 'user',
-    'action' => 'profile',
-    $username
-));
+if ($username) {
+    $userProfileUrl = $this->Url->build(array(
+        'controller' => 'user',
+        'action' => 'profile',
+        $username
+    ));
+}
 
 if (isset($message['Permissions'])) {
     $menu = $this->Wall->getMenuFromPermissions(
@@ -60,9 +62,13 @@ $canReply = false;
             <?= $this->Members->image($username, $avatar, array('class' => 'md-user-avatar')); ?>
         </md-card-avatar>
         <md-card-header-text>
+        <?php if ($username): ?>
             <span class="md-title">
                 <a href="<?= $userProfileUrl ?>"><?= $username ?></a>
             </span>
+        <?php else: ?>
+            <i><?= __('Former member') ?></i>
+        <?php endif; ?>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>
                 <md-tooltip ng-cloak><?= $dateTooltip ?></md-tooltip>

--- a/src/Template/Element/wall/message.ctp
+++ b/src/Template/Element/wall/message.ctp
@@ -67,7 +67,7 @@ $canReply = false;
                 <a href="<?= $userProfileUrl ?>"><?= $username ?></a>
             </span>
         <?php else: ?>
-            <i><?= __('Former member') ?></i>
+            <i><?= h(__('Former member')) ?></i>
         <?php endif; ?>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>

--- a/src/View/Helper/CommentsHelper.php
+++ b/src/View/Helper/CommentsHelper.php
@@ -73,7 +73,7 @@ class CommentsHelper extends AppHelper
         $commentId = $comment['id'];
 
         //send message
-        if ($permissions['canPM']) {
+        if ($permissions['canPM'] && isset($comment->user->username)) {
             $menu[] = array(
                 'text' => __('Send message'),
                 'icon' => 'mail',

--- a/src/View/Helper/CommentsHelper.php
+++ b/src/View/Helper/CommentsHelper.php
@@ -73,7 +73,7 @@ class CommentsHelper extends AppHelper
         $commentId = $comment['id'];
 
         //send message
-        if ($permissions['canPM'] && isset($comment->user->username)) {
+        if ($permissions['canPM']) {
             $menu[] = array(
                 'text' => __('Send message'),
                 'icon' => 'mail',

--- a/tests/TestCase/Controller/Component/PermissionsComponentTest.php
+++ b/tests/TestCase/Controller/Component/PermissionsComponentTest.php
@@ -1,0 +1,102 @@
+<?php
+namespace App\Test\TestCase\Controller\Component;
+
+use App\Controller\Component\PermissionsComponent;
+use App\Model\CurrentUser;
+use Cake\Controller\Controller;
+use Cake\Controller\ComponentRegistry;
+use Cake\Http\ServerRequest;
+use Cake\Http\Response;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class PermissionsComponentTest extends TestCase
+{
+    public $fixtures = [
+        'app.users',
+        'app.users_languages',
+        'app.walls',
+    ];
+    private $component;
+    private $controller;
+    private $Users;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $request = new ServerRequest();
+        $response = new Response();
+        $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setConstructorArgs([$request, $response])
+            ->setMethods(null)
+            ->getMock();
+        $registry = new ComponentRegistry($this->controller);
+        $this->component = new PermissionsComponent($registry);
+        $this->Users = TableRegistry::getTableLocator()->get('Users');
+    }
+
+    public function tearDown()
+    {
+        unset($this->component, $this->controller);
+        parent::tearDown();
+    }
+
+    public function WallMessageOptionsProvider() {
+        // lastInThread, owner, currentUser, expected
+        return [
+            [false, null, null,
+             ['canReply' => false, 'canDelete' => false, 'canEdit' => false, 'canPM' => false]
+            ],
+            [true, null, null,
+             ['canReply' => false, 'canDelete' => false, 'canEdit' => false, 'canPM' => false]
+            ],
+            [true, 1, null,
+             ['canReply' => false, 'canDelete' => false, 'canEdit' => false, 'canPM' => false]
+            ],
+            [false, 3, 3,
+             ['canReply' => true, 'canDelete' => false, 'canEdit' => true, 'canPM' => false]
+            ],
+            [true, 3, 3,
+             ['canReply' => true, 'canDelete' => true, 'canEdit' => true, 'canPM' => false]
+            ],
+            [false, 3, 1,
+             ['canReply' => true, 'canDelete' => false, 'canEdit' => true, 'canPM' => true]
+            ],
+            [true, 3, 1,
+             ['canReply' => true, 'canDelete' => true, 'canEdit' => true, 'canPM' => true]
+            ],
+            [false, 3, 2,
+             ['canReply' => true, 'canDelete' => false, 'canEdit' => false, 'canPM' => true]
+            ],
+            [true, 3, 2,
+             ['canReply' => true, 'canDelete' => false, 'canEdit' => false, 'canPM' => true]
+            ],
+            [true, null, 2,
+             ['canReply' => true, 'canDelete' => false, 'canEdit' => false, 'canPM' => false]
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider WallMessageOptionsProvider
+     */
+    public function testGetWallMessageOptions($lastInThread, $owner, $currentUser, $expected) {
+        if ($currentUser) {
+            CurrentUser::store($this->Users->get($currentUser)->toArray());
+        }
+        $result = $this->component->getWallMessageOptions($lastInThread, $owner, $currentUser);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetWallMessagesOptions() {
+        CurrentUser::store($this->Users->get(7)->toArray());
+        $wallThread = TableRegistry::getTableLocator()
+            ->get('Wall')
+            ->getWholeThreadContaining(1);
+        $wallThread = $this->component->getWallMessagesOptions($wallThread, 7);
+        $this->assertTrue($wallThread[0]['Permissions']['canEdit']);
+        $this->assertFalse($wallThread[0]['Permissions']['canDelete']);
+        $this->assertFalse($wallThread[0]['children'][0]['Permissions']['canEdit']);
+        $this->assertTrue($wallThread[0]['children'][0]['Permissions']['canPM']);
+    }
+}


### PR DESCRIPTION
This PR fixes some `Trying to get property '...' of non-object` warnings in the debug log due to sentence comment or wall message authors who do not exist any more in the database.

For comments, the non-existing username wasn't displayed at all, e.g. https://tatoeba.org/eng/sentences/show/1998393#comment-213608:
![comment](https://user-images.githubusercontent.com/6566321/94443536-92429200-01a5-11eb-9bf7-4e4abf27fe83.png)

For wall messages, the current username is displayed for the non-existing user, e.g. https://tatoeba.org/eng/wall/show_message/8319#message_8319:
![wall](https://user-images.githubusercontent.com/6566321/94443886-00875480-01a6-11eb-80c5-c05e960ac1ed.png)

In both cases the icon for sending a PM was also displayed.

My proposed solution is to remove the PM icon and to display `Former member` for the username but I'm open for other suggestions:
![new](https://user-images.githubusercontent.com/6566321/94444481-a6d35a00-01a6-11eb-979f-a79183c4807b.png)

