### PR TITLE
Use the same random sentence header for guests and members (fixes #2868)

### DIFF
--- a/src/Template/Element/random_sentence_header.ctp
+++ b/src/Template/Element/random_sentence_header.ctp
@@ -34,7 +34,7 @@ $langArray = $this->Languages->onlyLanguagesArray();
 
 <div ng-controller="RandomSentenceController as vm" ng-init="vm.init()">
 <md-toolbar class="md-hue-2">
-    <div class="md-toolbar-tools" layout-align="center center" layout-margin layout-wrap>
+    <div class="md-toolbar-tools" layout-align="center center" layout-wrap>
         <?php /* @translators: random sentence block header on the home page */ ?>
         <h2 flex><?= __('Random sentence') ?></h2>
 

--- a/src/Template/Element/random_sentence_header.ctp
+++ b/src/Template/Element/random_sentence_header.ctp
@@ -35,7 +35,7 @@ $langArray = $this->Languages->onlyLanguagesArray();
 <div ng-controller="RandomSentenceController as vm" ng-init="vm.init()">
 <md-toolbar class="md-hue-2">
     <div class="md-toolbar-tools">
-        <?php /* @translators: random sentence block header on the home page for members */ ?>
+        <?php /* @translators: random sentence block header on the home page */ ?>
         <h2 flex><?= __('Random sentence') ?></h2>
 
         <span>

--- a/src/Template/Element/random_sentence_header.ctp
+++ b/src/Template/Element/random_sentence_header.ctp
@@ -34,28 +34,30 @@ $langArray = $this->Languages->onlyLanguagesArray();
 
 <div ng-controller="RandomSentenceController as vm" ng-init="vm.init()">
 <md-toolbar class="md-hue-2">
-    <div class="md-toolbar-tools">
+    <div class="md-toolbar-tools" layout-align="center center" layout-margin layout-wrap>
         <?php /* @translators: random sentence block header on the home page */ ?>
         <h2 flex><?= __('Random sentence') ?></h2>
 
-        <span>
-        <?php
-        echo $this->element('language_dropdown', [
-            'name' => 'randomLangChoice',
-            'id' => 'randomLangChoice',
-            'languages' => $langArray,
-            'initialSelection' => '{{vm.lang}}',
-            /* @translators: placeholder of language dropdown
-                             in homepage random sentence block */
-            'placeholder' => __('All languages'),
-            'onSelectedLanguageChange' => 'vm.lang = language.code',
-        ]);
-        ?>
-        </span>
+        <div layout="row" layout-align="center center" layout-wrap>
+            <span>
+            <?php
+            echo $this->element('language_dropdown', [
+                'name' => 'randomLangChoice',
+                'id' => 'randomLangChoice',
+                'languages' => $langArray,
+                'initialSelection' => '{{vm.lang}}',
+                /* @translators: placeholder of language dropdown
+                                 in homepage random sentence block */
+                'placeholder' => __('All languages'),
+                'onSelectedLanguageChange' => 'vm.lang = language.code',
+            ]);
+            ?>
+            </span>
 
-        <md-button id="showRandom" ng-click="vm.showAnother(vm.lang)">
-            <?= __('show another ') ?>
-        </md-button>
+            <md-button id="showRandom" ng-click="vm.showAnother(vm.lang)">
+                <?= __('show another ') ?>
+            </md-button>
+        </div>
     </div>
 </md-toolbar>
 </div>

--- a/src/Template/Element/random_sentence_header.ctp
+++ b/src/Template/Element/random_sentence_header.ctp
@@ -54,8 +54,9 @@ $langArray = $this->Languages->onlyLanguagesArray();
             ?>
             </span>
 
-            <md-button id="showRandom" ng-click="vm.showAnother(vm.lang)">
-                <?= __('show another ') ?>
+            <md-button class="md-icon-button" id="showRandom" ng-click="vm.showAnother(vm.lang)">
+                <md-icon>refresh</md-icon>
+                <md-tooltip><?= __('show another ') ?></md-tooltip>
             </md-button>
         </div>
     </div>

--- a/src/Template/Element/short_description.ctp
+++ b/src/Template/Element/short_description.ctp
@@ -75,7 +75,7 @@
                     </md-button>
                 </div>
 
-                <div layout="row" layout-align="center center">
+                <div layout="row" layout-align="center center" layout-wrap>
                     <md-button href="<?= h($this->cell('WikiLink', ['text-search'])) ?>" target="_blank">
                         <?php
                         /* @translators: links to a page with tips to perform

--- a/src/Template/Pages/index.ctp
+++ b/src/Template/Pages/index.ctp
@@ -115,7 +115,6 @@ $moreCommentsUrl = $this->Url->build([
                     'sentence' => $random,
                     'translations' => $random->translations,
                     'user' => $random->user,
-                    'menuDisabled' => true
                 )
             );
             ?>

--- a/src/Template/Pages/index_for_guests.ctp
+++ b/src/Template/Pages/index_for_guests.ctp
@@ -43,25 +43,15 @@ $registerUrl = $this->Url->build(
 <?php if(!isset($searchProblem)) { ?>
 <div layout-margin>
 <div layout="column">
-    <md-toolbar class="md-hue-2">
-        <div class="md-toolbar-tools">
-            <?php /* @translators: random sentence block header on the home page for guests */ ?>
-            <h2><?= __('Random sentence'); ?></h2>
-        </div>
-    </md-toolbar>
-
     <section ng-cloak>
     <?php
-    $sentence = $random;
-    $translations = $random->translations;
-    $sentenceOwner = $random->user;
-
+    echo $this->element('random_sentence_header');
     echo $this->element(
         'sentences/sentence_and_translations',
         array(
-            'sentence' => $sentence,
-            'translations' => $translations,
-            'user' => $sentenceOwner
+            'sentence' => $random,
+            'translations' => $random->translations,
+            'user' => $random->user,
         )
     );
     ?>

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -2009,7 +2009,7 @@ md-autocomplete-wrap:not(.md-menu-showing) input.ng-invalid {
     max-height: unset;
 }
 
-.md-toolbar-tools.layout-wrap h2 {
+.md-toolbar-tools.layout-wrap > * {
     margin: 8px 0;
 }
 

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1995,3 +1995,24 @@ md-autocomplete-wrap:not(.md-menu-showing) input.ng-invalid {
 #login-dialog md-dialog-content {
     padding: 40px 20px 10px 20px;
 }
+
+/*
+ * --------------------------------------------------------------------
+ *
+ *   Wrapping toolbars
+ *
+ * --------------------------------------------------------------------
+ */
+
+.md-toolbar-tools.layout-wrap {
+    height: unset;
+    max-height: unset;
+}
+
+.md-toolbar-tools.layout-wrap h2 {
+    margin: 8px 0;
+}
+
+.md-toolbar-tools.layout-wrap .md-button {
+    margin: 6px 8px;
+}

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -2013,6 +2013,6 @@ md-autocomplete-wrap:not(.md-menu-showing) input.ng-invalid {
     margin: 8px 0;
 }
 
-.md-toolbar-tools.layout-wrap .md-button {
-    margin: 6px 8px;
+.md-toolbar-tools.layout-wrap .md-icon-button {
+    margin: 6px 0px;
 }

--- a/webroot/css/pages/index.css
+++ b/webroot/css/pages/index.css
@@ -18,21 +18,6 @@
  */
 
 /*
- * Random sentence
- */
-#randomLangChoice {
-    width: 200px;
-}
-
-#random_sentence_display {
-    padding: 10px;
-}
-
-#random_sentence_display .sentence .content.column {
-    width: 500px;
-}
-
-/*
  * Latest messages on Wall
  */
 .lastWallMessages {


### PR DESCRIPTION
With this PR, a language selector and refresh button are always included in the header of the random sentence block.

This required a little redesign to make everything fit on narrow screens:
![900px](https://user-images.githubusercontent.com/6555947/140661831-398bceb8-0f9f-4e04-b226-e5db2252bf37.png)
![500px](https://user-images.githubusercontent.com/6555947/140661876-cfbb5a39-1690-4d27-8060-87a2624a7c4d.png)
![300px](https://user-images.githubusercontent.com/6555947/140661889-ff7fed83-9a58-4228-9c98-7872d0859e3f.png)

The screenshots are in Indonesian because the homepage was apparently getting cached somewhere and I couldn't figure out how to disable that to test my changes. (`bin/cake cache clear_all` didn't seem to have any effect.) On the bright side, this helped me notice that the "More tips" and "Advanced search" buttons below the search form can get quite wide next to each other in some languages, so I enabled wrapping for them, too.
