### PR TITLE
Improve consistency of current user's data

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -124,7 +124,13 @@ class AppController extends Controller
 
         // So that we can access the current users info from models.
         // Important: needs to be done after RememberMe->check().
-        CurrentUser::store($this->Auth->user());
+        $user = $this->Auth->user();
+        if ($user) {
+            // Keep the info up to date
+            $this->loadModel('Users');
+            $user = $this->Users->getInformationOfCurrentUser($user['id'])->toArray();
+        }
+        CurrentUser::store($user);
 
         // Restore named parameters removed in CakePHP 3
         $this->request = Router::parseNamedParams($this->request);

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -150,6 +150,13 @@ class AppController extends Controller
      */
     public function beforeRender(Event $event)
     {
+        $current_user = CurrentUser::get('User');
+        $auth_user = $this->Auth->user();
+        if ($auth_user && $current_user && $auth_user != $current_user) {
+            // User data changed, tell the Auth component about it.
+            $this->Auth->setUser($current_user);
+        }
+
         // without these 3 lines, html sent by AJAX will have the whole layout
         if ($this->request->is('ajax')) {
             $this->viewBuilder()->setLayout('ajax');

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -319,7 +319,6 @@ class UserController extends AppController
         $savedUser = $this->Users->save($user);        
 
         if ($savedUser) {
-            $this->Auth->setUser($savedUser->toArray());
             $this->Flash->set(
                 __('Profile saved.')
             );
@@ -541,7 +540,6 @@ class UserController extends AppController
             $this->Users->patchEntity($user, $data, ['fields' => $allowedFields]);
             $savedUser = $this->Users->save($user);
             if ($savedUser) {
-                $this->Auth->setUser($savedUser->toArray());
                 $flashMsg = __('Your settings have been saved.');
             } else {
                 $flashMsg = __(
@@ -752,9 +750,6 @@ class UserController extends AppController
             'settings' => $data
         ]);
         $savedUser = $this->Users->save($user);
-        if ($savedUser) {
-            $this->Auth->setUser($savedUser->toArray());
-        }
 
         return $savedUser;
     }

--- a/src/Template/Element/currently_active_members.ctp
+++ b/src/Template/Element/currently_active_members.ctp
@@ -44,7 +44,6 @@ foreach($currentContributors as $i=>$currentContributor){
     $numberOfContributions = $currentContributor->total;
     $percentage = ($numberOfContributions/$total)*100;
     $username = $currentContributor->user->username;
-    $userImage = $currentContributor->user->image;
     $url = $this->Url->build([
         'controller' => 'contributions',
         'action' => 'of_user',
@@ -52,7 +51,7 @@ foreach($currentContributors as $i=>$currentContributor){
     ]);
     ?>
     <md-list-item class="md-2-line" href="<?= $url ?>">
-        <?= $this->Members->image($username, $userImage, array('class' => 'md-avatar')); ?>
+        <?= $this->Members->image($currentContributor->user, array('class' => 'md-avatar')); ?>
         <div class="md-list-item-text" layout="column">
             <h3><?= $username ?></h3>
             <p>

--- a/src/Template/Element/logs/log_entry.ctp
+++ b/src/Template/Element/logs/log_entry.ctp
@@ -5,8 +5,6 @@ $obsolete = false;
 if (isset($log->obsolete)) {
     $obsolete = $log->obsolete;
 }
-$username = $log->user ? $log->user->username : null;
-$avatar = $log->user ? $log->user->image : null;
 $action =  $log->action;
 $type = 'sentence';
 if (isset($log->type)) {
@@ -23,7 +21,7 @@ $sentenceUrl = $this->Url->build(array(
 
 <md-list-item class="md-2-line <?= $type.'-'.$style ?>">
     <?php
-    echo $this->Members->image($username, $avatar, array('class' => 'md-avatar'));
+    echo $this->Members->image($log->user, array('class' => 'md-avatar'));
     if ($type != 'link') {
         echo $this->Languages->icon(
             $langCode,

--- a/src/Template/Element/private_messages/message.ctp
+++ b/src/Template/Element/private_messages/message.ctp
@@ -1,6 +1,5 @@
 <?php
 $username = $user->username ?? null;
-$avatar = $user->image ?? null;
 $dateLabel = $this->Date->ago($message->date);
 $fullDateLabel = $message->date;
 $menu = $this->PrivateMessages->getMenu($message->folder, $message->id, $message->type);
@@ -12,7 +11,7 @@ $messageContent = $this->safeForAngular(
 <md-card class="comment">
     <md-card-header>
         <md-card-avatar>
-            <?= $this->Members->image($username, $avatar, array('class' => 'md-user-avatar')); ?>
+            <?= $this->Members->image($user, array('class' => 'md-user-avatar')); ?>
         </md-card-avatar>
         <md-card-header-text>
             <span class="md-title">

--- a/src/Template/Element/sentence_comments/add_form.ctp
+++ b/src/Template/Element/sentence_comments/add_form.ctp
@@ -3,14 +3,13 @@ use App\Model\CurrentUser;
 
 $user = CurrentUser::get('User');
 $username = $user['username'];
-$avatar = $user['image'];
 ?>
 
 <md-card class="comment form">
 
     <md-card-header>
         <md-card-avatar>
-            <?= $this->Members->image($username, $avatar, array('class' => 'md-user-avatar')); ?>
+            <?= $this->Members->image($user, array('class' => 'md-user-avatar')); ?>
         </md-card-avatar>
         <md-card-header-text>
             <span class="md-title">

--- a/src/Template/Element/sentence_comments/comment.ctp
+++ b/src/Template/Element/sentence_comments/comment.ctp
@@ -2,7 +2,8 @@
 use App\Lib\LanguagesLib;
 use App\Model\CurrentUser;
 
-$username = $comment->user->username ?? null;
+$user = $comment->user;
+$username = $user->username ?? null;
 if ($username) {
     $userProfileUrl = $this->Url->build(array(
         'controller' => 'user',
@@ -10,7 +11,6 @@ if ($username) {
         $username
     ));
 }
-$avatar = $comment->user->image ?? null;
 $createdDate = $comment->created;
 $modifiedDate = $comment->modified;
 $commentId = $comment->id;
@@ -109,7 +109,7 @@ if ($sentenceOwnerLink) {
 <md-card class="comment <?= $commentHidden ? 'inappropriate' : '' ?>">
     <md-card-header>
         <md-card-avatar>
-            <?= $this->Members->image($username, $avatar, array('class' => 'md-user-avatar')); ?>
+            <?= $this->Members->image($user, array('class' => 'md-user-avatar')); ?>
         </md-card-avatar>
         <md-card-header-text>
         <?php if ($username): ?>

--- a/src/Template/Element/sentence_comments/edit_form.ctp
+++ b/src/Template/Element/sentence_comments/edit_form.ctp
@@ -4,7 +4,6 @@ use App\Model\CurrentUser;
 $sentenceId = $comment->sentence_id;
 $user = $comment->user;
 $username = $user['username'];
-$avatar = $user['image'];
 $text = $comment->text;
 $createdDate = $comment->created;
 $modifiedDate = $comment->modified;
@@ -25,7 +24,7 @@ $cancelUrl = $this->Url->build([
 
     <md-card-header>
         <md-card-avatar>
-            <?= $this->Members->image($username, $avatar, array('class' => 'md-user-avatar')); ?>
+            <?= $this->Members->image($user, array('class' => 'md-user-avatar')); ?>
         </md-card-avatar>
         <md-card-header-text>
             <span class="md-title">

--- a/src/Template/Element/space.ctp
+++ b/src/Template/Element/space.ctp
@@ -29,7 +29,6 @@ use Cake\ORM\TableRegistry;
 
 $user = CurrentUser::get('User');
 $username = $user['username'];
-$avatar = $user['image'];
 
 $newMessages = TableRegistry::get('PrivateMessages')->numberOfUnreadMessages(
     CurrentUser::get('id')
@@ -57,7 +56,7 @@ $menuPositionMode = $htmlDir == 'rtl' ? 'target target' : 'target-right target';
 
     <div id="user-menu" class="dropdown">
         <div class="label">
-            <?= $this->Members->image(null, $avatar, ['width' => 24, 'height' => 24]); ?>
+            <?= $this->Members->image($user, ['width' => 24, 'height' => 24]); ?>
             <span><?= $username ?></span>
         </div>
         <div class="dropdown-content">

--- a/src/Template/Element/wall/add_form.ctp
+++ b/src/Template/Element/wall/add_form.ctp
@@ -3,14 +3,13 @@ use App\Model\CurrentUser;
 
 $user = CurrentUser::get('User');
 $username = $user['username'];
-$avatar = $user['image'];
 ?>
 
 <md-card class="comment form">
 
     <md-card-header>
         <md-card-avatar>
-            <?= $this->Members->image($username, $avatar, array('class' => 'md-user-avatar')); ?>
+            <?= $this->Members->image($user, array('class' => 'md-user-avatar')); ?>
         </md-card-avatar>
         <md-card-header-text>
             <span class="md-title">

--- a/src/Template/Element/wall/edit_form.ctp
+++ b/src/Template/Element/wall/edit_form.ctp
@@ -1,7 +1,6 @@
 <?php
 $user = $message->user;
 $username = $user['username'];
-$avatar = $user['image'];
 $createdDate = $message->date;
 $modifiedDate = $message->modified;
 
@@ -20,7 +19,7 @@ $cancelUrl = $this->Url->build([
 
     <md-card-header>
         <md-card-avatar>
-            <?= $this->Members->image($username, $avatar, array('class' => 'md-user-avatar')); ?>
+            <?= $this->Members->image($user, array('class' => 'md-user-avatar')); ?>
         </md-card-avatar>
         <md-card-header-text>
             <span class="md-title">

--- a/src/Template/Element/wall/message.ctp
+++ b/src/Template/Element/wall/message.ctp
@@ -2,8 +2,8 @@
 use App\Lib\LanguagesLib;
 use App\Model\CurrentUser;
 
-$username = $message->user->username ?? null;
-$avatar = $message->user->image ?? null;
+$user = $message->user;
+$username = $user->username ?? null;
 $createdDate = $message->date;
 $modifiedDate = $message->modified;
 $messageId = $message->id;
@@ -59,7 +59,7 @@ $canReply = false;
 <md-card id="message_<?= $messageId ?>" class="comment <?= $cssClass ?> <?= $messageHidden ? 'inappropriate' : '' ?>">
     <md-card-header>
         <md-card-avatar>
-            <?= $this->Members->image($username, $avatar, array('class' => 'md-user-avatar')); ?>
+            <?= $this->Members->image($user, array('class' => 'md-user-avatar')); ?>
         </md-card-avatar>
         <md-card-header-text>
         <?php if ($username): ?>

--- a/src/Template/Element/wall/reply_form.ctp
+++ b/src/Template/Element/wall/reply_form.ctp
@@ -3,7 +3,6 @@ use App\Model\CurrentUser;
 
 $user = CurrentUser::get('User');
 $username = $user['username'];
-$avatar = $user['image'];
 $editUrl = $this->Url->build([
     'controller' => 'wall',
     'action' => 'edit'
@@ -16,7 +15,7 @@ $editUrl = $this->Url->build([
 
     <md-card-header>
         <md-card-avatar>
-            <?= $this->Members->image($username, $avatar, array('class' => 'md-user-avatar')); ?>
+            <?= $this->Members->image($user, array('class' => 'md-user-avatar')); ?>
         </md-card-avatar>
         <md-card-header-text>
             <span class="md-title">

--- a/src/Template/PrivateMessages/folder.ctp
+++ b/src/Template/PrivateMessages/folder.ctp
@@ -96,9 +96,6 @@ $this->set('title_for_layout', $this->Pages->formatTitle(
 
                 $unread = $msg->isnonread == 1 ? 'unread' : '';
 
-                $username = $user ? $user->username : null;
-                $userImage = $user ? $user->image : null;
-
                 if ($msg->title == '') {
                     $messageTitle = __('[no subject]');
                 } else {
@@ -139,7 +136,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(
                 ]);
                 ?>
                 <md-list-item class="md-2-line <?= $unread ?>" href="<?= $url ?>">
-                    <?= $this->Members->image($username, $userImage, array('class' => 'md-avatar')); ?>
+                    <?= $this->Members->image($user, array('class' => 'md-avatar')); ?>
                     <div class="md-list-item-text" layout="column">
                         <h3><?= $this->safeForAngular($messageTitle) ?></h3>
                         <p>

--- a/src/Template/Users/all.ctp
+++ b/src/Template/Users/all.ctp
@@ -121,15 +121,10 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Members')));
         foreach ($users as $i=>$user):
         $role = $user->role;
         $status = "status_$role";
-        $username = $user->username;
-        $userImage = null;
-        if (isset($user->image)) {
-            $userImage = $user->image;
-        };
         ?>
         <div class="user <?php echo $status ?> md-whiteframe-1dp">
             <div class="image">
-                <?php echo $this->Members->image($username, $userImage); ?>
+                <?php echo $this->Members->image($user); ?>
             </div>
 
 

--- a/src/Template/Users/for_language.ctp
+++ b/src/Template/Users/for_language.ctp
@@ -111,12 +111,11 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
         foreach($users as $user) {
             
             $username = $user->user->username;
-            $userImage = $user->user->image;
             $languageLevel = $user->level;
 
             echo '<div class="user">';
             echo '<div class="profilePicture">';
-            echo $this->Members->image($username, $userImage);
+            echo $this->Members->image($user->user);
             echo '</div>';
             echo '<div class="usernameAndLevel">';
                 echo $this->Html->link(

--- a/src/View/Helper/MembersHelper.php
+++ b/src/View/Helper/MembersHelper.php
@@ -47,8 +47,15 @@ class MembersHelper extends AppHelper
     /**
      *
      */
-    public function image($username = null, $imageName = null, $options = array())
+    public function image($user = null, $options = array())
     {
+        $username = null;
+        $imageName = null;
+        if ($user) {
+            $user = (object)$user;
+            $username = $user->username;
+            $imageName = $user->image;
+        }
         if (empty($imageName)) {
             $imageName = 'unknown-avatar.png';
         }

--- a/tests/TestCase/Controller/UserControllerTest.php
+++ b/tests/TestCase/Controller/UserControllerTest.php
@@ -157,9 +157,13 @@ class UserControllerTest extends IntegrationTestCase
         $this->post('/en/user/save_basic', [
             'email' => $newEmail,
         ]);
+
+        $this->assertRedirect('/en/user/profile/contributor');
+        $redirectTarget = $this->_response->getHeaderLine('Location');
+        $this->get($redirectTarget);
+
         $this->assertEquals($this->_controller->Auth->user('username'), $username);
         $this->assertEquals($this->_controller->Auth->user('email'), $newEmail);
-        $this->assertRedirect('/en/user/profile/contributor');
     }
 
     public function testSaveBasic_ignoresUnallowedFields() {


### PR DESCRIPTION
This pull request addresses issue #2614, which has multiple causes:

1. The first reason the profile picture was replaced by the text "Former member" is that this was mistakenly used as the alt text for all users, because the username wasn't passed through to the image-tag generating function.

    To prevent similar problems from occurring in the future, I refactored the function to take the whole user object instead, so you can't accidentally pass it only the username or only the image file.

2. The second reason the profile picture was replaced by the text "Former member" is that the image file to use for the current user wasn't correctly changed after deleting the picture, causing the image to break.

    The underlying issue is that `CurrentUser` was using the data from `$this->Auth->user()`, which is stored in the session when authenticating and not reliably updated when the user data changes. This could also cause various other issues (e.g. what if a user's access gets restricted, but they're still logged into a session with higher privileges?) so I think the best solution is to always get the current data from the database.