### PR TITLE
Add quotation marks around “belongs” in French

### DIFF
--- a/src/Locale/fr/default.po
+++ b/src/Locale/fr/default.po
@@ -3238,7 +3238,7 @@ msgid ""
 "edit it. However, many of the sentences in Tatoeba come from a Japanese-"
 "English corpus called the Tanaka Corpus. These sentences do not have any "
 "owner because they have been collected outside of Tatoeba."
-msgstr "Lorsque vous ajoutez une phrase, cette phrase vous appartient - vous seul(e) pouvez la modifier. Toutefois, la plupart des phrases dans Tatoeba proviennent d'un corpus japonais-anglais appelé Tanaka Corpus. Ces phrases n'ont pas de propriétaire parce qu'elles ont été recueillies en dehors de Tatoeba."
+msgstr "Lorsque vous ajoutez une phrase, cette phrase vous « appartient » : vous seul(e) pouvez la modifier. Toutefois, la plupart des phrases dans Tatoeba proviennent d’un corpus japonais-anglais appelé Tanaka Corpus. Ces phrases n’ont pas de propriétaire parce qu'elles ont été recueillies en dehors de Tatoeba."
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Template/Pages/help.ctp#L243
 msgid ""


### PR DESCRIPTION
The translation was apparently misleading people into believing they actually owned a sentence, which is obviously not possible.  Thanks MS for spotting that issue!