### PR TITLE
Replace registration quiz with honeypot

### DIFF
--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -287,8 +287,7 @@ class UsersController extends AppController
 
         $newUser = $this->Users->newEntity();
 
-        $correctAnswer = mb_substr($this->request->getData('email'), 0, 5, 'UTF-8');
-        $quizOk = $this->request->getData('quiz') == $correctAnswer;
+        $honeypotTrapped = $this->request->getData('confirm') !== '';
 
         if ($this->request->is('post')) {
             $newUser = $this->Users->patchEntity(
@@ -299,7 +298,7 @@ class UsersController extends AppController
             $newUser->since = date("Y-m-d H:i:s");
             $newUser->role = User::ROLE_CONTRIBUTOR;
 
-            if ($quizOk
+            if (!$honeypotTrapped
                 && $this->request->getData('acceptation_terms_of_use')
                 && $this->Users->save($newUser)
                ) {
@@ -355,7 +354,6 @@ class UsersController extends AppController
 
         $this->set('user', $newUser);
         $this->set('language', $this->request->getData('language'));
-        $this->set('quizOk', $quizOk);
     }
 
 

--- a/src/Template/Users/register.ctp
+++ b/src/Template/Users/register.ctp
@@ -199,6 +199,26 @@ $label = format(
     </md-input-container>
 </div>
 
+<div layout="row" layout-align="center center" ng-show="confirm">
+    <md-input-container class="md-icon-float md-icon-left md-block" flex>
+        <md-icon>email</md-icon>
+        <?php
+        echo $this->Form->input(
+            'confirm',
+            array(
+                /* @translators: hidden field in registration form. It's a
+                   honeypot for spam bots. Normal users never see this text,
+                   but visually-impaired users may listen to it using
+                   screen-readers, so please translate it correctly. */
+                'label' => __('Leave this blank'),
+                'type' => 'email',
+                'required' => false,
+            )
+        );
+        ?>
+    </md-input-container>
+</div>
+
 <div id="native-language" layout="column">
     <div class="input" layout="row">
         <md-icon>language</md-icon>
@@ -225,48 +245,6 @@ $label = format(
         )
     );
     ?>
-</div>
-
-<div id="human-check" layout="column">
-    <div layout="row" layout-align="center start">
-        <md-icon>verified_user</md-icon>
-        <div class="title" flex>
-            <?= __('We need to make sure you are human.'); ?>
-        </div>
-    </div>
-
-    <div class="instructions">
-        <?= __('What are the first five characters of your email address?'); ?>
-    </div>
-
-    <md-input-container class="md-block">
-        <?php
-        echo $this->Form->input(
-            'quiz',
-            array(
-                /* @translators: captcha field name in register form (noun) */
-                'label' => __('Answer'),
-                'ng-model' => 'registration.quizAnswer',
-                'required' => true,
-                'server-error' => !$quizOk,
-                'value' => $this->Form->getSourceValue('quiz'),
-            )
-        );
-        ?>
-        <div ng-messages="registrationForm.quiz.$error">
-            <div ng-message="serverError">
-                <?= __('Wrong answer to the question.') ?>
-            </div>
-            <div ng-message="required">
-                <?= __('Field required') ?>
-            </div>
-        </div>
-        <?php
-        echo $this->Html->div('hint',
-            __('For instance, if your email address is a.b.cd@example.com, type a.b.c into the box.')
-        );
-        ?>
-    </md-input-container>
 </div>
 
 <md-input-container class="md-block">

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -213,7 +213,7 @@ class UsersControllerTest extends IntegrationTestCase {
             'language' => 'none',
             'acceptation_terms_of_use' => '1',
             'email' => 'polochon@example.net',
-            'quiz' => 'poloc',
+            'confirm' => '',
         ]);
         $this->assertSession('polochon', 'Auth.User.username');
         $this->assertRedirect('/eng');
@@ -226,7 +226,7 @@ class UsersControllerTest extends IntegrationTestCase {
             'language' => 'none',
             'acceptation_terms_of_use' => '1',
             'email' => 'polochon@example.net',
-            'quiz' => 'poloc',
+            'confirm' => '',
         ]);
         $this->assertSession(null, 'Auth.User.username');
         $this->assertResponseOk();
@@ -239,7 +239,7 @@ class UsersControllerTest extends IntegrationTestCase {
             'language' => 'none',
             'acceptation_terms_of_use' => '1',
             'email' => 'polo+chon@example.net',
-            'quiz' => 'polo+',
+            'confirm' => '',
         ]);
         $this->assertSession('polochon', 'Auth.User.username');
         $this->assertRedirect('/eng');
@@ -252,7 +252,20 @@ class UsersControllerTest extends IntegrationTestCase {
             'language' => 'none',
             'acceptation_terms_of_use' => '1',
             'email' => 'polochon@',
-            'quiz' => 'poloc',
+            'confirm' => '',
+        ]);
+        $this->assertSession(null, 'Auth.User.username');
+        $this->assertResponseOk();
+    }
+
+    public function testCheckLogin_cannotRegisterWithHoneypotFilledIn() {
+        $this->post('/eng/users/register', [
+            'username' => 'polochon',
+            'password' => 'very bad password',
+            'language' => 'none',
+            'acceptation_terms_of_use' => '1',
+            'email' => 'polochon@example.net',
+            'confirm' => 'polochon@example.net',
         ]);
         $this->assertSession(null, 'Auth.User.username');
         $this->assertResponseOk();

--- a/webroot/css/users/register.css
+++ b/webroot/css/users/register.css
@@ -39,8 +39,7 @@
     padding: 5px 0 20px 0;
 }
 
-#native-language md-icon,
-#human-check md-icon {
+#native-language md-icon {
     color: #000000;
     padding: 0 2px;
 }
@@ -53,18 +52,8 @@
     max-width: 200px;
 }
 
-#native-language label,
-#human-check .title {
+#native-language label {
     padding: 2px 0 0 10px;
-}
-
-#human-check {
-    margin: 20px 0;
-}
-
-
-#human-check .instructions {
-    margin-top: 10px;
 }
 
 #UserRegisterForm label.md-required::after {

--- a/webroot/js/users/register.ctrl.js
+++ b/webroot/js/users/register.ctrl.js
@@ -55,6 +55,7 @@
 
         vm.togglePassword = togglePassword;
         vm.isPasswordVisible = false;
+        vm.confirm = false;
 
         ///////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This PR replaces the registration form quiz with a honeypot (a hidden field spambots may be tempted to fill in) because the quiz has multiple problems.

We sometimes receive emails from users complaining that they cannot answer the quiz question correctly. The reason it that they omit punctuation characters in their answer. We already have an explanation text for that, but in the real world people don’t read carefully, so that doesn’t work.

In general, such captcha are not very UX-friendly because they force the user into performing a boring and seemingly useless action.

While I don’t have any number to estimate the performance of the quiz in preventing spambots from registering, I believe it’s about the same as the honeypot (that is to say pretty bad). But UX-wise the honeypot is definitely better; that’s the real improvement of this PR.