### PR TITLE
Language dropdowns UX improvements

### DIFF
--- a/src/Controller/ActivitiesController.php
+++ b/src/Controller/ActivitiesController.php
@@ -114,10 +114,10 @@ class ActivitiesController extends AppController
         $this->helpers[] = 'Languages';
         
         $langFrom = $this->request->getQuery('langFrom');
-        $langTo = $this->request->getQuery('langTo');
-        if ($langFrom && $langTo)
+        if ($langFrom)
         {
             $sort = $this->request->getQuery('sort', 'created');
+            $langTo = $this->request->getQuery('langTo');
 
             $this->Cookie->write(
                 'not_translated_into_lang',
@@ -126,16 +126,18 @@ class ActivitiesController extends AppController
                 '+1 month'
             );
 
+            $searchParams = array(
+                'from' => $langFrom,
+                'sort' => $sort
+            );
+            if ($this->request->getQuery('excludeLangTo') == 'yes') {
+                $searchParams['trans_filter'] = 'exclude';
+                $searchParams['trans_to'] = $langTo;
+            }
             $this->redirect(array(
                 'controller' => 'sentences',
                 'action' => 'search',
-                '?' => array(
-                    'from' => $langFrom,
-                    'to' => 'none',
-                    'trans_filter' => 'exclude',
-                    'trans_to' => $langTo,
-                    'sort' => $sort
-                )
+                '?' => $searchParams
             ));
         }
     }

