### PR TITLE
Allow admins to mark a blocked/suspended user's sentences as unreliable

### DIFF
--- a/config/auth_actions.php
+++ b/config/auth_actions.php
@@ -108,6 +108,7 @@ $config = [
             'change_language'       => User::ROLE_CONTRIBUTOR_OR_HIGHER,
             'edit_audio'            => [ User::ROLE_ADMIN ],
             'edit_correctness'      => [ User::ROLE_ADMIN ],
+            'mark_unreliable'      => [ User::ROLE_ADMIN ],
         ],
         'sentences_lists'      => [ '*' => User::ROLE_CONTRIBUTOR_OR_HIGHER ],
         'tags'                 => [ '*' => User::ROLE_ADV_CONTRIBUTOR_OR_HIGHER ],

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -29,6 +29,7 @@ namespace App\Controller;
 use App\Controller\AppController;
 use App\Form\SentencesSearchForm;
 use App\Model\CurrentUser;
+use App\Model\Entity\User;
 use App\Model\Table\SentencesTable;
 use App\Lib\LanguagesLib;
 use App\Lib\SphinxClient;
@@ -677,6 +678,9 @@ class SentencesController extends AppController
             return;
         }
 
+        $user = $this->Users->getUserById($userId);
+        $this->set("unreliableButton", CurrentUser::canMarkSentencesOfUser($user));
+
         $this->set("userExists", true);
 
         $onlyOriginal = array_key_exists('only_original', $this->request->getQueryParams());
@@ -828,6 +832,38 @@ class SentencesController extends AppController
         }
     }
 
+    
+    /**
+     * Mark all sentences of a user as incorrect.
+     *
+     * @param string $username User name of the user. 
+     * 
+     * @return void
+     */
+    public function mark_unreliable($username)
+    {   
+        $marked = $this->Sentences->markUnreliable($username);
+        
+        if($marked) {
+            $this->Flash->set(format(
+                __d('admin', 'Marked all sentences added by {username} as unreliable.'),
+                ['username' => $username]
+            ));
+        } else {
+            $this->Flash->set(format(
+                __d('admin', 'Error: Sentences added by {username} could not be marked as unreliable.'),
+                ['username' => $username]
+            ));
+        }
+        
+        $this->redirect(
+            array(
+                "controller" => "sentences",
+                "action" => "of_user",
+                $username
+            )
+        );
+    }
 
     public function edit_audio()
     {

--- a/src/Model/CurrentUser.php
+++ b/src/Model/CurrentUser.php
@@ -365,4 +365,11 @@ class CurrentUser
             return self::isTrusted() && $userAccountDeactivated;
         }
     }
+
+    public static function canMarkSentencesOfUser($user)
+    {
+        $userBlocked = $user->level == -1;
+        $userSuspended = $user->role == User::ROLE_SPAMMER;
+        return (CurrentUser::isAdmin() && ($userBlocked || $userSuspended));
+    }
 }

--- a/src/Template/Sentences/of_user.ctp
+++ b/src/Template/Sentences/of_user.ctp
@@ -71,7 +71,30 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
             </md-checkbox>
         </div>
         <?php
-     } ?>
+    }
+
+    if ($unreliableButton) {
+        ?>
+        <md-button class="md-warn md-raised"
+                   aria-label="<?= __d('admin', 'Mark as unreliable') ?>" >
+            <?php
+            echo $this->Html->link(
+                __d('admin', 'Mark as unreliable'),
+                [
+                    'controller' => 'sentences',
+                    'action' => 'mark_unreliable',
+                    $userName
+                ],
+                [
+                    'confirm' => __d('admin', 'Are you sure you want to mark all the sentences of this member as unreliable?'),
+                    'style' => 'color: white;'
+                ]
+            );
+            ?>
+        </md-button>
+        <?php
+    }    
+    ?>
 </div>
 <?php endif; ?>
 

