### PR TITLE
Reset UI state when refreshing random sentence

### DIFF
--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -190,6 +190,12 @@
         /////////////////////////////////////////////////////////////////////////
 
         function init(langs, sentence, directTranslations, indirectTranslations, translationLanguage) {
+            editableTranslations = [];
+            duplicateTranslations = [];
+            newTranslations = [];
+            vm.newTranslation = {};
+            vm.hasHiddenTranscriptions = false;
+
             vm.userLanguages = langs;
             vm.showAutoDetect = Object.keys(langs).length > 1;
             initSentence(sentence);
@@ -206,6 +212,7 @@
         }
 
         function initMenu(isExpanded, menu) {
+            vm.iconsInProgress = {};
             if (isExpanded) {
                 vm.isMenuExpanded = isExpanded;
             } else {
@@ -560,6 +567,7 @@
             vm.lists = allLists.filter(function(item) {
                 return item.is_mine === '1' || item.isLastSelected;
             }).slice(0, 10);
+            vm.listSearch = '';
             vm.listType = 'of_user';
         }
 


### PR DESCRIPTION
After seeing f90f7457b104d930a3e832fd4e137708a9197312 (thanks for fixing my mistakes) I had a closer look at what happens when the random sentence is refreshed, and I noticed that in addition to the `initLists` thing, there were other issues with the reinitialization.

Various variables (either on the `vm` object or local to the `SentenceAndTranslationsController`) are set only once when the controller is constructed, but not in the `initX` methods, so some UI state is incorrectly carried over when the sentence is refreshed. The one that is most easily noticed is that if you keep refreshing the random sentence as a guest, eventually you'll get a button to show unreviewed transcriptions, which never goes away even if there are no unreviewed transcriptions to show.

So I went through all the variables and reinitialized the ones that weren't already reset otherwise.

The one variable I intentionally left as-is without resetting it is `vm.visibility`, which controls e.g. whether the translation form is open. That way, users who want to translate another random sentence can do so without having to reopen the form. But the translation text does get cleared, to avoid accidentally adding the translation to the wrong sentence.