### PR TITLE
Rely on automatic detection for writing direction of Algerian Arabic

### DIFF
--- a/src/Lib/LanguagesLib.php
+++ b/src/Lib/LanguagesLib.php
@@ -730,7 +730,6 @@ class LanguagesLib
 
         $rightToLeftLangs = array(
             "ara",
-            "arq",
             "heb",
             "arz",
             "uig",
@@ -761,6 +760,7 @@ class LanguagesLib
 
         $autoLangs = array(
             "apc",
+            "arq",
             "ota",
             "chg",
             "lad",


### PR DESCRIPTION
See comments on [Sentence #10710401](https://tatoeba.org/en/sentences/show/10710401). Algerian Arabic is written using both Latin and Arabic scripts, so the writing direction needs to be `auto` to make both LTR and RTL sentences display correctly.