### PR TITLE
Update fixtures lists to ensure tests can be run independently

### DIFF
--- a/tests/TestCase/Controller/AngularTemplatesControllerTest.php
+++ b/tests/TestCase/Controller/AngularTemplatesControllerTest.php
@@ -11,6 +11,7 @@ class AngularTemplatesControllerTest extends TestCase
 
     public $fixtures = [
         'app.Users',
+        'app.users_languages',
     ];
 
     public function accessesProvider() {

--- a/tests/TestCase/Controller/SControllerTest.php
+++ b/tests/TestCase/Controller/SControllerTest.php
@@ -18,6 +18,7 @@ class SControllerTest extends IntegrationTestCase
         'app.transcriptions',
         'app.users',
         'app.users_languages',
+        'app.users_sentences',
         'app.wiki_articles',
     ];
 

--- a/tests/TestCase/Controller/SentencesListsControllerTest.php
+++ b/tests/TestCase/Controller/SentencesListsControllerTest.php
@@ -23,6 +23,7 @@ class SentencesListsControllerTest extends IntegrationTestCase
         'app.transcriptions',
         'app.users',
         'app.users_languages',
+        'app.users_sentences',
         'app.wiki_articles',
     ];
 

--- a/tests/TestCase/Controller/TagsControllerTest.php
+++ b/tests/TestCase/Controller/TagsControllerTest.php
@@ -20,6 +20,7 @@ class TagsControllerTest extends IntegrationTestCase {
         'app.transcriptions',
         'app.users',
         'app.users_languages',
+        'app.users_sentences',
         'app.wiki_articles',
     ];
 


### PR DESCRIPTION
I have an issue with my VM that causes `phpunit` to lose the database connection and crash if I execute it without arguments to run all tests at once. (Maybe I haven't provisioned enough memory? Not sure yet.)

Using `find tests/ -name '*Test.php' -exec phpunit '{}' ';'` as a replacement, some tests fail because they expect certain fixtures to be present that are only loaded by other tests.

This PR adds the missing fixtures in their respective lists, so each test can be run independently from its own file.