### PR TITLE
Make sidenav scrollable again on mobile

### DIFF
--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -119,8 +119,10 @@ html, body {
     min-width: 100%;
 }
 
-body {
-    height: auto;
+@media only screen and (min-width: 960px) {
+    body {
+        height: auto;
+    }
 }
 
 textarea {


### PR DESCRIPTION
This pull request solves #2567.

The issue happens because the `body` has the CSS rule `height: auto`. This rule was introduced because opening the autocomplete dropdown would remove the vertical scrollbar and therefore displace the content of the page. Having `height: auto` prevents the scrollbar from disappearing when using the autocomplete suggestions but has the side effect of expanding the height of the sidenavs, making them no longer scrollable.

The fix in this PR is to set `height: auto` on the body only when the screen width is 960px or more, which is the breakpoint for desktop mode. The scrollbar disappearing is not an issue on mobile so not having `height: auto` for smaller screens should be okay.