### PR TITLE
Add 'edit_languages' command

### DIFF
--- a/src/Command/EditLanguagesCommand.php
+++ b/src/Command/EditLanguagesCommand.php
@@ -1,0 +1,98 @@
+<?php
+namespace App\Command;
+
+use App\Lib\LanguagesLib;
+use App\Model\CurrentUser;
+use Cake\Collection\Collection;
+use Cake\Console\Arguments;
+use Cake\Console\Command;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+
+class EditLanguagesCommand extends Command
+{
+    protected $log;
+
+    public function initialize() {
+        parent::initialize();
+        $this->loadModel('Sentences');
+        $this->loadModel('Users');
+    }
+
+    protected function buildOptionParser(ConsoleOptionParser $parser) {
+        $parser
+            ->setDescription('Change sentence languages.')
+            ->addArgument('username', [
+                'help' => 'Do all the work as given user who needs to be either ' .
+                          'corpus maintainer or admin.',
+                'required' => true,
+            ])
+            ->addArgument('language', [
+                'help' => 'ISO code of the new language.',
+                'required' => true,
+            ])
+            ->addArgument('file', [
+                'help' => 'Name of the file that contains the sentence ids whose ' .
+                          'language should be changed. ("stdin" will read from ' .
+                          'standard input.)',
+                'required' => true,
+            ]);
+        return $parser;
+    }
+
+    protected function editLanguage($ids, $lang) {
+        foreach ($ids as $id) {
+            $result = $this->Sentences->editSentence(compact('id', 'lang'));
+            if ($result) {
+                $this->log[] = "id $id - Language set to {$result->lang}";
+            } else {
+                $this->log[] = "id $id - Record not found or could not save changes";
+            }
+        }
+    }
+
+    public function execute(Arguments $args, ConsoleIo $io) {
+        $username = $args->getArgument('username');
+        $userId = $this->Users->getIdFromUsername($username);
+        if (!$userId) {
+            $io->error("User '$username' does not exist!");
+            $this->abort();
+        } else {
+            CurrentUser::store($this->Users->get($userId));
+            if (!CurrentUser::isModerator()) {
+                $io->error('User must be corpus maintainer or admin!');
+                $this->abort();
+            }
+        }
+
+        $input = $args->getArgument('file');
+        if ($input === 'stdin') {
+            $input = 'php://stdin';
+        } elseif ($input && !file_exists($input)) {
+            $io->error("File '$input' does not exist!");
+            $this->abort();
+        }
+
+        $newLanguage = $args->getArgument('language');
+        if (!LanguagesLib::languageExists($newLanguage)) {
+            $io->error("Language '$newLanguage' does not exist!");
+            $this->abort();
+        }
+
+        $this->log = [];
+        $ids = collection(file($input, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES))
+               ->filter(function ($v) { return preg_match('/^\d+$/', $v); });
+        $total = $ids->count();
+
+        $this->editLanguage($ids, $newLanguage);
+
+        if (empty($this->log)) {
+            $io->out('There was nothing to do.');
+        } else {
+            $io->out("$total rows proceeded:");
+            foreach ($this->log as $logEntry) {
+                $io->out($logEntry);
+            }
+        }
+    }
+}

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -1201,7 +1201,8 @@ class SentencesTable extends Table
      * Edit the sentence.
      *
      * @param array $data We're taking the data from the AJAX request. It should contain
-     *                    the keys 'id', 'text', 'lang'.
+     *                    the key 'id' for the sentence ID and either 'text' or
+     *                    'lang' or both.
      *
      * @return Entity|false
      */
@@ -1222,17 +1223,15 @@ class SentencesTable extends Table
             return $sentence;
         }
 
