### PR TITLE
Automatically detect writing direction for Malay and Malay (Vernacular)

### DIFF
--- a/src/Lib/LanguagesLib.php
+++ b/src/Lib/LanguagesLib.php
@@ -762,6 +762,8 @@ class LanguagesLib
             "xqa",
             "qxq",
             "klj",
+            "zlm",
+            "zsm",
         );
 
         $lang = self::locale_To_Iso639_3($lang);


### PR DESCRIPTION
It was brought up [on the wall](https://tatoeba.org/zh-cn/wall/show_message/37293#message_37293) that there are two different scripts used to write Malay, derived from Latin and Arabic, respectively. So the writing direction for both "Malay" `zsm` and "Malay (Vernacular)" `zlm` should be set to `auto` to make sentences in both scripts appear with the correct alignment.