### PR TITLE
Use built-in email validation instead of overly-strict regexes

### DIFF
--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -89,13 +89,9 @@ class UsersTable extends Table
             ->minLength('password', 6, __('Password must be at least 6 characters long'));
 
         $validator
-            ->email('email')
+            ->email('email', True /* Check MX records */, __('Invalid email address'))
             ->requirePresence('email', 'create')
-            ->notEmpty('email', __('Field required'))
-            ->add('email', 'email', [
-                'rule' => ['custom', '/^([a-zA-Z0-9_\.\-])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+$/'],
-                'message' => __('Invalid email address'),
-            ]);
+            ->notEmpty('email', __('Field required'));
 
         $validator
             ->date('since');

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -89,7 +89,7 @@ class UsersTable extends Table
             ->minLength('password', 6, __('Password must be at least 6 characters long'));
 
         $validator
-            ->email('email', True /* Check MX records */, __('Invalid email address'))
+            ->email('email', False /* Don't check MX records */, __('Invalid email address'))
             ->requirePresence('email', 'create')
             ->notEmpty('email', __('Field required'));
 

--- a/src/Template/Users/register.ctp
+++ b/src/Template/Users/register.ctp
@@ -160,7 +160,6 @@ $label = format(
         <label for="registrationEmail"><?php echo __('Email address'); ?></label>
         <md-icon>email</md-icon>
         <?php
-        $pattern = '/^([a-zA-Z0-9_\.\-])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+$/';
         echo $this->Form->input(
             'email',
             array(
@@ -170,7 +169,6 @@ $label = format(
                 'ng-model' => 'user.email',
                 'server-error' => $this->Form->isFieldError('email'),
                 'required' => true,
-                'ng-pattern' => $pattern,
                 'unique-email' => '',
                 'value' => $this->Form->getSourceValue('email'),
                 'error' => false,
@@ -186,7 +184,7 @@ $label = format(
             <div ng-message="required">
                 <?= __('Field required') ?>
             </div>
-            <div ng-message="pattern">
+            <div ng-message="email">
                 <?= __('Invalid email address') ?>
             </div>
             <div ng-message="uniqueEmail">

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -251,7 +251,7 @@ class UsersControllerTest extends IntegrationTestCase {
             'password' => 'very bad password',
             'language' => 'none',
             'acceptation_terms_of_use' => '1',
-            'email' => 'polochon@example.invalid', # RFC 6761
+            'email' => 'polochon@',
             'quiz' => 'poloc',
         ]);
         $this->assertSession(null, 'Auth.User.username');

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -232,6 +232,32 @@ class UsersControllerTest extends IntegrationTestCase {
         $this->assertResponseOk();
     }
 
+    public function testCheckLogin_canRegisterWithPlusInEmail() {
+        $this->post('/eng/users/register', [
+            'username' => 'polochon',
+            'password' => 'very bad password',
+            'language' => 'none',
+            'acceptation_terms_of_use' => '1',
+            'email' => 'polo+chon@example.net',
+            'quiz' => 'polo+',
+        ]);
+        $this->assertSession('polochon', 'Auth.User.username');
+        $this->assertRedirect('/eng');
+    }
+
+    public function testCheckLogin_cannotRegisterWithInvalidEmail() {
+        $this->post('/eng/users/register', [
+            'username' => 'polochon',
+            'password' => 'very bad password',
+            'language' => 'none',
+            'acceptation_terms_of_use' => '1',
+            'email' => 'polochon@example.invalid', # RFC 6761
+            'quiz' => 'poloc',
+        ]);
+        $this->assertSession(null, 'Auth.User.username');
+        $this->assertResponseOk();
+    }
+
     public function testCheckLogin_loginUpdatedPasswordVersion() {
         $this->post('/eng/users/check_login', [
             'username' => 'contributor',


### PR DESCRIPTION
This PR fixes #2609.

As it turns out, both the [AngularJS email input](https://docs.angularjs.org/api/ng/input/input%5Bemail%5D) and [CakePHP's email validator](https://api.cakephp.org/3.8/class-Cake.Validation.Validator.html#_email) were already being used to ensure users enter a valid email address during registration. The additional regex was just unnecessarily rejecting spec-compliant addresses that didn't fit its simplified pattern.

CakePHP supports additionally validating that the domain part of the email has valid MX records (otherwise it can't receive email). This is disabled by default (probably because it requires DNS queries, which might be slow), but I had to specify a value to be able to pass the optional error message as the third parameter. So I decided to enable it because I think it's a good idea and one check per registration attempt shouldn't be much of a burden for the server.

I tested this locally and it seems to work in the sense that emails that should pass validation (like `john+doe@example.com`) do pass it while others are rejected (like `john+doe@example`, because `example` isn't a registered domain with MX records, or `john+doe`, because the `@` is mandatory).

However, after passing validation, I was greeted with an error message `SQLSTATE[HY000]: General error: 1364 Field 'description' doesn't have a default value`. This also happens when using the current `master` and `dev` branches in a freshly-provisioned VM, so I think it's unrelated to this PR. It also doesn't happen on *dev.tatoeba.org*, so I guess my VM is misconfigured somehow.