### PR TITLE
Some final adjustments for the Kurdish languages

### DIFF
--- a/src/Lib/LanguagesLib.php
+++ b/src/Lib/LanguagesLib.php
@@ -617,7 +617,7 @@ class LanguagesLib
                 'nus' => __d('languages', 'Nuer'),
                 'ckb' => __d('languages', 'Central Kurdish (Soranî)'),
                 'kmr' => __d('languages', 'Northern Kurdish (Kurmancî)'),
-                'sdh' => __d('languages', 'Southern Kurdish (Xwarîn)'),
+                'sdh' => __d('languages', 'Xwarîn'),
             );
         }
         return $languages;

--- a/src/Lib/LanguagesLib.php
+++ b/src/Lib/LanguagesLib.php
@@ -689,6 +689,8 @@ class LanguagesLib
             "hbo",
             "ajp",
             "ayl",
+            "sdh",
+            "ckb"
         );
 
         $autoLangs = array(

--- a/src/Lib/LanguagesLib.php
+++ b/src/Lib/LanguagesLib.php
@@ -617,7 +617,7 @@ class LanguagesLib
                 'nus' => __d('languages', 'Nuer'),
                 'ckb' => __d('languages', 'Central Kurdish (Soranî)'),
                 'kmr' => __d('languages', 'Northern Kurdish (Kurmancî)'),
-                'sdh' => __d('languages', 'Xwarîn'),
+                'sdh' => __d('languages', 'Southern Kurdish'),
             );
         }
         return $languages;


### PR DESCRIPTION
This PR solves part of #2570 

- The qualifier has been removed from Southern Kurdish.
- Corrected the writing direction of Central and Southern Kurdish