--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -628,10 +628,6 @@ class SentencesController extends AppController
      */
     public function random($lang = null)
     {
-        if ($lang == null) {
-            $lang = $this->request->getSession()->read('random_lang_selected');
-        }
-
         $randomId = $this->Sentences->getRandomId($lang);
 
         if (is_null($randomId)) {

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -306,7 +306,7 @@ class UsersController extends AppController
                 $this->loadModel('UsersLanguages');
                 // Save native language
                 $language = $this->request->getData('language');
-                if (!empty($language) && $language != 'none') {
+                if (!empty($language)) {
                     $userLanguage = $this->UsersLanguages->newEntity([
                         'of_user_id' => $newUser->id,
                         'by_user_id' => $newUser->id,

--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -23,8 +23,8 @@ class SentencesSearchForm extends Form
 
     private $defaultCriteria = [
         'query' => '',
-        'from' => 'und',
-        'to' => 'und',
+        'from' => '',
+        'to' => '',
         'tags' => '',
         'list' => '',
         'user' => '',
@@ -32,7 +32,7 @@ class SentencesSearchForm extends Form
         'unapproved' => 'no',
         'native' => '',
         'has_audio' => '',
-        'trans_to' => 'und',
+        'trans_to' => '',
         'trans_link' => '',
         'trans_user' => '',
         'trans_orphan' => '',
@@ -87,7 +87,7 @@ class SentencesSearchForm extends Form
     }
 
     protected function setDataFrom(string $from) {
-        return $this->search->filterByLanguage($from) ?? 'und';
+        return $this->search->filterByLanguage($from) ?? '';
     }
 
     protected function setDataUser(string $user) {
@@ -152,7 +152,7 @@ class SentencesSearchForm extends Form
     }
 
     protected function setDataTransTo(string $lang) {
-        return $this->search->filterByTranslationLanguage($lang) ?? 'und';
+        return $this->search->filterByTranslationLanguage($lang) ?? '';
     }
 
     protected function setDataTransHasAudio(string $trans_has_audio) {
@@ -234,7 +234,7 @@ class SentencesSearchForm extends Form
 
     protected function setDataTo(string $to) {
         if ($to != 'none') {
-            $to = LanguagesLib::languageExists($to) ? $to : 'und';
+            $to = LanguagesLib::languageExists($to) ? $to : '';
         }
         return $to;
     }
@@ -357,7 +357,7 @@ class SentencesSearchForm extends Form
             $this->_data['trans_orphan'] = $this->setDataTransOrphan('');
         }
 
-        if ($this->_data['native'] === 'yes' && $this->_data['from'] === 'und') {
+        if ($this->_data['native'] === 'yes' && $this->_data['from'] === '') {
             $this->ignored[] = __(
                 /* @translators: This string will be preceded by “Warning: the
                    following criteria have been ignored:” */

--- a/src/Model/Table/ExportsTable.php
+++ b/src/Model/Table/ExportsTable.php
@@ -227,7 +227,7 @@ class ExportsTable extends Table
                 if (in_array('trans_text', $config['fields'])) {
                     $q->matching('Translations', function ($q) use ($config) {
                         $q->select(['Translations.text']);
-                        if (isset($config['trans_lang']) && $config['trans_lang'] != 'none') {
+                        if (isset($config['trans_lang'])) {
                             $q->where(['SentencesTranslations.translation_lang' => $config['trans_lang']]);
                         }
                         return $q;

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -523,7 +523,7 @@ class SentencesTable extends Table
      */
     public function getRandomId($lang = null)
     {
-        if (!$lang || $lang == 'und') {
+        if (!$lang) {
             return $this->getRandomIdAmongAllLanguages();
         } else {
             $arrayIds = $this->getSeveralRandomIds($lang, 1);
@@ -543,14 +543,10 @@ class SentencesTable extends Table
      *
      * @return array An array of ids.
      */
-    public function getSeveralRandomIds($lang = 'und',  $numberOfIdWanted = 10)
+    public function getSeveralRandomIds($lang = null, $numberOfIdWanted = 10)
     {
         if(Configure::read('Search.enabled') == false) {
             return null;
-        }
-
-        if(empty($lang)) {
-            $lang = 'und';
         }
 
         $returnIds = array ();
@@ -598,15 +594,15 @@ class SentencesTable extends Table
      * cached after, this way we do not need to request the random id source
      * each time we need a random id
      *
-     * @param string $lang             In which language takes the ids, 'und' if from all
+     * @param string $lang             In which language takes the ids, null if from all
      * @param int    $numberOfIdWanted Size of the array we will return
      *
      * @return array An array of int
      */
     private function _getRandomsToCached($lang, $numberOfIdWanted) {
-        $index = $lang == 'und' ?
-                 array('und_index') :
-                 array($lang . '_main_index', $lang . '_delta_index');
+        $index = $lang ?
+                 array($lang . '_main_index', $lang . '_delta_index') :
+                 array('und_index');
         $sphinx = array(
             'index' => $index,
             'sortMode' => array(SPH_SORT_EXTENDED => "@random"),

--- a/src/Template/Activities/translate_sentences.ctp
+++ b/src/Template/Activities/translate_sentences.ctp
@@ -34,16 +34,8 @@ $notTranslatedInto = $session->read('not_translated_into_lang');
 if (empty($currentLanguage)) {
     $currentLanguage = $session->read('random_lang_selected');
 }
-if (empty($notTranslatedInto)) {
-    $notTranslatedInto = 'none';
-}
 $langsFrom = $this->Languages->profileLanguagesArray();
-$langsTo = $this->Languages->profileLanguagesArray(false, [
-    'none' => '—',
-    /* @translators: option used in language selection dropdown
-       for "Not directly translated into", on Translate sentences page */
-    'und'  => __x('not-directly-translated-into', 'Any language'),
-]);
+$langsTo = $this->Languages->profileLanguagesArray();
 ?>
 
 <div id="annexe_content">
@@ -139,9 +131,17 @@ $langsTo = $this->Languages->profileLanguagesArray(false, [
             </fieldset>
 
             <fieldset class="select">
-                <label for="ActivityLangTo">
-                    <?php echo __('Not directly translated into:'); ?>
-                </label>
+                <md-checkbox ng-model="exclude_lang_to">
+                    <label for="ActivityLangTo">
+                        <?php echo __('Not directly translated into:'); ?>
+                    </label>
+                </md-checkbox>
+                <?=
+                    $this->Form->hidden('excludeLangTo', [
+                        'value' => '{{exclude_lang_to ? "yes" : ""}}',
+                    ]);
+                ?>
+
                 <?php
                 echo $this->element(
                     'language_dropdown',
@@ -151,6 +151,10 @@ $langsTo = $this->Languages->profileLanguagesArray(false, [
                         'languages' => $langsTo,
                         'initialSelection' => $notTranslatedInto,
                         'alwaysShowAll' => true,
+                        /* @translators: option used in language selection dropdown
+                           for "Not directly translated into", on Translate sentences page */
+                        'placeholder' => __x('not-directly-translated-into', 'Any language'),
+                        'onSelectedLanguageChange' => 'exclude_lang_to = true',
                     )
                 );
                 ?>

--- a/src/Template/Activities/translate_sentences.ctp
+++ b/src/Template/Activities/translate_sentences.ctp
@@ -132,6 +132,7 @@ $langsTo = $this->Languages->profileLanguagesArray(false, [
                         'id' => 'ActivityLangFrom',
                         'languages' => $langsFrom,
                         'initialSelection' => $currentLanguage,
+                        'alwaysShowAll' => true,
                     )
                 );
                 ?>
@@ -149,6 +150,7 @@ $langsTo = $this->Languages->profileLanguagesArray(false, [
                         'id' => 'ActivityLangTo',
                         'languages' => $langsTo,
                         'initialSelection' => $notTranslatedInto,
+                        'alwaysShowAll' => true,
                     )
                 );
                 ?>

--- a/src/Template/Element/advanced_search_form.ctp
+++ b/src/Template/Element/advanced_search_form.ctp
@@ -25,7 +25,9 @@ echo $this->Form->create('AdvancedSearch', [
     'url' => [
         'controller' => 'sentences',
         'action' => 'search',
-    ]
+    ],
+    'name' => 'ctrl.form',
+    'ng-submit' => 'ctrl.form.$valid || $event.preventDefault()',
 ]);
 ?>
 

--- a/src/Template/Element/advanced_search_form.ctp
+++ b/src/Template/Element/advanced_search_form.ctp
@@ -83,6 +83,9 @@ echo $this->Form->create('AdvancedSearch', [
                 <?php
                 echo $this->Search->selectLang('to', $to, [
                     'languages' => $this->Languages->languagesArrayShowTranslationsIn(),
+                    /* @translators: option used in language selection dropdown for
+                                     "Show translations in" in advanced search form */
+                    'placeholder' => __x('show-translations-in', 'All languages'),
                 ]);
                 ?>
             </div>

--- a/src/Template/Element/language_dropdown.ctp
+++ b/src/Template/Element/language_dropdown.ctp
@@ -25,4 +25,7 @@ $this->Form->unlockField($name);
     initial-selection="<?= $initialSelection ?>"
     placeholder="<?= $placeholder ?>"
     force-item-selection="<?= $forceItemSelection ?? false ?>"
+<?php if ($alwaysShowAll ?? false): ?>
+    always-show-all="true"
+<?php endif; ?>
 ></language-dropdown>

--- a/src/Template/Element/language_dropdown.ctp
+++ b/src/Template/Element/language_dropdown.ctp
@@ -25,5 +25,5 @@ $openOnFocus = isset($openOnFocus) ? $openOnFocus : true;
 <?php endif; ?>
     initial-selection="<?= $initialSelection ?>"
     placeholder="<?= $placeholder ?>"
-    min-length="<?= (int)!$openOnFocus; ?>"
+    open-on-focus="<?= $openOnFocus ?>"
 ></language-dropdown>

--- a/src/Template/Element/language_dropdown.ctp
+++ b/src/Template/Element/language_dropdown.ctp
@@ -9,7 +9,6 @@ $this->AngularTemplate->addTemplate(
 );
 
 $this->Form->unlockField($name);
-$openOnFocus = isset($openOnFocus) ? $openOnFocus : true;
 ?>
 <language-dropdown
 <?php if (isset($id)): ?>
@@ -25,5 +24,5 @@ $openOnFocus = isset($openOnFocus) ? $openOnFocus : true;
 <?php endif; ?>
     initial-selection="<?= $initialSelection ?>"
     placeholder="<?= $placeholder ?>"
-    open-on-focus="<?= $openOnFocus ?>"
+    force-item-selection="<?= $forceItemSelection ?? false ?>"
 ></language-dropdown>

--- a/src/Template/Element/language_dropdown_angular.ctp
+++ b/src/Template/Element/language_dropdown_angular.ctp
@@ -11,7 +11,7 @@
         md-items="language in vm.querySearch(vm.searchText)"
         md-item-text="language.name"
         md-min-length="minLength"
-        md-autoselect="vm.searchText.length"
+        md-autoselect="vm.autoselect"
         ng-blur="vm.onBlur()"
         ng-focus="vm.onFocus()"
         md-require-match="true"

--- a/src/Template/Element/language_dropdown_angular.ctp
+++ b/src/Template/Element/language_dropdown_angular.ctp
@@ -13,7 +13,7 @@
         md-min-length="minLength"
         md-autoselect="vm.autoselect"
         ng-blur="vm.onBlur()"
-        ng-focus="vm.onFocus()"
+        ng-focus="vm.onFocus($event)"
         md-require-match="true"
         placeholder="{{placeholder}}">
         <md-item-template>

--- a/src/Template/Element/language_dropdown_angular.ctp
+++ b/src/Template/Element/language_dropdown_angular.ctp
@@ -16,11 +16,27 @@
         ng-blur="vm.onBlur()"
         ng-focus="vm.onFocus($event)"
         md-require-match="true"
+        md-no-cache="vm.showAll"
         placeholder="{{placeholder}}">
         <md-item-template>
-            <span md-highlight-text="vm.searchText"
-                  md-highlight-flags="ig"
-                  ng-class="{'priority-language': language.isPriority}">{{language.name}}</span>
+            <?php /* Warning: <li> injection hack ahead, expect missing opening tags */ ?>
+                    <span md-highlight-text="vm.searchText"
+                          md-highlight-flags="ig"
+                          ng-class="{'priority-language': language.isPriority}">{{language.name}}</span>
+                </md-autocomplete-parent-scope>
+            </li>
+            <li class="show-all"
+                md-autocomplete-parent-scope
+                ng-if="!$mdAutocompleteCtrl.notFoundVisible()">
+                <md-button ng-show="!vm.showAll && vm.suggestionsDisplaying()"
+                           class="md-primary"
+                           ng-mouseup="vm.showAll = true">
+                    <?php /* @translators: button in language dropdown
+                                           to show all languages */ ?>
+                    <?= __('Show all') ?>
+                    <md-icon ng-cloak>keyboard_arrow_down</md-icon>
+                </md-button>
+            </li>
         </md-item-template>
         <md-not-found>
         <?= __('No language found.') ?>

--- a/src/Template/Element/language_dropdown_angular.ctp
+++ b/src/Template/Element/language_dropdown_angular.ctp
@@ -14,6 +14,7 @@
         md-autoselect="vm.searchText.length"
         ng-blur="vm.onBlur()"
         ng-focus="vm.onFocus()"
+        md-require-match="true"
         placeholder="{{placeholder}}">
         <md-item-template>
             <span md-highlight-text="vm.searchText"

--- a/src/Template/Element/language_dropdown_angular.ctp
+++ b/src/Template/Element/language_dropdown_angular.ctp
@@ -29,7 +29,14 @@
                  ng-class="{'priority-language': language.isPriority}">{{language.name}}</span>
         </md-item-template>
         <md-not-found>
-        <?= __('No language found.') ?>
+            <?= __('No language found.') ?>
+            <md-button class="md-primary"
+                       ng-click="vm.setShowAll(true)">
+                <?php /* @translators: button in language dropdown
+                                       to show all languages */ ?>
+                <md-icon ng-cloak>keyboard_arrow_left</md-icon>
+                <?= __('Show all') ?>
+            </md-button>
         </md-not-found>
     </md-autocomplete>
 </div>

--- a/src/Template/Element/language_dropdown_angular.ctp
+++ b/src/Template/Element/language_dropdown_angular.ctp
@@ -11,7 +11,7 @@
         md-search-text-change="vm.onSearchTextChange()"
         md-items="language in vm.querySearch(vm.searchText)"
         md-item-text="language.name"
-        md-min-length="minLength"
+        md-min-length="1-+(vm.hasSuggestions||vm.showAll)"
         md-autoselect="vm.autoselect"
         ng-blur="vm.onBlur()"
         ng-focus="vm.onFocus($event)"

--- a/src/Template/Element/language_dropdown_angular.ctp
+++ b/src/Template/Element/language_dropdown_angular.ctp
@@ -20,6 +20,11 @@
         placeholder="{{placeholder}}">
         <md-item-template>
             <?php /* Warning: <li> injection hack ahead, expect missing opening tags */ ?>
+                    <svg class="language-icon" ng-if="vm.hasLanguageIcon(language.code)">
+                        <use ng-attr-xlink:href="{{vm.getLanguageIconSpriteUrl(language.code)}}"
+                             xlink:href="" />
+                    </svg>
+
                     <span md-highlight-text="vm.searchText"
                           md-highlight-flags="ig"
                           ng-class="{'priority-language': language.isPriority}">{{language.name}}</span>

--- a/src/Template/Element/language_dropdown_angular.ctp
+++ b/src/Template/Element/language_dropdown_angular.ctp
@@ -2,6 +2,7 @@
     <input type="hidden" name="{{name}}" value="{{selectedLanguage.code}}" autocomplete="off">
     <md-autocomplete
         ng-cloak
+        md-select-on-focus
         md-input-id="{{inputId}}"
         md-menu-class="language-dropdown"
         md-selected-item="selectedLanguage"

--- a/src/Template/Element/language_dropdown_angular.ctp
+++ b/src/Template/Element/language_dropdown_angular.ctp
@@ -19,29 +19,14 @@
         md-no-cache="vm.showAll"
         placeholder="{{placeholder}}">
         <md-item-template>
-            <?php /* Warning: <li> injection hack ahead, expect missing opening tags */ ?>
-                    <svg class="language-icon" ng-if="vm.hasLanguageIcon(language.code)">
-                        <use ng-attr-xlink:href="{{vm.getLanguageIconSpriteUrl(language.code)}}"
-                             xlink:href="" />
-                    </svg>
+           <svg class="language-icon" ng-if="vm.hasLanguageIcon(language.code)">
+               <use ng-attr-xlink:href="{{vm.getLanguageIconSpriteUrl(language.code)}}"
+                    xlink:href="" />
+           </svg>
 
-                    <span md-highlight-text="vm.searchText"
-                          md-highlight-flags="ig"
-                          ng-class="{'priority-language': language.isPriority}">{{language.name}}</span>
-                </md-autocomplete-parent-scope>
-            </li>
-            <li class="show-all"
-                md-autocomplete-parent-scope
-                ng-if="!$mdAutocompleteCtrl.notFoundVisible()">
-                <md-button ng-show="!vm.showAll && vm.suggestionsDisplaying()"
-                           class="md-primary"
-                           ng-mouseup="vm.showAll = true">
-                    <?php /* @translators: button in language dropdown
-                                           to show all languages */ ?>
-                    <?= __('Show all') ?>
-                    <md-icon ng-cloak>keyboard_arrow_down</md-icon>
-                </md-button>
-            </li>
+           <span md-highlight-text="vm.searchText"
+                 md-highlight-flags="ig"
+                 ng-class="{'priority-language': language.isPriority}">{{language.name}}</span>
         </md-item-template>
         <md-not-found>
         <?= __('No language found.') ?>

--- a/src/Template/Element/language_dropdown_angular.ctp
+++ b/src/Template/Element/language_dropdown_angular.ctp
@@ -33,9 +33,9 @@
             <md-button class="md-primary"
                        ng-show="!vm.showAll"
                        ng-click="vm.showAll = true; vm.searchText = ''">
-                <?php /* @translators: button in language dropdown
-                                       to show all languages */ ?>
                 <md-icon ng-cloak>keyboard_arrow_left</md-icon>
+                <?php /* @translators: button in language dropdown to show all
+                         languages. Appears when entered text returns no matches. */ ?>
                 <?= __('Show all') ?>
             </md-button>
         </md-not-found>

--- a/src/Template/Element/language_dropdown_angular.ctp
+++ b/src/Template/Element/language_dropdown_angular.ctp
@@ -16,7 +16,7 @@
         ng-blur="vm.onBlur()"
         ng-focus="vm.onFocus($event)"
         md-require-match="true"
-        md-no-cache="vm.showAll"
+        md-no-cache="vm.searchText == ''"
         placeholder="{{placeholder}}">
         <md-item-template>
            <svg class="language-icon" ng-if="vm.hasLanguageIcon(language.code)">
@@ -31,7 +31,8 @@
         <md-not-found>
             <?= __('No language found.') ?>
             <md-button class="md-primary"
-                       ng-click="vm.setShowAll(true)">
+                       ng-show="!vm.showAll"
+                       ng-click="vm.showAll = true; vm.searchText = ''">
                 <?php /* @translators: button in language dropdown
                                        to show all languages */ ?>
                 <md-icon ng-cloak>keyboard_arrow_left</md-icon>

--- a/src/Template/Element/random_sentence_header.ctp
+++ b/src/Template/Element/random_sentence_header.ctp
@@ -45,7 +45,8 @@ $langArray = $this->Languages->languagesArrayAlone();
             'id' => 'randomLangChoice',
             'languages' => $langArray,
             'initialSelection' => '{{vm.lang}}',
-            'onSelectedLanguageChange' => 'vm.lang = language.code'
+            'onSelectedLanguageChange' => 'vm.lang = language.code',
+            'forceItemSelection' => true,
         ]);
         ?>
         </span>

--- a/src/Template/Element/random_sentence_header.ctp
+++ b/src/Template/Element/random_sentence_header.ctp
@@ -29,7 +29,7 @@ use App\Model\CurrentUser;
 
 $this->Html->script('sentences/random.ctrl.js', ['block' => 'scriptBottom']);
 
-$langArray = $this->Languages->languagesArrayAlone();
+$langArray = $this->Languages->onlyLanguagesArray();
 ?>
 
 <div ng-controller="RandomSentenceController as vm" ng-init="vm.init()">
@@ -45,8 +45,10 @@ $langArray = $this->Languages->languagesArrayAlone();
             'id' => 'randomLangChoice',
             'languages' => $langArray,
             'initialSelection' => '{{vm.lang}}',
+            /* @translators: placeholder of language dropdown
+                             in homepage random sentence block */
+            'placeholder' => __('All languages'),
             'onSelectedLanguageChange' => 'vm.lang = language.code',
-            'forceItemSelection' => true,
         ]);
         ?>
         </span>

--- a/src/Template/Element/search_bar.ctp
+++ b/src/Template/Element/search_bar.ctp
@@ -132,9 +132,11 @@ echo $this->Form->create(
                     'id' => 'SentenceFrom',
                     'name' => 'from',
                     'initialSelection' => $selectedLanguageFrom,
-                    /* @translators: option used in language selection dropdowns in top search bar */
-                    'languages' => $this->Languages->getSearchableLanguagesArray(__x('searchbar', 'Any language')),
-                    'selectedLanguage' => 'ctrl.langFrom'
+                    'languages' => $this->Languages->getSearchableLanguagesArray(),
+                    /* @translators: placeholder used in translation language selection dropdown in top search bar */
+                    'placeholder' => __x('searchbar', 'Any language'),
+                    'selectedLanguage' => 'ctrl.langFrom',
+                    'openOnFocus' => false,
                 )
             );
             ?>
@@ -156,9 +158,11 @@ echo $this->Form->create(
                     'id' => 'SentenceTo',
                     'name' => 'to',
                     'initialSelection' => $selectedLanguageTo,
-                    /* @translators: option used in language selection dropdowns in top search bar */
-                    'languages' => $this->Languages->getSearchableLanguagesArray(__x('searchbar', 'Any language')),
-                    'selectedLanguage' => 'ctrl.langTo'
+                    'languages' => $this->Languages->getSearchableLanguagesArray(),
+                    /* @translators: placeholder used in translation language selection dropdown in top search bar */
+                    'placeholder' => __x('searchbar', 'Any language'),
+                    'selectedLanguage' => 'ctrl.langTo',
+                    'openOnFocus' => false,
                 )
             );
             ?>

--- a/src/Template/Element/search_bar.ctp
+++ b/src/Template/Element/search_bar.ctp
@@ -138,7 +138,6 @@ echo $this->Form->create(
                     /* @translators: placeholder used in translation language selection dropdown in top search bar */
                     'placeholder' => __x('searchbar', 'Any language'),
                     'selectedLanguage' => 'ctrl.langFrom',
-                    'openOnFocus' => false,
                 )
             );
             ?>
@@ -164,7 +163,6 @@ echo $this->Form->create(
                     /* @translators: placeholder used in translation language selection dropdown in top search bar */
                     'placeholder' => __x('searchbar', 'Any language'),
                     'selectedLanguage' => 'ctrl.langTo',
-                    'openOnFocus' => false,
                 )
             );
             ?>

--- a/src/Template/Element/search_bar.ctp
+++ b/src/Template/Element/search_bar.ctp
@@ -75,7 +75,9 @@ echo $this->Form->create(
     'Sentence',
     array(
         'id' => 'SentenceSearchForm',
+        'name' => 'ctrl.form',
         "url" => array("controller" => "sentences", "action" => "search"),
+        'ng-submit' => 'ctrl.form.$valid || $event.preventDefault()',
         "type" => "get"
     )
 );

--- a/src/Template/Element/sentences/index/search.ctp
+++ b/src/Template/Element/sentences/index/search.ctp
@@ -11,7 +11,6 @@
               /* @translators: placeholder text in search field of
                                Browse by languages page */
               'placeholder' => __('Search a language'),
-              'openOnFocus' => false,
               'onSelectedLanguageChange' => 'vm.onSelectedLanguageChange(language)',
           )
       );

--- a/src/Template/Element/sentences/navigation.ctp
+++ b/src/Template/Element/sentences/navigation.ctp
@@ -47,7 +47,9 @@ $sentenceUrl = $this->Url->build([
             array(
                 'name' => 'lang',
                 'initialSelection' => $selectedLanguage,
-                'languages' => $this->Languages->getSearchableLanguagesArray(),
+                /* @translators: placeholder used in language dropdown
+                                 in navigation block on sentence pages */
+                'languages' => $this->Languages->getSearchableLanguagesArray(__x('navigation', 'Any language')),
                 'onSelectedLanguageChange' => 'vm.onSelectedLanguageChange(language)',
             )
         );

--- a/src/Template/Element/sentences/navigation.ctp
+++ b/src/Template/Element/sentences/navigation.ctp
@@ -51,6 +51,7 @@ $sentenceUrl = $this->Url->build([
                                  in navigation block on sentence pages */
                 'languages' => $this->Languages->getSearchableLanguagesArray(__x('navigation', 'Any language')),
                 'onSelectedLanguageChange' => 'vm.onSelectedLanguageChange(language)',
+                'forceItemSelection' => true,
             )
         );
         ?>

--- a/src/Template/Sentences/search.ctp
+++ b/src/Template/Sentences/search.ctp
@@ -34,7 +34,7 @@ if ($is_advanced_search) {
 } else if (!empty($query)) {
     $title = format(__('Sentences with: {keywords}'), array('keywords' => h($query)));
 } else {
-    if ($from != 'und' && $to != 'und') {
+    if (!empty($from) && !empty($to)) {
         if ($trans_filter == 'exclude') {
             $title = format(__('Sentences in {language} not translated into {translationLanguage}'),
                             array('language' => $this->Languages->codeToNameToFormat($from),
@@ -44,10 +44,10 @@ if ($is_advanced_search) {
                             array('language' => $this->Languages->codeToNameToFormat($from),
                                   'translationLanguage' => $this->Languages->codeToNameToFormat($to)));
         }
-    } elseif ($from != 'und') {
+    } elseif (!empty($from)) {
         $title = format(__('Sentences in {language}'),
                         array('language' => $this->Languages->codeToNameToFormat($from)));
-    } elseif ($to != 'und') {
+    } elseif (!empty($to)) {
         if ($trans_filter == 'exclude') {
             $title = format(__('Sentences not translated into {language}'),
                             array('language' => $language->codeToNameToFormat($to)));

--- a/src/Template/SentencesLists/download.ctp
+++ b/src/Template/SentencesLists/download.ctp
@@ -99,14 +99,15 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Download list: ') .
             <td><?php echo __('Translation (optional)'); ?></td>
             <td>
             <?php
-            $langArray = $this->Languages->languagesArrayWithNone();
+            $langArray = $this->Languages->onlyLanguagesArray();
             echo $this->element(
                 'language_dropdown',
                 array(
                     'name' => 'TranslationsLang',
                     'languages' => $langArray,
-                    'initialSelection' => 'none',
-                    'onSelectedLanguageChange' => 'trans_lang = language.code',
+                    /* @translators: placeholder in language dropdown of list download page */
+                    'placeholder' => __('None'),
+                    'selectedLanguage' => 'trans_lang',
                 )
             );
             ?>

--- a/src/Template/Users/register.ctp
+++ b/src/Template/Users/register.ctp
@@ -47,7 +47,8 @@ echo $this->Form->create($user, array(
     'name' => 'registrationForm',
     'url' => array('action' => 'register'),
     'class' => 'md-whiteframe-1dp',
-    'ng-controller' => 'UsersRegisterController as ctrl'
+    'ng-controller' => 'UsersRegisterController as ctrl',
+    'ng-submit' => 'registrationForm.$valid || $event.preventDefault()',
 ));
 
 $label = format(

--- a/src/Template/Users/register.ctp
+++ b/src/Template/Users/register.ctp
@@ -204,13 +204,14 @@ $label = format(
         <md-icon>language</md-icon>
         <label for="UserLanguage" flex><?= __('Native language:'); ?></label>
         <?php
-        $languagesList = $this->Languages->languagesArrayWithNone(false);
-        $language = $language ? $language : 'none';
+        $languagesList = $this->Languages->onlyLanguagesArray();
         echo $this->element(
             'language_dropdown',
             array(
                 'name' => 'language',
                 'languages' => $languagesList,
+                /* @translators: native language dropdown placeholder in Register page */
+                'placeholder' => __('None'),
                 'initialSelection' => $language,
                 'onSelectedLanguageChange' => 'user.language = language.code',
             )

--- a/src/View/Helper/CommonModulesHelper.php
+++ b/src/View/Helper/CommonModulesHelper.php
@@ -103,6 +103,7 @@ class CommonModulesHelper extends AppHelper
                     'name' => 'filterLanguageSelect',
                     'languages' => $langs,
                     'initialSelection' => $lang,
+                    'forceItemSelection' => true,
                     'onSelectedLanguageChange' => "
                         window.location.href =
                         '$path'

--- a/src/View/Helper/LanguagesHelper.php
+++ b/src/View/Helper/LanguagesHelper.php
@@ -199,8 +199,6 @@ class LanguagesHelper extends AppHelper
         $options = [
             /* @translators: option used in language selection dropdown for "Show translations in" in advanced search form */
             'none' => __('None'),
-            /* @translators: option used in language selection dropdown for "Show translations in" in advanced search form */
-            'und' => __x('show-translations-in', 'All languages')
         ];
 
         return $options + $languages;

--- a/src/View/Helper/LanguagesHelper.php
+++ b/src/View/Helper/LanguagesHelper.php
@@ -189,7 +189,7 @@ class LanguagesHelper extends AppHelper
 
 
     /**
-     * Return array of languages, with "None" and "All languages" options.
+     * Return array of languages, with "None" option.
      *
      * @return array
      */

--- a/src/View/Helper/LanguagesHelper.php
+++ b/src/View/Helper/LanguagesHelper.php
@@ -224,17 +224,16 @@ class LanguagesHelper extends AppHelper
     /**
      * Return array of languages in which you can search.
      *
-     * @param string $anyOption String for option "Any language" (und)
+     * @param string $anyOption (optional) String for option "Any language" (und)
      * @return array
      */
     public function getSearchableLanguagesArray($anyOption = null)
     {
         $languages = $this->onlyLanguagesArray();
-        /* @translators: option used in language selection dropdowns in other places */
-        $anyOption = $anyOption ?? __('Any language');
-        $options = array('und' => $anyOption);
-        
-        return $options + $languages;
+        if (!is_null($anyOption)) {
+            $languages = array('und' => $anyOption) + $languages;
+        }
+        return $languages;
     }
 
     /**

--- a/src/View/Helper/ListsHelper.php
+++ b/src/View/Helper/ListsHelper.php
@@ -315,6 +315,7 @@ class ListsHelper extends AppHelper
                 'languages' => $this->Languages->languagesArrayShowTranslationsIn(),
                 'initialSelection' => $translationsLang,
                 'onSelectedLanguageChange' => "window.location.href = '$path' + language.code",
+                'forceItemSelection' => true,
             )
         );
 

--- a/src/View/Helper/SearchHelper.php
+++ b/src/View/Helper/SearchHelper.php
@@ -38,6 +38,7 @@ class SearchHelper extends AppHelper
                 'name' => $fieldName,
                 'languages' => $this->langs,
                 'initialSelection' => $selectedLanguage,
+                'placeholder' => __('Any language'),
             ),
             $options
         );

--- a/src/View/Helper/ShowAllHelper.php
+++ b/src/View/Helper/ShowAllHelper.php
@@ -116,6 +116,7 @@ class ShowAllHelper extends AppHelper
                 'initialSelection' => $selectedLanguage,
                 'languages' => $langs,
                 'onSelectedLanguageChange' => "window.location.href = $javascriptUrl",
+                'forceItemSelection' => true,
             )
         );
 

--- a/tests/TestCase/Form/SentencesSearchFormTest.php
+++ b/tests/TestCase/Form/SentencesSearchFormTest.php
@@ -27,8 +27,8 @@ class SentencesSearchFormTest extends TestCase
     public function testDefaultData() {
         $expected = [
             'query' => '',
-            'to' => 'und',
-            'from' => 'und',
+            'to' => '',
+            'from' => '',
             'unapproved' => 'no',
             'orphans' => 'no',
             'user' => '',
@@ -37,7 +37,7 @@ class SentencesSearchFormTest extends TestCase
             'list' => '',
             'native' => '',
             'trans_filter' => 'limit',
-            'trans_to' => 'und',
+            'trans_to' => '',
             'trans_link' => '',
             'trans_has_audio' => '',
             'trans_unapproved' => '',
@@ -75,14 +75,14 @@ class SentencesSearchFormTest extends TestCase
             ],
 
             [ 'from', 'ain',         ['filterByLanguage', 'ain'        ], 'ain' ],
-            [ 'from', '',            ['filterByLanguage', ''           ], 'und' ],
-            [ 'from', 'invalidlang', ['filterByLanguage', 'invalidlang'], 'und' ],
+            [ 'from', '',            ['filterByLanguage', ''           ], '' ],
+            [ 'from', 'invalidlang', ['filterByLanguage', 'invalidlang'], '' ],
 
-            [ 'to', 'und',     [], 'und' ],
+            [ 'to', 'und',     [], '' ],
             [ 'to', 'none',    [], 'none' ],
             [ 'to', 'fra',     [], 'fra' ],
-            [ 'to', '',        [], 'und' ],
-            [ 'to', 'invalid', [], 'und' ],
+            [ 'to', '',        [], '' ],
+            [ 'to', 'invalid', [], '' ],
 
             [ 'unapproved', 'yes',     ['filterByCorrectness', true],  'yes' ],
             [ 'unapproved', 'no',      ['filterByCorrectness', false], 'no'  ],
@@ -121,8 +121,8 @@ class SentencesSearchFormTest extends TestCase
             [ 'trans_filter', 'invalidvalue', ['filterByTranslation'], 'limit' ],
 
             [ 'trans_to', 'ain',     ['filterByTranslationLanguage', 'ain'    ], 'ain' ],
-            [ 'trans_to', '',        ['filterByTranslationLanguage', ''       ], 'und' ],
-            [ 'trans_to', 'invalid', ['filterByTranslationLanguage', 'invalid'], 'und' ],
+            [ 'trans_to', '',        ['filterByTranslationLanguage', ''       ], '' ],
+            [ 'trans_to', 'invalid', ['filterByTranslationLanguage', 'invalid'], '' ],
 
             [ 'trans_link', 'direct',   ['filterByTranslationLink', 'direct'],  'direct'],
             [ 'trans_link', 'indirect', ['filterByTranslationLink', 'indirect'],'indirect'],
@@ -205,21 +205,21 @@ class SentencesSearchFormTest extends TestCase
         $this->Form->setData(['to' => 'none']);
         $result = $this->Form->getData();
         $this->assertEquals('none', $result['to']);
-        $this->assertEquals('und',  $result['trans_to']);
+        $this->assertEquals('',  $result['trans_to']);
     }
 
     public function testSearchParamToIsCopiedToTransTo_empty() {
         $this->Form->setData(['to' => '']);
         $result = $this->Form->getData();
-        $this->assertEquals('und', $result['to']);
-        $this->assertEquals('und', $result['trans_to']);
+        $this->assertEquals('', $result['to']);
+        $this->assertEquals('', $result['trans_to']);
     }
 
     public function testSearchParamToIsCopiedToTransTo_invalid() {
         $this->Form->setData(['to' => 'invalid']);
         $result = $this->Form->getData();
-        $this->assertEquals('und', $result['to']);
-        $this->assertEquals('und', $result['trans_to']);
+        $this->assertEquals('', $result['to']);
+        $this->assertEquals('', $result['trans_to']);
     }
 
     public function testTransFilter_limitWithoutTransFilters() {
@@ -369,7 +369,7 @@ class SentencesSearchFormTest extends TestCase
             [true, null]
         );
 
-        $this->Form->setData(['from' => 'und', 'native' => 'yes']);
+        $this->Form->setData(['from' => '', 'native' => 'yes']);
         $this->Form->checkUnwantedCombinations();
 
         $this->assertCount(1, $this->Form->getIgnoredFields());
@@ -421,13 +421,13 @@ class SentencesSearchFormTest extends TestCase
         $expected = [
             'native' => 'yes',
             'user' => '',
-            'from' => 'und',
+            'from' => '',
             'orphans' => 'no',
             'tags' => '',
             'query' => 'order should be preserved',
             'unapproved' => 'no',
             'has_audio' => '',
-            'to' => 'und',
+            'to' => '',
             'list' => '',
         ];
         $this->Form->setData($expected);

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1741,7 +1741,6 @@ html[dir="rtl"] .sentence-and-translations .translation.trusted-user.expanded .t
 }
 
 .md-virtual-repeat-container.md-autocomplete-suggestions-container {
-    min-height: 300px;
     width: 280px;
 }
 

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1755,6 +1755,8 @@ html[dir="rtl"] .sentence-and-translations .translation.trusted-user.expanded .t
 
 md-autocomplete-wrap:not(.md-menu-showing) input.ng-invalid {
     color: red;
+    transition-delay: 0.2s;
+    transition-property: color;
 }
 
 .usersLanguages .languageInfo {

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1742,6 +1742,7 @@ html[dir="rtl"] .sentence-and-translations .translation.trusted-user.expanded .t
 
 .md-virtual-repeat-container.md-autocomplete-suggestions-container {
     min-height: 300px;
+    width: 280px;
 }
 
 .md-autocomplete-suggestions-container li .highlight{
@@ -1751,6 +1752,25 @@ html[dir="rtl"] .sentence-and-translations .translation.trusted-user.expanded .t
 
 .priority-language {
     font-weight: bold;
+}
+
+svg.language-icon {
+  width: 30px;
+  height: 20px;
+  margin-right: 0.5em;
+}
+
+/* Work around https://bugzilla.mozilla.org/show_bug.cgi?id=1511997 */
+@-moz-document url-prefix() {
+  svg.language-icon {
+    filter: none;
+    box-shadow: 1px 1px 3px 0px rgba(204,204,204,1);
+  }
+}
+
+.language-dropdown .language-icon {
+    display: inline-block;
+    vertical-align: middle;
 }
 
 md-autocomplete-wrap:not(.md-menu-showing) input.ng-invalid {

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1753,6 +1753,10 @@ html[dir="rtl"] .sentence-and-translations .translation.trusted-user.expanded .t
     font-weight: bold;
 }
 
+md-autocomplete-wrap:not(.md-menu-showing) input.ng-invalid {
+    color: red;
+}
+
 .usersLanguages .languageInfo {
     margin: 0;
     padding: 0;

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1740,6 +1740,22 @@ html[dir="rtl"] .sentence-and-translations .translation.trusted-user.expanded .t
     height: 42px;
 }
 
+/* Custom md-not-found with "Show all" button */
+.md-not-found li:hover {
+    background-color: inherit;
+    cursor: default;
+}
+md-virtual-repeat-container.md-not-found {
+    min-height: 84px;
+}
+.md-not-found .language-dropdown li {
+    white-space: normal;
+    height: 84px
+}
+.md-not-found .language-dropdown button {
+    margin: 0;
+}
+
 .md-virtual-repeat-container.md-autocomplete-suggestions-container {
     width: 280px;
 }

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1759,6 +1759,11 @@ md-autocomplete-wrap:not(.md-menu-showing) input.ng-invalid {
     transition-property: color;
 }
 
+li.show-all:hover {
+    background-color: inherit;
+    cursor: default;
+}
+
 .usersLanguages .languageInfo {
     margin: 0;
     padding: 0;

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1760,6 +1760,11 @@ svg.language-icon {
   margin-right: 0.5em;
 }
 
+html[dir="rtl"] svg.language-icon {
+  margin-right: 0;
+  margin-left: 0.5em;
+}
+
 /* Work around https://bugzilla.mozilla.org/show_bug.cgi?id=1511997 */
 @-moz-document url-prefix() {
   svg.language-icon {

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1783,11 +1783,6 @@ md-autocomplete-wrap:not(.md-menu-showing) input.ng-invalid {
     transition-property: color;
 }
 
-li.show-all:hover {
-    background-color: inherit;
-    cursor: default;
-}
-
 .usersLanguages .languageInfo {
     margin: 0;
     padding: 0;

--- a/webroot/css/sentences/index.css
+++ b/webroot/css/sentences/index.css
@@ -55,18 +55,6 @@ img.centered-logo {
   display: table-cell;
   vertical-align: middle;
 }
-svg.language-icon {
-  width: 30px;
-  height: 20px;
-}
-
-/* Work around https://bugzilla.mozilla.org/show_bug.cgi?id=1511997 */
-@-moz-document url-prefix() {
-  svg.language-icon {
-    filter: none;
-    box-shadow: 1px 1px 3px 0px rgba(204,204,204,1);
-  }
-}
 
 .lang1  { top: 0;   right: 60%; }
 .lang2  { top: 0;    left: 60%; }
@@ -147,10 +135,6 @@ svg.language-icon {
   vertical-align: middle;
   word-wrap: anywhere;
   hyphens: auto;
-}
-
-.language-icon {
-  margin-right: 0.5em;
 }
 
 #content-container .header-with-hline {

--- a/webroot/css/user/profile.css
+++ b/webroot/css/user/profile.css
@@ -87,10 +87,10 @@
     height: 20px;
 }
 
-.language-icon {
+md-list .language-icon {
     margin: 26px 20px 0 0;
 }
-html[dir="rtl"] .language-icon {
+html[dir="rtl"] md-list .language-icon {
     margin: 26px 0 0 20px;
 }
 

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -114,7 +114,9 @@
                 }
 
                 function onSearchTextChange() {
-                    vm.searchText = vm.searchText.replace(/\t/, ' ');
+                    if (typeof vm.searchText === 'string') {
+                        vm.searchText = vm.searchText.replace(/\t/, ' ');
+                    }
                 }
 
                 function onBlur() {

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -35,7 +35,10 @@
                 onSelectedLanguageChange: '&?',
                 initialSelection: '@?',
                 placeholder: '@',
-                minLength: '<',
+                openOnFocus: '<',
+            },
+            link: function($scope) {
+                $scope.minLength = $scope.openOnFocus ? 0 : 1;
             },
             templateUrl: 'language-dropdown-template',
             controllerAs: 'vm',
@@ -120,15 +123,19 @@
                 }
 
                 function onBlur() {
-                    if (!$scope.selectedLanguage) {
-                        $scope.selectedLanguage = vm.previousSelectedItem;
+                    if ($scope.openOnFocus) {
+                        if (!$scope.selectedLanguage) {
+                            $scope.selectedLanguage = vm.previousSelectedItem;
+                        }
                     }
                 }
 
                 function onFocus() {
-                    if ($scope.selectedLanguage) {
-                        vm.previousSelectedItem = $scope.selectedLanguage;
-                        vm.searchText = '';
+                    if ($scope.openOnFocus) {
+                        if ($scope.selectedLanguage) {
+                            vm.previousSelectedItem = $scope.selectedLanguage;
+                            vm.searchText = '';
+                        }
                     }
                 }
             }]

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -61,6 +61,7 @@
                 vm.suggestionsDisplaying = suggestionsDisplaying;
                 vm.getLanguageIconSpriteUrl = getLanguageIconSpriteUrl;
                 vm.hasLanguageIcon = hasLanguageIcon;
+                vm.setShowAll = setShowAll;
 
                 /////////////////////////////////////////////////////////////////////////
 
@@ -186,6 +187,11 @@
                 function hasLanguageIcon(code) {
                     // naive yet working implementation
                     return code != 'und' && code != 'none';
+                }
+
+                function setShowAll(showAll) {
+                    vm.showAll = showAll;
+                    vm.searchText = '';
                 }
 
                 function getLanguageIconSpriteUrl(code) {

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -61,7 +61,6 @@
                 vm.suggestionsDisplaying = suggestionsDisplaying;
                 vm.getLanguageIconSpriteUrl = getLanguageIconSpriteUrl;
                 vm.hasLanguageIcon = hasLanguageIcon;
-                vm.setShowAll = setShowAll;
 
                 /////////////////////////////////////////////////////////////////////////
 
@@ -156,6 +155,7 @@
                         $scope.selectedLanguage = vm.previousSelectedItem;
                     }
                     havingFocus = false;
+                    vm.showAll = !!$scope.alwaysShowAll;
                 }
 
                 function onFocus($event) {
@@ -185,11 +185,6 @@
                 function hasLanguageIcon(code) {
                     // naive yet working implementation
                     return code != 'und' && code != 'none';
-                }
-
-                function setShowAll(showAll) {
-                    vm.showAll = showAll;
-                    vm.searchText = '';
                 }
 
                 function getLanguageIconSpriteUrl(code) {

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -36,6 +36,7 @@
                 initialSelection: '@?',
                 placeholder: '@',
                 forceItemSelection: '<',
+                alwaysShowAll: '<',
             },
             templateUrl: 'language-dropdown-template',
             controllerAs: 'vm',
@@ -46,9 +47,9 @@
 
                 vm.previousSelectedItem = null;
                 vm.searchText = '';
-                vm.hasSuggestions = false;
+                vm.hasSuggestions = !!$scope.alwaysShowAll;
                 vm.autoselect = true;
-                vm.showAll = false;
+                vm.showAll = !!$scope.alwaysShowAll;
 
                 vm.$onInit = $onInit;
                 vm.querySearch = querySearch;

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -48,6 +48,7 @@
                 vm.searchText = '';
                 vm.hasSuggestions = false;
                 vm.autoselect = true;
+                vm.showAll = false;
 
                 vm.$onInit = $onInit;
                 vm.querySearch = querySearch;
@@ -55,6 +56,7 @@
                 vm.onSearchTextChange = onSearchTextChange;
                 vm.onBlur = onBlur;
                 vm.onFocus = onFocus;
+                vm.suggestionsDisplaying = suggestionsDisplaying;
 
                 /////////////////////////////////////////////////////////////////////////
 
@@ -96,10 +98,14 @@
                             return nameA.indexOf(search) > nameB.indexOf(search);
                         });
                     } else {
-                        var results = languages.filter(function (item) {
-                            return item.isPriority;
-                        });
-                        return results.length ? results : languages;
+                        if (vm.showAll)  {
+                            return languages;
+                        } else {
+                            var results = languages.filter(function (item) {
+                                return item.isPriority;
+                            });
+                            return results.length ? results : languages;
+                        }
                     }
                 }
 
@@ -156,6 +162,11 @@
                         vm.autoselect = false;
                         vm.searchText += SUGGESTIONS_MARKER_HACK;
                     }
+                }
+
+                function suggestionsDisplaying() {
+                    return vm.searchText === ''
+                           || vm.searchText.endsWith(SUGGESTIONS_MARKER_HACK);
                 }
             }]
         };

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -142,7 +142,10 @@
                     }
                 }
 
-                function onFocus() {
+                function onFocus($event) {
+                    if ($event.target.tagName != 'INPUT') {
+                        return;
+                    }
                     if ($scope.selectedLanguage) {
                         vm.previousSelectedItem = $scope.selectedLanguage;
                     }

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -74,7 +74,12 @@
                             });
                             vm.hasSuggestions = true;
                         } else {
-                            languages.push({code: key1, name: data[key1]});
+                            var code = key1;
+                            var lang = {code: code, name: data[code]};
+                            if (code == 'und' || code == 'none') {
+                                lang.isPriority = true;
+                            }
+                            languages.push(lang);
                         }
                     });
 

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -126,8 +126,9 @@
                 }
 
                 function onSelectedLanguageChange() {
-                    if ($scope.selectedLanguage
-                        && $scope.selectedLanguage != vm.previousSelectedItem
+                    if ((!$scope.forceItemSelection
+                         || $scope.selectedLanguage
+                         && $scope.selectedLanguage != vm.previousSelectedItem)
                         && $scope.onSelectedLanguageChange
                     ) {
                         $scope.onSelectedLanguageChange({

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -47,6 +47,7 @@
                 vm.previousSelectedItem = null;
                 vm.searchText = '';
                 vm.hasSuggestions = false;
+                vm.autoselect = true;
 
                 vm.$onInit = $onInit;
                 vm.querySearch = querySearch;
@@ -82,6 +83,8 @@
                 }
 
                 function querySearch(value) {
+                    vm.autoselect = true;
+
                     if (!value.endsWith(SUGGESTIONS_MARKER_HACK) && value) {
                         var search = value.toLowerCase();
                         return languages.filter(function (item) {
@@ -147,6 +150,7 @@
                         $event.relatedTarget &&
                         $event.relatedTarget.tagName == 'BUTTON';
                     if (vm.hasSuggestions && vm.searchText !== '' && !clearButtonPressed) {
+                        vm.autoselect = false;
                         vm.searchText += SUGGESTIONS_MARKER_HACK;
                     }
                 }

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -43,6 +43,7 @@
             controller: ['$scope', '$window', function($scope, $window) {
                 var vm = this;
                 var languages = [];
+                var havingFocus = false;
                 const SUGGESTIONS_MARKER_HACK = '\x0d';
 
                 vm.previousSelectedItem = null;
@@ -152,10 +153,12 @@
                         vm.searchText = vm.searchText.replace(SUGGESTIONS_MARKER_HACK, '');
                         $scope.selectedLanguage = vm.previousSelectedItem;
                     }
+                    havingFocus = false;
                 }
 
                 function onFocus($event) {
-                    if ($event.target.tagName != 'INPUT') {
+                    if (havingFocus || $event.target.tagName != 'INPUT') {
+                        // we are sometimes getting called for no reason...
                         return;
                     }
                     if ($scope.selectedLanguage) {
@@ -169,6 +172,7 @@
                         vm.autoselect = false;
                         vm.searchText += SUGGESTIONS_MARKER_HACK;
                     }
+                    havingFocus = true;
                 }
 
                 function suggestionsDisplaying() {

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -143,7 +143,10 @@
                     if ($scope.selectedLanguage) {
                         vm.previousSelectedItem = $scope.selectedLanguage;
                     }
-                    if (vm.hasSuggestions && vm.searchText !== '') {
+                    const clearButtonPressed =
+                        $event.relatedTarget &&
+                        $event.relatedTarget.tagName == 'BUTTON';
+                    if (vm.hasSuggestions && vm.searchText !== '' && !clearButtonPressed) {
                         vm.searchText += SUGGESTIONS_MARKER_HACK;
                     }
                 }

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -90,8 +90,6 @@
                     if ($scope.initialSelection) {
                         setLang($scope.initialSelection);
                     }
-
-                    $scope.minLength = vm.hasSuggestions ? 0 : 1;
                 }
 
                 function querySearch(value) {
@@ -191,7 +189,6 @@
 
                 function setShowAll(showAll) {
                     vm.showAll = showAll;
-                    $scope.minLength = 0;
                     vm.searchText = '';
                 }
 

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -163,7 +163,8 @@
                     }
                     const clearButtonPressed =
                         $event.relatedTarget &&
-                        $event.relatedTarget.tagName == 'BUTTON';
+                        $event.relatedTarget.tagName == 'BUTTON' &&
+                        $event.relatedTarget.parentNode == $event.target.parentNode;
                     if (vm.hasSuggestions && vm.searchText !== '' && !clearButtonPressed) {
                         vm.autoselect = false;
                         vm.searchText += SUGGESTIONS_MARKER_HACK;

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -133,13 +133,15 @@
                             $scope.selectedLanguage = vm.previousSelectedItem;
                         }
                     }
+                    if (vm.searchText.endsWith(SUGGESTIONS_MARKER_HACK)) {
+                        vm.searchText = vm.searchText.replace(SUGGESTIONS_MARKER_HACK, '');
+                        $scope.selectedLanguage = vm.previousSelectedItem;
+                    }
                 }
 
                 function onFocus() {
-                    if ($scope.forceItemSelection) {
-                        if ($scope.selectedLanguage) {
-                            vm.previousSelectedItem = $scope.selectedLanguage;
-                        }
+                    if ($scope.selectedLanguage) {
+                        vm.previousSelectedItem = $scope.selectedLanguage;
                     }
                     if (vm.hasSuggestions && vm.searchText !== '') {
                         vm.searchText += SUGGESTIONS_MARKER_HACK;

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -59,6 +59,8 @@
                 vm.onBlur = onBlur;
                 vm.onFocus = onFocus;
                 vm.suggestionsDisplaying = suggestionsDisplaying;
+                vm.getLanguageIconSpriteUrl = getLanguageIconSpriteUrl;
+                vm.hasLanguageIcon = hasLanguageIcon;
 
                 /////////////////////////////////////////////////////////////////////////
 
@@ -179,6 +181,15 @@
                 function suggestionsDisplaying() {
                     return vm.searchText === ''
                            || vm.searchText.endsWith(SUGGESTIONS_MARKER_HACK);
+                }
+
+                function hasLanguageIcon(code) {
+                    // naive yet working implementation
+                    return code != 'und' && code != 'none';
+                }
+
+                function getLanguageIconSpriteUrl(code) {
+                    return '/cache_svg/allflags.svg#' + code;
                 }
             }]
         };

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -191,6 +191,7 @@
 
                 function setShowAll(showAll) {
                     vm.showAll = showAll;
+                    $scope.minLength = 0;
                     vm.searchText = '';
                 }
 

--- a/webroot/js/directives/language-dropdown.dir.js
+++ b/webroot/js/directives/language-dropdown.dir.js
@@ -58,7 +58,6 @@
                 vm.onSearchTextChange = onSearchTextChange;
                 vm.onBlur = onBlur;
                 vm.onFocus = onFocus;
-                vm.suggestionsDisplaying = suggestionsDisplaying;
                 vm.getLanguageIconSpriteUrl = getLanguageIconSpriteUrl;
                 vm.hasLanguageIcon = hasLanguageIcon;
 
@@ -175,11 +174,6 @@
                         vm.searchText += SUGGESTIONS_MARKER_HACK;
                     }
                     havingFocus = true;
-                }
-
-                function suggestionsDisplaying() {
-                    return vm.searchText === ''
-                           || vm.searchText.endsWith(SUGGESTIONS_MARKER_HACK);
                 }
 
                 function hasLanguageIcon(code) {

--- a/webroot/js/sentences_lists/download.ctrl.js
+++ b/webroot/js/sentences_lists/download.ctrl.js
@@ -43,9 +43,9 @@
                 fields.push('id');
             }
             fields.push('text');
-            if ($scope.trans_lang && $scope.trans_lang != 'none') {
+            if ($scope.trans_lang) {
                 fields.push('trans_text');
-                options['trans_lang'] = $scope.trans_lang;
+                options['trans_lang'] = $scope.trans_lang.code;
             }
             options['fields'] = fields;
             options['format'] = $scope.format;


### PR DESCRIPTION
Despite the advent of `md-autocomplete` for all our language selection dropdowns, we have been forcing upon them the old `<select>` behavior for technical and practical reasons (8f9e40b0ca18c5d89456ed369cd2ab4f64d235fc). This PR gets rid of these limitations to unleash the full power of autocompleting dropdowns for a better UX. :rocket: 

The limitations included:
1. The field was cleared and restored upon focus/blur, in order to make suggestions appear. → I found a (hackish) way to make suggestions appear without clearing the field.
2. The field was cleared and restored upon focus/blur, in order to make "Filter by language" blocks work (they reload the page upon language selection. → I kept that behavior only for these dropdowns.
3. The field was cleared and restored upon focus/blur, in order to make sure one cannot put the form in an invalid state. → If a language dropdown has invalid input, it now shows in red color and clicking the submit button does nothing.
4. Pressing the clear button (✘ button) was clearing the field but it was always restored to the last value. As a result, no matter you clicked on the ✘ or inside the field, it had the same effect. This makes ✘ useless. → Clearing the field, using backspace or the ✘ button, now leaves a placeholder showing what used to be a special option, such as "Any language" (except in case 2.)
5. Showing a 300+ languages list is a bit overwhelming and can [bring the users’ focus into spending dozens of seconds searching through the list rather than typing something](https://en.wiki.tatoeba.org/articles/show/ux-test-3#contributing). → Only profile languages are now showing first. If whatever was typed in returns no results, the "No language found." text now shows along with an additional (hackish!) "Show all" button. As for guests, they still see "last used languages" as suggestions. As a result, guests do not see any suggestions when they visit the website for the very first time; they *have* to type something in, only that time.
6. In the "Translate sentences" page, the "Not directly translated into" dropdown had two special options: "—" and "Any language". → I changed "—" into a checkbox. I also noticed a bug: selecting "—" produced the same results as "Any language". I fixed it.

As a bonus, I also included language icons within the suggestions because it looks so cool. :sparkles: I had to widen the box a little bit to make the icons fit. While I was at it, I decided to I widen it even more because it felt cramped in the first place.

![shot](https://user-images.githubusercontent.com/5107734/106985334-8bd2b100-6769-11eb-88d9-392ec0b8dcdc.png)

Currently set up on https://dev.tatoeba.org/.
Wall thread: https://tatoeba.org/wall/show_message/36512