### PR TITLE
Replaced the word 'logs' by 'contributions' on the user menu and on Contributions/of_user

### DIFF
--- a/src/Template/Contributions/of_user.ctp
+++ b/src/Template/Contributions/of_user.ctp
@@ -66,7 +66,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
             ?>
             <div layout-padding>
                 <?= format(
-                    __('Only the last {n} log entries are displayed here.'),
+                    __('Only the last {n} contributions are displayed here.'),
                     ['n' => $this->Number->format($totalLimit)]
                 ); ?>
             </div>

--- a/src/Template/Element/space.ctp
+++ b/src/Template/Element/space.ctp
@@ -187,7 +187,7 @@ $menuPositionMode = $htmlDir == 'rtl' ? 'target target' : 'target-right target';
                     <span>
                     <?php
                     /* @ŧranslators: top-right user menu item to list your contributions */
-                    echo __('My sentence logs');
+                    echo __('My latest contributions');
                     ?>
                     </span>
                 </a>


### PR DESCRIPTION
This PR solves partially #1638.

It replaces the word "logs" by "contribution on the user's menu.

![image](https://user-images.githubusercontent.com/7658430/118387183-45f07900-b5f3-11eb-8895-941e27b53cbd.png)

However, it does not solve cases like this one, but maybe it wasn't the scope of this ticket:

https://tatoeba.org/eng/contributions/of_user/TRANG

![image](https://user-images.githubusercontent.com/7658430/118387222-8fd95f00-b5f3-11eb-86c0-390b8154214e.png)

