### PR TITLE
Disable Form Tampering Protection for comment forms (fixes #1809)

### DIFF
--- a/src/Controller/SentenceCommentsController.php
+++ b/src/Controller/SentenceCommentsController.php
@@ -93,6 +93,13 @@ class SentenceCommentsController extends AppController
         $eventManager = $this->SentenceComments->getEventManager();
         $eventManager->attach(new NotificationListener());
 
+        // disable Form Tampering Protection for actions where it's no big deal
+        // (it was only protecting against changing the sentence_id)
+        $this->Security->setConfig('unlockedActions', [
+            'save',
+            'edit',
+        ]);
+
         return parent::beforeFilter($event);
     }
 


### PR DESCRIPTION
CakePHP's `FormHelper` [uses a SHA1 HMAC signature](https://api.cakephp.org/3.8/source-class-Cake.View.Helper.SecureFieldTokenTrait.html#61) to protect hidden fields against modification by malicious users. The signature also covers the `session_id`, which means that if the `session_id` changes, all previously loaded forms break.

For the comment forms, the only hidden field is the `sentence_id`. Being able to modify it doesn't grant malicious users any interesting capabilities. If they want to post a comment on a different sentence, they can already do that.

<hr/>

I'm not sure whether this protection should be enabled for *any* form. There are a few other issues mentioning black-holed requests when submitting a form: #1922, #1955, #2198. I'd hope that in each case the form is validated on the backend and changing parameters on the frontend won't allow bypassing that even without the signature. But I guess it's nice to have in principle, as a kind of defense-in-depth?