-        $this->patchEntity($sentence, [
-            'text' => $data['text'] ?? null,
-            'lang' => $data['lang'] ?? null,
-        ]);
-
-        $sentenceSaved = $this->save($sentence);
-        if ($sentenceSaved) {
-            $this->UsersSentences->makeDirty($id);
+        $this->patchEntity($sentence, $data, ['fields' => ['text', 'lang']]);
+        if ($sentence->isDirty()) {
+            $sentenceSaved = $this->save($sentence);
+            if ($sentenceSaved) {
+                $this->UsersSentences->makeDirty($id);
+            }
+            return $sentenceSaved;
         }
-
-        return $sentenceSaved;
+        return $sentence;
     }
 
     /**

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -1200,26 +1200,18 @@ class SentencesTable extends Table
     /**
      * Edit the sentence.
      *
-     * @param array $data We're taking the data from the AJAX request. It has an
-     *                    'id' and a 'value', but the 'id' actually contains the
-     *                    language followed by the id, separated by an underscore.
+     * @param array $data We're taking the data from the AJAX request. It should contain
+     *                    the keys 'id', 'text', 'lang'.
      *
-     * @return array
+     * @return Entity|false
      */
     public function editSentence($data)
     {
-        $text = $this->_getEditFormText($data);
-        $idLangArray = $this->_getEditFormIdLang($data);
-        if (!$text || !$idLangArray) {
-            return array();
-        }
-
-        // Set $id and $lang
-        extract($idLangArray);
+        $id = (int)$data['id'] ?? null;
         try {
             $sentence = $this->get($id);
         } catch (RecordNotFoundException $e) {
-            return array();
+            return false;
         }
 
         if ($this->_cantEditSentence($sentence)) {
@@ -1231,8 +1223,8 @@ class SentencesTable extends Table
         }
 
         $this->patchEntity($sentence, [
-            'text' => $text,
-            'lang' => $lang
+            'text' => $data['text'] ?? null,
+            'lang' => $data['lang'] ?? null,
         ]);
 
         $sentenceSaved = $this->save($sentence);
@@ -1241,47 +1233,6 @@ class SentencesTable extends Table
         }
 
         return $sentenceSaved;
-    }
-
-    /**
-     * Get text from edit form params.
-     *
-     * @param  array $params Form parameters.
-     *
-     * @return string|boolean
-     */
-    private function _getEditFormText($params)
-    {
-        if (isset($params['value'])) {
-            return trim($params['value']);
-        }
-
-        return false;
-    }
-
-    /**
-     * Get id and lang from edit form params.
-     *
-     * @param  array $params Form parameters.
-     *
-     * @return array|boolean
-     */
-    private function _getEditFormIdLang($params)
-    {
-        if (isset($params['id'])) {
-            // ['form']['id'] contains both the sentence id and its language.
-            // Do not sanitize it directly.
-            $sentenceId = $params['id'];
-
-            $dirtyArray = explode("_", $sentenceId);
-
-            return [
-                'id' => (int)$dirtyArray[1],
-                'lang' => $dirtyArray[0]
-            ];
-        }
-
-        return false;
     }
 
     /**

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -689,14 +689,10 @@ class SentencesHelper extends AppHelper
         if ($isEditable) {
             $classes[] = 'editableSentence';
             
-            // TODO: HACK SPOTTED id is used in edit_in_place
-            // NOTE: I didn't find an easy way to pass the sentenceId to jEditable
-            // using jQuery.data...
             echo $this->Languages->tagWithLang(
                 'div', $sentenceLang, $sentenceText,
                 array(
                     'class' => join(' ', $classes),
-                    'id' => $sentenceLang.'_'.$sentenceId,
                     /* @translators: submit button of sentence edition form */
                     'data-submit' => __('OK'),
                     /* @translators: cancel button of sentence edition form (verb) */

