### PR TITLE
Increase memory for VM build

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.memory = 512 # in MB
 
     # This one is when we build a new VM with "BUILD=1 vagrant up"
-    v.memory = 1024 if ENV['BUILD'] == '1'
+    v.memory = 2048 if ENV['BUILD'] == '1'
   end
 
   if ENV['BUILD'] == '1'


### PR DESCRIPTION
I rebuilt my VM today after upgrading to a new version of VirtualBox and ran into an issue with one of the C++ compilation steps failing with an out-of-memory error. The build succeeded once I doubled the available memory.