### PR TITLE
Improve HTML escaping for transcriptions

### DIFF
--- a/src/Model/Entity/FuriganaTrait.php
+++ b/src/Model/Entity/FuriganaTrait.php
@@ -7,11 +7,18 @@ trait FuriganaTrait
      * Transforms "[kanji|reading]" to HTML <ruby> tags
      */
     public function rubify($formatted) {
-        return preg_replace_callback(
+        $ruby = '';
+        $parts = preg_split(
             '/\[([^|]*)\|([^\]]*)\]/',
-            function ($matches) {
-               $kanjis = preg_split('//u', $matches[1], null, PREG_SPLIT_NO_EMPTY);
-               $readings = explode('|',$matches[2]);
+            $formatted, -1, PREG_SPLIT_DELIM_CAPTURE);
+        // PREG_SPLIT_DELIM_CAPTURE inserts the two capture groups between the
+        // non-matching parts, so we walk the result three steps at a time and
+        // distinguish between match vs non-match based on the index.
+        for($part = 0; $part < count($parts); $part += 3) {
+            $ruby .= htmlentities($parts[$part]);
+            if ($part+2 < count($parts)) {
+               $kanjis = preg_split('//u', $parts[$part+1], null, PREG_SPLIT_NO_EMPTY);
+               $readings = explode('|', $parts[$part+2]);
                for ($i = 0; $i < count($readings); $i++) {
                    if ($i > 0 && empty($readings[$i])) {
                        if (array_key_exists($i, $kanjis)) {
@@ -25,15 +32,14 @@ trait FuriganaTrait
                    $last = array_pop($kanjis);
                    array_push($kanjis, array_pop($kanjis).$last);
                }
-               $ruby = '';
                for ($i = 0; $i < count($kanjis); $i++) {
                    $kanji = htmlentities($kanjis[$i]);
                    $reading = htmlentities($readings[$i]);
                    $ruby .= "<ruby>$kanji<rp>（</rp><rt>$reading</rt><rp>）</rp></ruby>";
                }
-               return $ruby;
-            },
-            $formatted);
+            }
+        }
+        return $ruby;
     }
 
     /**

--- a/src/Model/Entity/Transcription.php
+++ b/src/Model/Entity/Transcription.php
@@ -161,12 +161,13 @@ class Transcription extends Entity
         }
 
         $lang = $this->sentence->lang;
-        $text = htmlentities($this->text);
 
         if ($this->script == 'Hrkt') {
             $text = $this->rubify($this->text);
         } elseif ($lang == 'cmn' && $this->script == 'Latn') {
-            $text = $this->numeric2diacritic($text);
+            $text = htmlentities($this->numeric2diacritic($this->text));
+        } else {
+            $text = htmlentities($this->text);
         }
 
         return $text;
@@ -180,10 +181,10 @@ class Transcription extends Entity
         $text = null;
         $editable = !$this->readonly && CurrentUser::canEditTranscription($this->user_id, $this->sentence->user_id);
         if ($editable) {
-            $lang = $this->sentence->lang;
-            $text = $this->text;
             if ($this->script == 'Hrkt') {
                 $text = $this->bracketify($this->text);
+            } else {
+                $text = $this->text;
             }
         }
 

--- a/src/Model/Entity/Transcription.php
+++ b/src/Model/Entity/Transcription.php
@@ -181,7 +181,7 @@ class Transcription extends Entity
         $editable = !$this->readonly && CurrentUser::canEditTranscription($this->user_id, $this->sentence->user_id);
         if ($editable) {
             $lang = $this->sentence->lang;
-            $text = htmlentities($this->text);
+            $text = $this->text;
             if ($this->script == 'Hrkt') {
                 $text = $this->bracketify($this->text);
             }

--- a/tests/TestCase/Model/Entity/TranscriptionTest.php
+++ b/tests/TestCase/Model/Entity/TranscriptionTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace App\Test\TestCase\Model\Entity;
+
+use App\Model\CurrentUser;
+use App\Model\Entity\Sentence;
+use App\Model\Entity\Transcription;
+use Cake\TestSuite\TestCase;
+
+class TranscriptionTest extends TestCase
+{
+    public $fixtures = array(
+            'app.users_languages'
+    );
+
+    public function setUp()
+    {
+        parent::setUp();
+        CurrentUser::store([
+            'id' => 1,
+            'role' => \App\Model\Entity\User::ROLE_CORPUS_MAINTAINER,
+        ]);
+    }
+
+    function makeTranscription($lang, $sourceScript, $targetScript, $text) {
+        $transcription = new Transcription();
+        $transcription->sentence = new Sentence();
+        $transcription->sentence->lang = $lang;
+        $transcription->sentence->script = $sourceScript;
+        $transcription->script = $targetScript;
+        $transcription->text = $text;
+
+        return $transcription;
+    }
+
+    public function testGetHtml_jpn()
+    {
+        $this->assertEquals(
+            '「<ruby>何<rp>（</rp><rt>なに</rt><rp>）</rp></ruby>？」',
+            $this->makeTranscription('jpn', 'Jpan', 'Hrkt', '「[何|なに]？」')->html
+        );
+
+        $this->assertEquals(
+            '&lt;!--',
+            $this->makeTranscription('jpn', 'Jpan', 'Hrkt', '<!--')->html
+        );
+    }
+
+    public function testGetHtml_cmn()
+    {
+        $this->assertEquals(
+            '&quot;Sh&eacute;nme?&quot;',
+            $this->makeTranscription('cmn', 'Hans', 'Latn', '"Shen2me5?"')->html
+        );
+    }
+
+    public function testGetHtml_uzb()
+    {
+        $this->assertEquals(
+            '&quot;Nima?&quot;',
+            $this->makeTranscription('uzb', 'Cyrl', 'Latn', '"Nima?"')->html
+        );
+    }
+
+    public function testGetMarkup_jpn()
+    {
+        $this->assertEquals(
+            '「何｛なに｝？」',
+            $this->makeTranscription('jpn', 'Jpan', 'Hrkt', '「[何|なに]？」')->markup
+        );
+
+        $this->assertEquals(
+            '<!--',
+            $this->makeTranscription('jpn', 'Jpan', 'Hrkt', '<!--')->markup
+        );
+    }
+
+    public function testGetMarkup_cmn()
+    {
+        $this->assertEquals(
+            '"Shen2me5?"',
+            $this->makeTranscription('cmn', 'Hant', 'Latn', '"Shen2me5?"')->markup
+        );
+    }
+
+    public function testGetMarkup_uzb()
+    {
+        $this->assertEquals(
+            '',
+            $this->makeTranscription('uzb', 'Latn', 'Cyrl', '"Nima?"')->markup
+        );
+    }
+}


### PR DESCRIPTION
#2355 was caused by an unnecessary call to `htmlentities` in the default (non-hiragana-katakana) path for turning transcriptions into editable markup. The call is unnecessary because the markup is only displayed inside an AngularJS textarea, where it doesn't need escaping.

It took me a while to track down this root cause, because the call is executed unconditionally, but its result gets overwritten for Japanese. I think that's confusing style, so I reorganized the `if` branches to not mutate existing state.

This then led me to wonder whether the same lack of HTML escaping was alright when generating *HTML* for a Japanese transcription. As it turns out, it was not. The `rubify` code was only escaping characters with furigana, while passing everything else through unchanged.

I don't think this is exploitable for injection attacks, since any keyword in the injected code will have empty furigana placed on it, but if you insert an HTML comment `<!-- ` it survives intact and comments out the rest of the sentence.