--- a/tests/TestCase/Controller/SentencesControllerTest.php
+++ b/tests/TestCase/Controller/SentencesControllerTest.php
@@ -379,7 +379,7 @@ class SentencesControllerTest extends IntegrationTestCase {
     }
 
     public function testEditCorrectness_asCorpusMaintainer() {
-        $this->logInAs('advanced_contributor');
+        $this->logInAs('corpus_maintainer');
         $this->post('/jpn/sentences/edit_correctness', ['id' => '1', 'correctness' => '-1']);
         $this->assertRedirect('/');
     }
@@ -388,6 +388,26 @@ class SentencesControllerTest extends IntegrationTestCase {
         $this->logInAs('admin');
         $this->post('/jpn/sentences/edit_correctness', ['id' => '1', 'correctness' => '-1']);
         $this->assertRedirect('/jpn/sentences/show/1');
+    }
+
+    public function testMarkUnreliable_asGuest() {
+        $this->assertAccessUrlAs('/eng/sentences/mark_unreliable/spammer', null, '');
+    }
+
+    public function testMarkUnreliable_asContributor() {
+        $this->assertAccessUrlAs('/eng/sentences/mark_unreliable/spammer', 'contributor', '/');
+    }
+
+    public function testMarkUnreliable_asAdvancedContributor() {
+        $this->assertAccessUrlAs('/eng/sentences/mark_unreliable/spammer', 'advanced_contributor', '/');
+    }
+
+    public function testMarkUnreliable_asCorpusMaintainer() {
+        $this->assertAccessUrlAs('/eng/sentences/mark_unreliable/spammer', 'corpus_maintainer', '/');
+    }
+
+    public function testMarkUnreliable() {
+        $this->assertAccessUrlAs('/eng/sentences/mark_unreliable/spammer', 'admin', '/eng/sentences/of_user/spammer');
     }
 
     public function testEditAudio_asGuest() {
@@ -409,7 +429,7 @@ class SentencesControllerTest extends IntegrationTestCase {
     }
 
     public function testEditAudio_asCorpusMaintainer() {
-        $this->logInAs('advanced_contributor');
+        $this->logInAs('corpus_maintainer');
         $this->post('/jpn/sentences/edit_audio', ['id' => '1', 'hasaudio' => '1', 'ownerName' => 'kazuki']);
         $this->assertRedirect('/');
     }

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -1299,6 +1299,31 @@ class SentencesTableTest extends TestCase {
 		$this->assertEquals(-1, $result->correctness);
 	}
 
+	function testMarkUnreliable_ofSpammer_asAdmin() {
+		CurrentUser::store($this->Sentence->Users->get(1));
+        $this->Sentence->saveNewSentence('test', 'eng', 6);
+
+		$result = $this->Sentence->markUnreliable('spammer');
+		$this->assertNotFalse($result);
+
+		$correctCount = $this->Sentence->find('all')
+            ->where(['user_id' => 6, 'correctness' => 0])
+			->count();
+		$this->assertEquals(0, $correctCount);
+	}
+
+	function testMarkUnreliable_ofSpammer_asContributor() {
+		CurrentUser::store($this->Sentence->Users->get(4));
+		$result = $this->Sentence->markUnreliable('spammer');
+		$this->assertFalse($result);
+	}
+
+	function testMarkUnreliable_ofContributor_asAdmin() {
+		CurrentUser::store($this->Sentence->Users->get(1));
+		$result = $this->Sentence->markUnreliable('contributor');
+		$this->assertFalse($result);
+	}
+
 	function testGetNeighborsSentenceIds() {
 		$result = $this->Sentence->getNeighborsSentenceIds(8, 'fra');
 		$expected = [


### PR DESCRIPTION
This PR is for solving #2586.

This is what the UI currently looks like (look at the bottom right to see the "Mark Unreliable" button).

![Screenshot_2020-12-10 cerrax's sentences - Tatoeba](https://user-images.githubusercontent.com/34064492/101788745-7739ba00-3b26-11eb-91dc-1caa3de08f0d.png)

## Some things to be looked into:
- 2 new UI strings have been used in the code. 'Mark Unreliable' (button text) and 'Are you sure you want to mark user as unreliable?' (confirmation text). Should I replace these with anything else? Also, I think we'll need to add these strings to the admin files of each language. Are there any docs I can refer to, that can help me do this the right way?
- How do I improve the button UI?