### PR TITLE
Optimize translation display in the new design

### DIFF
--- a/src/Template/Element/sentences/translation.ctp
+++ b/src/Template/Element/sentences/translation.ctp
@@ -1,4 +1,4 @@
-<div ng-repeat="translation in <?= $translations ?>"
+<div ng-repeat="translation in <?= $translations ?> track by translation.id"
      class="translation" ng-class="{'not-reliable' : translation.correctness === -1, 'expanded': vm.isMenuExpanded, 'trusted-user': vm.menu.canLink}">
     
     <div layout="row" layout-align="stretch" flex>


### PR DESCRIPTION
I've been trying to improve the rendering performance of the `sentence_and_translations` element, using a sentence with 50 direct and 50 indirect translations as the test case and measuring the time it took between clicking on "show 95 more translations" and actually getting to see those translations. The baseline is ≈8 seconds on my machine, which is ... not great.

Unfortunately, nothing I tried really made a dent in that figure. The main problem is that we're rendering too much stuff. Profiling in Chrome shows that about 20% of the time is spent just setting up event handlers for the various tooltips and buttons.
- Removing everything but the sentence text did cut the time to less than a second, but then all the features are gone as well, of course ...
- Using `::one-time-bindings` for as many AngularJS expressions as possible did reduce the number of watches that had to be checked on subsequent digests, but unfortunately those were already very fast (a few milliseconds) while the initial render was unaffected.
- Using `track by translation.id` in the `ng-repeat` likewise didn't improve the initial render, but it does make linking much faster. Linking one of the indirect translations took ≈14 seconds before and ≈4 seconds afterwards. Hence this PR.

With `track by`, AngularJS will reuse any translations whose `id`s were already contained in the previous list, even if the object pointers are different. Since linking only adds/removes a handful of translations, reusing the others leads to a sizeable speedup. One possible drawback is that other translations won't be updated even if their text changed on the server, leading to stale data staying around for longer. However, I think that scenario is rare enough and the speedup large enough to justify making this change.