### PR TITLE
Allow sentence text to shrink as necessary (fixes #2823)

### DIFF
--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1323,6 +1323,10 @@ html[dir="rtl"] .sentence-and-translations .menu {
     border-bottom-right-radius: 15px;
 }
 
+.sentence-and-translations .text {
+    min-width: 0;
+}
+
 .sentence-and-translations .text,
 .sentence-and-translations .lang {
     margin: 3px 0;


### PR DESCRIPTION
According to the [flexbox spec](https://drafts.csswg.org/css-flexbox/#min-size-auto)

> To provide a more reasonable default minimum size for flex items, the used value of a main axis automatic minimum size on a flex item that is not a scroll container is its content-based minimum size; for scroll containers the automatic minimum size is zero, as usual.

Which means that even text with `word-wrap: break-word` enabled will nonetheless have a minimum width larger than what could be achieved with word breaks, hence possibly exceeding the horizontal space available to the flexbox container.

Setting the `min-width` to zero explicitly avoids this scenario and allows word breaking to do its job.