### PR TITLE
Remove user info from hidden messages/comments

### DIFF
--- a/src/Template/Element/sentence_comments/comment.ctp
+++ b/src/Template/Element/sentence_comments/comment.ctp
@@ -106,7 +106,7 @@ if ($sentenceOwnerLink) {
 </div>
 <?php } ?>
 
-<md-card class="comment <?= $commentHidden ? 'inappropriate' : '' ?>">
+<md-card class="comment">
     <md-card-header>
         <?php if (!$commentHidden || $canViewContent): ?>
         <md-card-avatar>
@@ -157,7 +157,7 @@ if ($sentenceOwnerLink) {
 
     <md-divider></md-divider>
 
-    <md-card-content>
+    <md-card-content class="<?= $commentHidden ? 'inappropriate' : '' ?>">
         <?php if ($commentHidden) { ?>
             <div class="warning-info" layout="row" layout-align="start center">
                 <md-icon>warning</md-icon>

--- a/src/Template/Element/sentence_comments/comment.ctp
+++ b/src/Template/Element/sentence_comments/comment.ctp
@@ -108,16 +108,20 @@ if ($sentenceOwnerLink) {
 
 <md-card class="comment <?= $commentHidden ? 'inappropriate' : '' ?>">
     <md-card-header>
+        <?php if (!$commentHidden || $canViewContent): ?>
         <md-card-avatar>
             <?= $this->Members->image($username, $avatar, array('class' => 'md-user-avatar')); ?>
         </md-card-avatar>
+        <?php endif; ?>
         <md-card-header-text>
-        <?php if ($username): ?>
-            <span class="md-title">
-                <a href="<?= $userProfileUrl ?>"><?= $username ?></a>
-            </span>
-        <?php else: ?>
-            <i><?= h(__('Former member')) ?></i>
+        <?php if (!$commentHidden || $canViewContent): ?>
+            <?php if ($username): ?>
+                <span class="md-title">
+                    <a href="<?= $userProfileUrl ?>"><?= $username ?></a>
+                </span>
+            <?php else: ?>
+                <i><?= h(__('Former member')) ?></i>
+            <?php endif; ?>
         <?php endif; ?>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>

--- a/src/Template/Element/wall/message.ctp
+++ b/src/Template/Element/wall/message.ctp
@@ -58,16 +58,20 @@ $canReply = false;
 
 <md-card id="message_<?= $messageId ?>" class="comment <?= $cssClass ?> <?= $messageHidden ? 'inappropriate' : '' ?>">
     <md-card-header>
+        <?php if (!$messageHidden || $canViewContent): ?>
         <md-card-avatar>
             <?= $this->Members->image($username, $avatar, array('class' => 'md-user-avatar')); ?>
         </md-card-avatar>
+        <?php endif; ?>
         <md-card-header-text>
-        <?php if ($username): ?>
-            <span class="md-title">
-                <a href="<?= $userProfileUrl ?>"><?= $username ?></a>
-            </span>
-        <?php else: ?>
-            <i><?= h(__('Former member')) ?></i>
+        <?php if (!$messageHidden || $canViewContent): ?>
+            <?php if ($username): ?>
+                <span class="md-title">
+                    <a href="<?= $userProfileUrl ?>"><?= $username ?></a>
+                </span>
+            <?php else: ?>
+                <i><?= h(__('Former member')) ?></i>
+            <?php endif; ?>
         <?php endif; ?>
             <span class="md-subhead ellipsis">
                 <?= $dateLabel ?>

--- a/src/Template/Element/wall/message.ctp
+++ b/src/Template/Element/wall/message.ctp
@@ -56,7 +56,7 @@ $cssClass = isset($isRoot) ? 'wall-thread' : 'reply';
 $canReply = false;
 ?>
 
-<md-card id="message_<?= $messageId ?>" class="comment <?= $cssClass ?> <?= $messageHidden ? 'inappropriate' : '' ?>">
+<md-card id="message_<?= $messageId ?>" class="comment <?= $cssClass ?>">
     <md-card-header>
         <?php if (!$messageHidden || $canViewContent): ?>
         <md-card-avatar>
@@ -104,7 +104,7 @@ $canReply = false;
         <?php } ?>
     </md-card-header>
 
-    <md-card-content>
+    <md-card-content class="<?= $messageHidden ? 'inappropriate' : '' ?>">
         <?php if ($messageHidden) { ?>
             <div class="warning-info" layout="row" layout-align="start center">
                 <md-icon>warning</md-icon>

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -266,12 +266,12 @@ html[dir="rtl"] .comment-sentence .text {
     text-align: right;
 }
 
-.comment.inappropriate .warning-info p {
+.comment .inappropriate .warning-info p {
     padding: 0 10px;
     margin: 0;
 }
 
-.comment.inappropriate > md-card-content > .content {
+.comment .inappropriate .content {
     color: #d50000;
     border-top: 1px #f1f1f1 solid;
     padding-top: 10px;
@@ -495,38 +495,6 @@ html[dir="rtl"] .comment-sentence .text {
 
 .message .body > .textarea {
     padding: 20px 20px 0 20px;
-}
-
-
-/*
- * Inappropriate messages
- */
-
-.inappropriate .body {
-    color: #CC2828;
-}
-
-.inappropriate .warningInfo {
-    color: #999;
-    padding: 10px 10px 10px 47px;
-    background: url(../../img/warning.svg) no-repeat 7px center;
-}
-
-.inappropriate .separator {
-    border-top: 1px dotted #ccc;
-}
-
-.inappropriate .header a {
-    color: #bbb;
-    text-decoration: none;
-}
-.inappropriate .username a, .inappropriate .menu a {
-    background-color: #f7f7f7;
-    border: 1px solid #ddd;
-}
-
-.inappropriate .username a {
-    border-left: none;
 }
 
 

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -271,7 +271,7 @@ html[dir="rtl"] .comment-sentence .text {
     margin: 0;
 }
 
-.comment.inappropriate .content {
+.comment.inappropriate > md-card-content > .content {
     color: #d50000;
     border-top: 1px #f1f1f1 solid;
     padding-top: 10px;


### PR DESCRIPTION
One of the community admins reported that it feels like a kind of "brandmarking" to have the username displayed along with the warning "this was against our rules" when a Wall post is hidden. See example below:

![image](https://user-images.githubusercontent.com/221850/163230716-6d4c4bd4-8662-4df1-91d0-034e037c869d.png)

Keeping the username displayed while the content is hidden has indeed no real benefits, and it was suggested that we only make this information visible to the admins and to the user who posted the comment.

This pull request hides the username as well as the profile picture to anyone who is not an admin or the author of the comment/post. It also fixes a bug where the replies below a hidden Wall post were displayed in red even though the post was not hidden.

![image](https://user-images.githubusercontent.com/221850/163232090-902aee26-76e3-4295-aaac-5a81eae5d187.png)
