### PR TITLE
Update sentence and sentence menu upon (un)adoption

### DIFF
--- a/src/Controller/SentencesController.php
+++ b/src/Controller/SentencesController.php
@@ -393,16 +393,17 @@ class SentencesController extends AppController
     private function renderAdopt($id)
     {
         $acceptsJson = $this->request->accepts('application/json');
-        $sentence = $this->Sentences->get($id, [
-            'contain' => ['Users' => ['fields' => ['username']]]
-        ]);
 
         if ($acceptsJson) {
+            $sentence = $this->Sentences->getSentenceWith($id);
             $this->loadComponent('RequestHandler');
-            $this->set('user', $sentence->user);
-            $this->set('_serialize', ['user']);
+            $this->set('sentence', $sentence);
+            $this->set('_serialize', ['sentence']);
             $this->RequestHandler->renderAs($this, 'json');
         } else {
+            $sentence = $this->Sentences->get($id, [
+                'contain' => ['Users' => ['fields' => ['username']]]
+            ]);
             $this->set('sentenceId', $id);
             $this->set('owner', $sentence->user);
             $this->viewBuilder()->setLayout('ajax');

--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -449,8 +449,10 @@
             var action = vm.sentence.is_owned_by_current_user ? 'let_go' : 'adopt';
             vm.iconsInProgress.adopt = true;
             $http.get(rootUrl + '/sentences/' + action + '/' + vm.sentence.id).then(function(result) {
-                vm.sentence.user = result.data.user;
-                vm.sentence.is_owned_by_current_user = vm.sentence.user && vm.sentence.user.username;
+                var sentence = result.data.sentence;
+                sentence.expandLabel = vm.sentence.expandLabel;
+                initSentence(sentence);
+                initMenu(!vm.isExpanded, sentence.permissions);
                 vm.iconsInProgress.adopt = false;
             });
         }


### PR DESCRIPTION
This pull request fixes inconsistent behavior in the new UI when a user adopts/unadopts a sentence.

When a user unadopts a sentence, they should no longer be able to edit the sentence because only the sentence "owner" can edit. And when a user adopts a sentence, they become the owner so they should be able to edit the sentence.

With the changes here, we makes sure that the edit button is removed after unadoption (this fixes #2232) and shown after adoption, and that the sentence data is up-to-date.

Related: #2351