--- a/tests/TestCase/Command/EditLanguagesCommandTest.php
+++ b/tests/TestCase/Command/EditLanguagesCommandTest.php
@@ -1,0 +1,121 @@
+<?php
+namespace App\Test\TestCase\Command;
+
+use Cake\Console\Command;
+use Cake\Filesystem\File;
+use Cake\Filesystem\Folder;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+class EditLanguagesCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    public $fixtures = [
+        'app.audios',
+        'app.contributions',
+        'app.languages',
+        'app.links',
+        'app.reindex_flags',
+        'app.sentences',
+        'app.tags',
+        'app.tags_sentences',
+        'app.transcriptions',
+        'app.users',
+        'app.users_languages',
+        'app.users_sentences',
+    ];
+
+    const TESTDIR = TMP . 'edit_languages_tests' . DS;
+
+    public static function setUpBeforeClass() {
+        new Folder(self::TESTDIR, true, 0755);
+    }
+
+    public static function tearDownAfterClass() {
+        $folder = new Folder(self::TESTDIR);
+        $folder->delete();
+    }
+
+    public function setUp() {
+        parent::setUp();
+        $this->UseCommandRunner();
+        $this->Sentences = TableRegistry::getTableLocator()->get('Sentences');
+    }
+
+    private function create_test_file($ids) {
+        $path = self::TESTDIR . 'input_test';
+        $file = new File($path);
+        $file->write(implode("\n", $ids));
+        $file->close();
+        return $path;
+    }
+
+    public function testExecute_changesLanguage() {
+        $path = $this->create_test_file([1, 2]);
+        $this->exec("edit_languages admin fra $path");
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+
+        $sentence = $this->Sentences->get(2);
+        $this->assertEquals('fra', $sentence->lang);
+        $this->assertEquals("259east\0\0\0\0\0\0\0\0\0", $sentence->hash);
+    }
+
+    public function successesProvider() {
+        // username, language, ids, number of changes
+        return [
+            'all ids changed to fra' =>
+                ['admin', 'fra', [1, 2, 5], 3],
+            'some ids changed to fra' =>
+                ['admin', 'fra', [1, 3, 5, 8], 2],
+            'with wrong ids' =>
+                ['admin', 'fra', [1, 99, 999], 1],
+            'empty file' => ['admin', 'fra', [], 0],
+        ];
+    }
+
+    private function countLanguage($ids, $lang) {
+        if (empty($ids)) {
+            return 0;
+        } else {
+            return $this->Sentences
+                        ->find()
+                        ->where(['id IN' => $ids, 'lang' => $lang])
+                        ->count();
+        }
+    }
+
+    /**
+     * @dataProvider successesProvider
+     **/
+    public function testExecute_severalScenarios($user, $newLanguage, $ids, $changes) {
+        $path = $this->create_test_file($ids);
+        $before = $this->countLanguage($ids, $newLanguage);
+        $this->exec("edit_languages $user $newLanguage $path");
+        $after = $this->countLanguage($ids, $newLanguage);
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertEquals($changes, $after - $before);
+    }
+
+    public function failuresProvider() {
+        return [
+            'without any required argument' => ['edit_languages'],
+            'without language' => ['edit_languages admin'],
+            'without file' => ['edit_languages admin eng'],
+            'with unknown file' => ['edit_languages admin eng unknown_file'],
+            'with invalid language' => ['edit_languages admin invalid stdin'],
+            'as unknown user' => ['edit_languages unknown_user eng stdin'],
+            'as non-moderator' => ['edit_languages contributor eng stdin'],
+        ];
+    }
+
+    /**
+     * @dataProvider failuresProvider
+     */
+    public function testExecute_failures($command) {
+        $this->exec($command);
+        $this->assertExitCode(Command::CODE_ERROR);
+    }
+}

