### PR TITLE
Enable responsive search results if the new design is used (fixes #2839)

### DIFF
--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -87,8 +87,8 @@ $sentenceUrl = $this->Url->build([
         <div flex><?= $duplicateWarning ?></div>
     </div>
     <div layout="column">
-        <div layout="row" class="header">
-            <md-subheader flex ng-if="!vm.isMenuExpanded">
+        <div layout="row" layout-align="end" layout-wrap class="header">
+            <md-subheader flex="auto" ng-if="!vm.isMenuExpanded">
                 <span ng-if="vm.sentence.user && vm.sentence.user.username">
                     <?php
                     $linkText = $this->Pages->formatSentenceIdWithSharp('{{vm.sentence.id}}');

--- a/src/Template/Element/sentences/sentence_menu.ctp
+++ b/src/Template/Element/sentences/sentence_menu.ctp
@@ -1,66 +1,66 @@
 <div class="menu-wrapper" sentence-menu flex="{{vm.isMenuExpanded ? '100' : 'none'}}"
      ng-init="vm.initMenu(<?= (int)$expanded ?>, vm.sentence.permissions)">
     <div class="menu" layout="row" layout-align="space-between center">
-        <div>
-            <md-button class="md-icon-button" ng-click="vm.translate(vm.sentence.id)"
-                ng-disabled="vm.sentence.correctness === -1 || vm.sentence.license === ''">
-                <md-icon>translate</md-icon>
-                <?php /* @translators: translate button on sentence menu (verb) */ ?>
-                <md-tooltip><?= __('Translate') ?></md-tooltip>
-            </md-button>
-
-            <md-button ng-if="vm.menu.canEdit || vm.menu.canTranscribe" class="md-icon-button" ng-click="vm.edit()">
-                <md-icon>edit</md-icon>
-                <?php /* @translators: edit button on sentence menu (verb) */ ?>
-                <md-tooltip><?= __('Edit') ?></md-tooltip>
-            </md-button>
-            
-            <md-button class="md-icon-button" ng-click="vm.list()">
-                <md-icon>list</md-icon>
-                <md-tooltip><?= __('Add sentence to list') ?></md-tooltip>
-            </md-button>
-
-            <icon-with-progress is-loading="vm.iconsInProgress.favorite">
-                <md-button class="md-icon-button" ng-if="vm.isMenuExpanded" ng-click="vm.favorite()">
-                    <md-icon>{{vm.sentence.is_favorite ? 'favorite' : 'favorite_border'}}</md-icon>
-                    <md-tooltip ng-if="!vm.sentence.is_favorite"><?= __('Add to favorites') ?></md-tooltip>
-                    <md-tooltip ng-if="vm.sentence.is_favorite"><?= __('Remove from favorites') ?></md-tooltip>
+        <div flex="{{vm.isMenuExpanded ? '80' : 'none'}}" layout="row" layout-align="space-between center" layout-wrap>
+            <div>
+                <md-button class="md-icon-button" ng-click="vm.translate(vm.sentence.id)"
+                    ng-disabled="vm.sentence.correctness === -1 || vm.sentence.license === ''">
+                    <md-icon>translate</md-icon>
+                    <?php /* @translators: translate button on sentence menu (verb) */ ?>
+                    <md-tooltip><?= __('Translate') ?></md-tooltip>
                 </md-button>
-            </icon-with-progress>
 
-            <md-button class="md-icon-button" ng-if="vm.isMenuExpanded && vm.menu.canDelete"
-                       onclick="return confirm('<?= __('Are you sure?') ?>');"
-                       ng-href="<?= $this->Url->build(['controller' => 'sentences', 'action' => 'delete']) ?>/{{vm.sentence.id}}">
-                <md-icon>delete</md-icon>
-                <?php /* @translators: delete button on sentence menu (verb) */ ?>
-                <md-tooltip><?= __('Delete') ?></md-tooltip>
-            </md-button>
-        </div>
-
-        <div ng-if="vm.isMenuExpanded && vm.menu.canReview" class="correctness-info">
-            <edit-review sentence-id="{{vm.sentence.id}}"
-                         correctness="vm.sentence.current_user_review">
-            </edit-review>
-        </div>
-
-        <div>
-            <icon-with-progress is-loading="vm.iconsInProgress.adopt">
-                <md-button class="md-icon-button" ng-if="vm.isMenuExpanded && vm.menu.canAdopt" ng-click="vm.adopt()">
-                    <md-icon>{{vm.sentence.is_owned_by_current_user ? 'person' : 'person_outline'}}</md-icon>
-                    <md-tooltip ng-if="!vm.sentence.is_owned_by_current_user"><?= __('Click to adopt') ?></md-tooltip>
-                    <md-tooltip ng-if="vm.sentence.is_owned_by_current_user"><?= __('Click to unadopt') ?></md-tooltip>
+                <md-button ng-if="vm.menu.canEdit || vm.menu.canTranscribe" class="md-icon-button" ng-click="vm.edit()">
+                    <md-icon>edit</md-icon>
+                    <?php /* @translators: edit button on sentence menu (verb) */ ?>
+                    <md-tooltip><?= __('Edit') ?></md-tooltip>
                 </md-button>
-            </icon-with-progress>
 
-            <md-button ng-if="!vm.isMenuExpanded" class="md-icon-button" ng-click="vm.toggleMenu()">
-                <md-icon>unfold_more</md-icon>
-                <md-tooltip><?= __('Show more features') ?></md-tooltip>
-            </md-button>
+                <md-button class="md-icon-button" ng-click="vm.list()">
+                    <md-icon>list</md-icon>
+                    <md-tooltip><?= __('Add sentence to list') ?></md-tooltip>
+                </md-button>
 
-            <md-button ng-if="vm.isMenuExpanded" class="md-icon-button" ng-click="vm.toggleMenu()">
-                <md-icon>unfold_less</md-icon>
-                <md-tooltip><?= __('Show fewer features') ?></md-tooltip>
-            </md-button>
+                <icon-with-progress is-loading="vm.iconsInProgress.favorite">
+                    <md-button class="md-icon-button" ng-if="vm.isMenuExpanded" ng-click="vm.favorite()">
+                        <md-icon>{{vm.sentence.is_favorite ? 'favorite' : 'favorite_border'}}</md-icon>
+                        <md-tooltip ng-if="!vm.sentence.is_favorite"><?= __('Add to favorites') ?></md-tooltip>
+                        <md-tooltip ng-if="vm.sentence.is_favorite"><?= __('Remove from favorites') ?></md-tooltip>
+                    </md-button>
+                </icon-with-progress>
+
+                <md-button class="md-icon-button" ng-if="vm.isMenuExpanded && vm.menu.canDelete"
+                           onclick="return confirm('<?= __('Are you sure?') ?>');"
+                           ng-href="<?= $this->Url->build(['controller' => 'sentences', 'action' => 'delete']) ?>/{{vm.sentence.id}}">
+                    <md-icon>delete</md-icon>
+                    <?php /* @translators: delete button on sentence menu (verb) */ ?>
+                    <md-tooltip><?= __('Delete') ?></md-tooltip>
+                </md-button>
+            </div>
+
+            <div ng-if="vm.isMenuExpanded && vm.menu.canReview" class="correctness-info">
+                <edit-review sentence-id="{{vm.sentence.id}}"
+                             correctness="vm.sentence.current_user_review">
+                </edit-review>
+            </div>
         </div>
+
+        <icon-with-progress is-loading="vm.iconsInProgress.adopt">
+            <md-button class="md-icon-button" ng-if="vm.isMenuExpanded && vm.menu.canAdopt" ng-click="vm.adopt()">
+                <md-icon>{{vm.sentence.is_owned_by_current_user ? 'person' : 'person_outline'}}</md-icon>
+                <md-tooltip ng-if="!vm.sentence.is_owned_by_current_user"><?= __('Click to adopt') ?></md-tooltip>
+                <md-tooltip ng-if="vm.sentence.is_owned_by_current_user"><?= __('Click to unadopt') ?></md-tooltip>
+            </md-button>
+        </icon-with-progress>
+
+        <md-button ng-if="!vm.isMenuExpanded" class="md-icon-button" ng-click="vm.toggleMenu()">
+            <md-icon>unfold_more</md-icon>
+            <md-tooltip><?= __('Show more features') ?></md-tooltip>
+        </md-button>
+
+        <md-button ng-if="vm.isMenuExpanded" class="md-icon-button" ng-click="vm.toggleMenu()">
+            <md-icon>unfold_less</md-icon>
+            <md-tooltip><?= __('Show fewer features') ?></md-tooltip>
+        </md-button>
     </div>
 </div>

--- a/src/Template/Sentences/search.ctp
+++ b/src/Template/Sentences/search.ctp
@@ -26,9 +26,10 @@
  */
 use App\Model\CurrentUser;
 
-if (!CurrentUser::isMember()) {
+if (!CurrentUser::isMember() || CurrentUser::getSetting('use_new_design')) {
     $this->set('isResponsive', true);
 }
+
 if ($is_advanced_search) {
     $title = __x('title', 'Advanced search');
 } else if (!empty($query)) {


### PR DESCRIPTION
This PR allows authenticated users to benefit from the more mobile-friendly layout if they have enabled the new design.

Two issues using the sentence menu on narrow screen are fixed with a slight redesign.

## Expanded menu
### Before
Screen width 900 px
![Expanded menu before, at screen width of 900 pixels](https://user-images.githubusercontent.com/6555947/135667301-26aaf06b-3431-467b-95cf-c75ecba46856.png)
Screen width 400 px
![Expanded menu before, at screen width of 400 pixels](https://user-images.githubusercontent.com/6555947/135671815-a30580c0-b2b1-4370-9358-354efefc7632.png)
Screen width 300 px
![Expanded menu before, at screen width of 300 pixels](https://user-images.githubusercontent.com/6555947/135667490-3c63da61-b145-4594-bd0f-47382e148970.png)
### After rearranging the menu
Screen width 900 px
![Expanded menu after, at screen width of 900 pixels](https://user-images.githubusercontent.com/6555947/135671034-5173dbc5-e563-4343-964a-4aefecfdad2f.png)
Screen width 400 px
![Expanded menu after, at screen width of 400 pixels](https://user-images.githubusercontent.com/6555947/135671961-3e24910c-15a5-466a-906d-54b6d4ddb018.png)
Screen width 300 px
![Expanded menu after, at screen width of 300 pixels](https://user-images.githubusercontent.com/6555947/135671159-adf8bcbc-b316-49fe-bd53-59076d264c84.png)

I also tried smaller screens (200 px), but then something else hits its minimum width, preventing the page from shrinking further.

## Collapsed menu
At 300 px, the problem caused by placing the sentence description ("sentence x belongs to y") next to the menu ([already mentioned by jiru on the original PR](https://github.com/Tatoeba/tatoeba2/pull/2473#issuecomment-671033196)) becomes quite severe:
### Before
![Collapsed menu before, at screen width of 300 px](https://user-images.githubusercontent.com/6555947/135673326-0854c643-33c5-49a8-8afb-15ef59be38e3.png)

I think a good solution is to allow the menu to wrap below the description:
### After
![Collapsed menu after, at screen width of 300 px](https://user-images.githubusercontent.com/6555947/135673728-6822fc60-0679-48a6-aa94-4d4a0082de2c.png)