### PR TITLE
Represent empty non-default parameters by "any" (fixes #2806)

### DIFF
--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -304,6 +304,14 @@ class SentencesSearchForm extends Form
             $keyCamel = Inflector::camelize($key);
             $setter = "setData$keyCamel";
             $this->_data[$key] = $this->$setter($value);
+
+            if(empty($this->_data[$key]) && !empty($this->defaultCriteria[$key])) {
+                /* Using Router::url() to reconstruct a URL for the given data
+                 * strips out empty parameters, which would lead to a non-empty
+                 * default being applied instead of the empty non-default value.
+                 * So represent them by "any" instead. */
+                $this->_data[$key] = 'any';
+            }
         }
     }
 

--- a/src/Template/Element/advanced_search_form.ctp
+++ b/src/Template/Element/advanced_search_form.ctp
@@ -118,7 +118,7 @@ echo $this->Form->create('AdvancedSearch', [
                         'label' => '',
                         'options' => [
                             /* @translators: dropdown option of "Is orphan" field in search form */
-                            '' => __x('orphan', 'Any'),
+                            'any' => __x('orphan', 'Any'),
                             /* @translators: part of Any/No/Yes dropdown options in search form */
                             'no' => __('No'),
                             /* @translators: part of Any/No/Yes dropdown options in search form */
@@ -142,7 +142,7 @@ echo $this->Form->create('AdvancedSearch', [
                         'label' => '',
                         'options' => array(
                             /* @translators: dropdown option of "Is unapproved" field in search form */
-                            '' => __x('unapproved', 'Any'),
+                            'any' => __x('unapproved', 'Any'),
                             'no' => __('No'),
                             'yes' => __('Yes'),
                         ),

--- a/tests/TestCase/Form/SentencesSearchFormTest.php
+++ b/tests/TestCase/Form/SentencesSearchFormTest.php
@@ -86,13 +86,15 @@ class SentencesSearchFormTest extends TestCase
 
             [ 'unapproved', 'yes',     ['filterByCorrectness', true],  'yes' ],
             [ 'unapproved', 'no',      ['filterByCorrectness', false], 'no'  ],
-            [ 'unapproved', 'invalid', ['filterByCorrectness', null],  ''    ],
-            [ 'unapproved', '',        ['filterByCorrectness', null],  ''    ],
+            [ 'unapproved', 'any',     ['filterByCorrectness', null],  'any' ],
+            [ 'unapproved', 'invalid', ['filterByCorrectness', null],  'any' ],
+            [ 'unapproved', '',        ['filterByCorrectness', null],  'any' ],
 
             [ 'orphans', 'yes',     ['filterByOrphanship', true],  'yes' ],
             [ 'orphans', 'no',      ['filterByOrphanship', false], 'no'  ],
-            [ 'orphans', 'invalid', ['filterByOrphanship', null],  ''    ],
-            [ 'orphans', '',        ['filterByOrphanship', null],  ''    ],
+            [ 'orphans', 'any',     ['filterByOrphanship', null],  'any' ],
+            [ 'orphans', 'invalid', ['filterByOrphanship', null],  'any' ],
+            [ 'orphans', '',        ['filterByOrphanship', null],  'any' ],
 
             [ 'user', 'contributor', ['filterByOwnerId', 4], 'contributor' ],
             [ 'user', 'invaliduser', ['filterByOwnerId'],    '', 1 ],


### PR DESCRIPTION
As mentioned in #2806, the issue is only triggered when the search is set to "random" sort. This is because of the [redirect using `Router::url()`](https://github.com/Tatoeba/tatoeba2/blob/2284e7caba68943bbf21191cae3bbbdc9c05467c/src/Controller/SentencesController.php#L497) when a random seed was generated for the search. Because `Router::url()` ignores empty parameters, the "Any" setting for "Is Orphan" and "Is Unapproved" should not be represented by an empty string.