### PR TITLE
Add Zaza (Kirmancki) as UI language

### DIFF
--- a/config/app_local.php.template
+++ b/config/app_local.php.template
@@ -208,6 +208,7 @@ return [
             ['uzb', null, 'Oʻzbekcha'],
             ['vie', null, 'Tiếng Việt'],
             ['zsm', null, 'Bahasa Melayu'],
+            ['zza', null, 'Kirmancki'],
         ],
     ],
 


### PR DESCRIPTION
According to https://www.transifex.com/tatoeba/tatoeba_website/dashboard/, as for November 14th, 2020, Zaza's default pot got 100% translated

![image](https://user-images.githubusercontent.com/7658430/99180096-29d25480-2702-11eb-95cc-a401212c268c.png)

The translator told me that the most preferable name for this language is Kirmancki. That's the one I added here

https://en.wikipedia.org/wiki/Zaza_language