### PR TITLE
Ensure that changing the filter language does not alter other parts of the URL (fixes #2845)

### DIFF
--- a/src/View/Helper/CommonModulesHelper.php
+++ b/src/View/Helper/CommonModulesHelper.php
@@ -91,12 +91,6 @@ class CommonModulesHelper extends AppHelper
 
             $langs = $this->Languages->languagesArrayAlone();
 
-            // Avoid loosing the query parameters
-            $query = parse_url($this->request->getRequestTarget(), PHP_URL_QUERY);
-            if (!empty($query)) {
-                $query = '?' . $query;
-            }
-
             echo $this->_View->element(
                 'language_dropdown',
                 array(
@@ -105,10 +99,9 @@ class CommonModulesHelper extends AppHelper
                     'initialSelection' => $lang,
                     'forceItemSelection' => true,
                     'onSelectedLanguageChange' => "
-                        window.location.href =
+                        window.location.pathname =
                         '$path'
-                        + (language.code == 'und' ? '' : '/'+language.code)
-                        + '$query'",
+                        + (language.code == 'und' ? '' : '/'+language.code)",
                     // the check for 'und' is to avoid a duplicate page (with and without it)
                 )
             );

--- a/src/View/Helper/ListsHelper.php
+++ b/src/View/Helper/ListsHelper.php
@@ -300,12 +300,7 @@ class ListsHelper extends AppHelper
     public function displayTranslationsDropdown($listId, $translationsLang = null) {
         echo __('Show translations :') . ' ';
 
-        // TODO User $this->Url->build()
-        $path = '/';
-        if (!empty($this->request->params['lang'])) {
-            $path .= $this->request->params['lang'] . '/';
-        }
-        $path .= 'sentences_lists/show/'. $listId.'/';
+        $path = $this->Url->build(['action' => 'show', $listId]) . '/';
 
         // TODO onSelectedLanguageChange should be defined in a separate js file
         echo $this->_View->element(

--- a/src/View/Helper/ListsHelper.php
+++ b/src/View/Helper/ListsHelper.php
@@ -309,7 +309,7 @@ class ListsHelper extends AppHelper
                 'name' => 'translationLangChoice',
                 'languages' => $this->Languages->languagesArrayShowTranslationsIn(),
                 'initialSelection' => $translationsLang,
-                'onSelectedLanguageChange' => "window.location.href = '$path' + language.code",
+                'onSelectedLanguageChange' => "window.location.pathname = '$path' + language.code",
                 'forceItemSelection' => true,
             )
         );

--- a/src/View/Helper/ShowAllHelper.php
+++ b/src/View/Helper/ShowAllHelper.php
@@ -115,7 +115,7 @@ class ShowAllHelper extends AppHelper
                 'name' => 'filterLanguageSelect',
                 'initialSelection' => $selectedLanguage,
                 'languages' => $langs,
-                'onSelectedLanguageChange' => "window.location.href = $javascriptUrl",
+                'onSelectedLanguageChange' => "window.location.pathname = $javascriptUrl",
                 'forceItemSelection' => true,
             )
         );


### PR DESCRIPTION
Various language selection dropdowns were setting `window.location.href` when the selected language changes. However, this overwrites the entire URL, including the `?query` and `#fragment` parts, causing issues like #2845. The "Filter by language" dropdown already had a fix to add the `?query` back in, but a simpler solution is to set `window.location.pathname` instead. Then all other parts of the URL remain unchanged.

The one remaining use of `window.location.href` is in `webroot/js/services/search.srv.js`, where it's used to redirect to a search page and overwriting the query parameters is intended.