### PR TITLE
Make Chinese Wu available in the UI

### DIFF
--- a/config/app_local.php.template
+++ b/config/app_local.php.template
@@ -217,7 +217,7 @@ return [
             'cmn' => 'zh-cn',
             'zh-tw' => ['中文（臺灣正體）', 'zh-hant-tw', 'zh-hk', 'zh-hant-hk'],
             // Chinese (Wu)
-            'wuu' => [吳語], 'wuu' => 'wu'
+            'wuu' => ['吳語'],
             // Croatian
             'hr' => ['Hrvatski'], 'hrv' => 'hr',
             // Czech

--- a/config/app_local.php.template
+++ b/config/app_local.php.template
@@ -216,6 +216,8 @@ return [
             'chi' => 'zh-cn',
             'cmn' => 'zh-cn',
             'zh-tw' => ['中文（臺灣正體）', 'zh-hant-tw', 'zh-hk', 'zh-hant-hk'],
+            // Chinese (Wu)
+            'wuu' => [吳語], 'wuu' => 'wu'
             // Croatian
             'hr' => ['Hrvatski'], 'hrv' => 'hr',
             // Czech


### PR DESCRIPTION
This PR enables Chinese Wu as a user interface language on Tatoeba.

![image](https://user-images.githubusercontent.com/7658430/129278841-4bc9858b-a9ca-4a9b-b3fe-57bec2a0e8d4.png)


https://www.transifex.com/tatoeba/tatoeba_website/translate/#wuu