--- a/tests/TestCase/Controller/SentencesControllerTest.php
+++ b/tests/TestCase/Controller/SentencesControllerTest.php
@@ -265,7 +265,7 @@ class SentencesControllerTest extends IntegrationTestCase {
     public function testEditSentence_doesntWorkForUnknownSentence() {
         $this->logInAs('contributor');
         $this->ajaxPost('/jpn/sentences/edit_sentence', [
-            'id' => 'epo_999999', 'value' => 'Forlasu!',
+            'id' => '999999', 'lang' => 'epo', 'text' => 'Forlasu!',
         ]);
         $this->assertRedirect('/jpn/home');
     }

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -405,8 +405,9 @@ class SentencesTableTest extends TestCase {
 		$cmnSentenceId = 2;
 		$newLang = 'por';
 		$requestData = [
-			'id' => "${newLang}_$cmnSentenceId",
-			'value' => $this->Sentence->get($cmnSentenceId)->text
+			'id' => $cmnSentenceId,
+			'lang' => $newLang,
+			'text' => $this->Sentence->get($cmnSentenceId)->text
 		];
 
 		$this->Sentence->editSentence($requestData);
@@ -902,18 +903,13 @@ class SentencesTableTest extends TestCase {
 	function editSentenceWithSuccess() {
 		$before = $this->Sentence->get(53);
 		$data = array(
-			'id' => 'eng_53',
-			'value' => 'Edited sentence.'
-		);
-		$sentence = $this->Sentence->editSentence($data);
-
-		$expected = array(
-			'id' => 53,
+			'id' => '53',
 			'lang' => 'eng',
 			'text' => 'Edited sentence.'
 		);
-		$result = array_intersect_key($sentence->toArray(), $expected);
-		$this->assertEquals($expected, $result);
+		$sentence = $this->Sentence->editSentence($data);
+
+		$this->assertArraySubset($data, $sentence->toArray());
 
 		$after = $this->Sentence->get(53);
 		$this->assertNotEquals($before->text, $after->text);
@@ -925,19 +921,13 @@ class SentencesTableTest extends TestCase {
 		CurrentUser::store($user);
 
 		$data = array(
-			'id' => '_53',
-			'value' => 'Sentence with unknown lang.'
+			'id' => '53',
+			'lang' => '',
+			'text' => 'Sentence with unknown lang.'
 		);
 		$sentence = $this->Sentence->editSentence($data);
 
-		$expected = array(
-			'id' => 53,
-			'lang' => null,
-			'text' => 'Sentence with unknown lang.'
-		);
-		$result = array_intersect_key($sentence->toArray(), $expected);
-
-		$this->assertEquals($expected, $result);
+		$this->assertArraySubset($data, $sentence->toArray());
 	}
 
 	function testEditSentence_failsBecauseHasAudio() {
@@ -945,8 +935,9 @@ class SentencesTableTest extends TestCase {
 		CurrentUser::store($user);
 
 		$data = array(
-			'id' => 'spa_3',
-			'value' => 'changing'
+			'id' => '3',
+			'lang' => 'spa',
+			'text' => 'changing'
 		);
 		$expected = $this->Sentence->get(3);
 		$result = $this->Sentence->editSentence($data);
@@ -959,8 +950,9 @@ class SentencesTableTest extends TestCase {
 		CurrentUser::store($user);
 
 		$data = array(
-			'id' => 'eng_1',
-			'value' => 'Edited sentence.'
+			'id' => '1',
+			'lang' => 'eng',
+			'text' => 'Edited sentence.'
 		);
 		$before = $this->Sentence->get(1);
 
@@ -976,8 +968,9 @@ class SentencesTableTest extends TestCase {
 		CurrentUser::store($user);
 
 		$data = array(
-			'id' => '53_eng',
-			'value' => 'Edited sentence.'
+			'id' => 'eng',
+			'lang' => '53',
+			'text' => 'Edited sentence.'
 		);
 		$result = $this->Sentence->editSentence($data);
 
@@ -987,8 +980,9 @@ class SentencesTableTest extends TestCase {
     function testEditSentence_languageChangeUpdatesReindexFlags() {
         CurrentUser::store($this->Sentence->Users->get(7));
         $data = [
-            'id' => 'ita_7',
-            'value' => 'This is a lonely sentence.'
+            'id' => '7',
+            'lang' => 'ita',
+            'text' => 'This is a lonely sentence.'
         ];
 
         $result = $this->Sentence->editSentence($data);
@@ -1003,8 +997,9 @@ class SentencesTableTest extends TestCase {
     function testEditSentence_noEntryInReindexFlagsForUnknownPreviousLanguage() {
         CurrentUser::store($this->Sentence->Users->get(3));
         $data = [
-            'id' => 'eng_9',
-            'value' => 'This sentences purposely misses its flag.'
+            'id' => '9',
+            'lang' => 'eng',
+            'text' => 'This sentence purposely misses its flag.'
         ];
 
         $sentence = $this->Sentence->editSentence($data);
@@ -1018,8 +1013,9 @@ class SentencesTableTest extends TestCase {
     function testEditSentence_noEntryInReindexFlagsForUnknownNewLanguage() {
         CurrentUser::store($this->Sentence->Users->get(7));
         $data = [
-            'id' => '_7',
-            'value' => 'This is a lonely sentence.'
+            'id' => '7',
+            'lang' => '',
+            'text' => 'This is a lonely sentence.'
         ];
         $sentence = $this->Sentence->editSentence($data);
         $this->assertTrue((bool)$sentence);
@@ -1368,8 +1364,9 @@ class SentencesTableTest extends TestCase {
 
         $old = $this->Sentence->get(7);
         $data = array(
-            'id' => 'eng_7',
-            'value' => 'This  is  a   lonely sentence. '
+            'id' => '7',
+            'lang' => 'eng',
+            'text' => 'This  is  a   lonely sentence. '
         );
         $result = $this->Sentence->editSentence($data);
 

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -1025,6 +1025,48 @@ class SentencesTableTest extends TestCase {
         $this->assertNull($row);
     }
 
+    function testEditSentence_onlyTextAndLangAreEditable() {
+        CurrentUser::store($this->Sentence->Users->get(7));
+        $before = $this->Sentence->get(7);
+        $data = [
+            'id' => '7',
+            'text' => 'New text.',
+            'lang' => 'por',
+            'created' => '2020-10-01 12:34:56',
+            'user_id' => '1',
+        ];
+        $after = $this->Sentence->editSentence($data);
+        $this->assertEquals($before->created, $after->created);
+        $this->assertEquals($before->user_id, $after->user_id);
+    }
+
+    function testEditSentence_onlyNewText() {
+        CurrentUser::store($this->Sentence->Users->get(7));
+        $before = $this->Sentence->get(7);
+        $data = ['id' => '7', 'text' => 'New text.'];
+        $after = $this->Sentence->editSentence($data);
+        $this->assertNotEquals($before->text, $after->text);
+        $this->assertEquals($before->lang, $after->lang);
+    }
+
+    function testEditSentence_onlyNewLang() {
+        CurrentUser::store($this->Sentence->Users->get(7));
+        $before = $this->Sentence->get(7);
+        $data = ['id' => '7', 'lang' => 'fra'];
+        $after = $this->Sentence->editSentence($data);
+        $this->assertEquals($before->text, $after->text);
+        $this->assertNotEquals($before->lang, $after->lang);
+    }
+
+    function testEditSentence_onlyIdGiven() {
+        CurrentUser::store($this->Sentence->Users->get(7));
+        $before = $this->Sentence->get(2);
+        $data = ['id' => '2'];
+        $after = $this->Sentence->editSentence($data);
+        $this->assertEquals($before, $after);
+        $this->assertFalse($this->Sentence->UsersSentences->get(1)->dirty);
+    }
+
 	function testDeleteSentence_succeedsBecauseIsOwnerAndHasNoTranslations()
 	{
 		$user = $this->Sentence->Users->get(4);

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -398,10 +398,10 @@
         }
 
         function saveSentence(sentence) {
-            var lang = sentence.lang === 'unknown' ? '' : sentence.lang;
             var data = {
-                id: [lang, sentence.id].join('_'),
-                value: sentence.text
+                id: sentence.id,
+                lang: sentence.lang === 'unknown' ? '' : sentence.lang,
+                text: sentence.text
             };
             return $http.post(rootUrl + '/sentences/edit_sentence', data);
         }

--- a/webroot/js/sentences.edit_in_place.js
+++ b/webroot/js/sentences.edit_in_place.js
@@ -23,7 +23,9 @@ $(document).ready(function() {
         $('.editableSentence').each(function() {
             var div = $(this);
 
-            var sentenceId = div.parent().attr('data-sentence-id');
+            var sentenceData = div.attr('id').split('_');
+            var sentenceLang = sentenceData[0];
+            var sentenceId = sentenceData[1];
             div.editable(rootUrl + '/sentences/edit_sentence', {
                 type      : 'textarea',
                 submit    : div.attr('data-submit'),
@@ -38,6 +40,11 @@ $(document).ready(function() {
                 event     : 'edit_sentence',
                 data : function(value, settings) {
                     return $(this).data('text');
+                },
+                name      : 'text',
+                submitdata : {
+                    'id': sentenceId,
+                    'lang': sentenceLang,
                 },
                 callback : function(result, settings) {
                     var text = $('<div>').html(result).text(); // fix html entities

--- a/webroot/js/sentences.edit_in_place.js
+++ b/webroot/js/sentences.edit_in_place.js
@@ -23,9 +23,7 @@ $(document).ready(function() {
         $('.editableSentence').each(function() {
             var div = $(this);
 
-            var sentenceData = div.attr('id').split('_');
-            var sentenceLang = sentenceData[0];
-            var sentenceId = sentenceData[1];
+            var sentenceId = div.parent().attr('data-sentence-id');
             div.editable(rootUrl + '/sentences/edit_sentence', {
                 type      : 'textarea',
                 submit    : div.attr('data-submit'),
@@ -42,10 +40,7 @@ $(document).ready(function() {
                     return $(this).data('text');
                 },
                 name      : 'text',
-                submitdata : {
-                    'id': sentenceId,
-                    'lang': sentenceLang,
-                },
+                submitdata : {'id': sentenceId},
                 callback : function(result, settings) {
                     var text = $('<div>').html(result).text(); // fix html entities
                     $(this).data('text', text);


### PR DESCRIPTION
This PR adds a command to change the language of many sentences from the command line. This should help in moving all Kurdish sentences to Northern Kurdish (see #2570, point 2) and for splitting other macro languages in the future.

Since I wanted to use `SentencesTable::editSentence` for the updating part, I've also refactored that method to make it more reusable. As a side-effect I've also fixed #1678. :smiley: 