### PR TITLE
Add Ol Chiki to charset_table (fixes #2843)

### DIFF
--- a/src/Shell/SphinxConfShell.php
+++ b/src/Shell/SphinxConfShell.php
@@ -287,6 +287,8 @@ class SphinxConfShell extends Shell {
         'U+2c80..U+2ce3/2', 'U+2ce4', 'U+2ceb..U+2cee/2', 'U+2cef..U+2cf1', 'U+2cf2..U+2cf3/2', 'U+2cfd',
         # Syloti Nagri
         'U+a800..U+a827',
+        # Ol Chiki, for Santali (sat)
+        'U+1c50..U+1c7d',
     );
 
     public $scriptsWithoutWordBoundaries = array(


### PR DESCRIPTION
Ol Chiki is the script used for Santali (sat).

Unicode block: https://www.unicode.org/charts/PDF/U1C50.pdf