### PR TITLE
Enhance display of multiline language icons

### DIFF
--- a/webroot/css/sentences/index.css
+++ b/webroot/css/sentences/index.css
@@ -126,6 +126,10 @@ svg.language-icon {
 }
 .language-list li {
   display: block;
+  background-image: linear-gradient(to bottom, #e0e0e0, #e0e0e0);
+  background-size: 2px calc(100% - 30px);
+  background-repeat: no-repeat;
+  background-position: 14px calc(100% - 5px);
 }
 .language-list a {
   display: table;


### PR DESCRIPTION
On the ["browse by language" page](https://tatoeba.org/eng/sentences/index), when a language name spans over multiple lines, it feels like an icon is missing.

That was [reported by Trang](https://tatoeba.org/eng/wall/show_message/35895#message_35895) a while ago.

This commits adds a vertical gray line to fill the blank created by multiline languages.

![pr_middle_line](https://user-images.githubusercontent.com/5107734/103914760-9e29e280-510a-11eb-88f1-a0f0fa82a430.png)
