### PR TITLE
Remove one-time binding on main sentence data

### DIFF
--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -101,12 +101,12 @@ $sentenceUrl = $this->Url->build([
             <md-subheader flex="auto">
                 <span ng-if="vm.sentence.user && vm.sentence.user.username">
                     <?php
-                    $linkText = $this->Pages->formatSentenceIdWithSharp('{{::vm.sentence.id}}');
+                    $linkText = $this->Pages->formatSentenceIdWithSharp('{{vm.sentence.id}}');
                     echo format(
                         __('Sentence {number} — belongs to {username}'),
                         array(
-                            'number' => '<a ng-href="'.$sentenceUrl.'/{{::vm.sentence.id}}">'.h($linkText).'</a>',
-                            'username' => '<a ng-href="'.$profileUrl.'/{{::vm.sentence.user.username}}">{{::vm.sentence.user.username}}</a>'
+                            'number' => '<a ng-href="'.$sentenceUrl.'/{{vm.sentence.id}}">'.h($linkText).'</a>',
+                            'username' => '<a ng-href="'.$profileUrl.'/{{vm.sentence.user.username}}">{{vm.sentence.user.username}}</a>'
                         )
                     );
                     ?>
@@ -116,7 +116,7 @@ $sentenceUrl = $this->Url->build([
                     echo format(
                         __('Sentence {number}'),
                         array(
-                            'number' => '<a ng-href="'.$sentenceUrl.'/{{::vm.sentence.id}}">#{{::vm.sentence.id}}</a>'
+                            'number' => '<a ng-href="'.$sentenceUrl.'/{{vm.sentence.id}}">#{{vm.sentence.id}}</a>'
                         )
                     );
                     ?>
@@ -131,13 +131,13 @@ $sentenceUrl = $this->Url->build([
                 <language-icon lang="vm.sentence.lang" title="vm.sentence.lang_name"></language-icon>
             </div>
             
-            <div class="text" dir="{{::vm.sentence.dir}}" lang="{{::vm.sentence.lang_tag}}">
+            <div class="text" dir="{{vm.sentence.dir}}" lang="{{vm.sentence.lang_tag}}">
                 <span ng-if="vm.sentence.highlightedText" ng-bind-html="vm.sentence.highlightedText"></span>
                 <span ng-if="!vm.sentence.highlightedText">
                     <span ng-if="vm.sentence.furigana" ng-bind-html="vm.sentence.furigana.html">
-                        <md-tooltip md-direction="top">{{::vm.sentence.furigana.info_message}}</md-tooltip>
+                        <md-tooltip md-direction="top">{{vm.sentence.furigana.info_message}}</md-tooltip>
                     </span>
-                    <span ng-if="!vm.sentence.furigana">{{::vm.sentence.text}}</span>
+                    <span ng-if="!vm.sentence.furigana">{{vm.sentence.text}}</span>
                 </span>
             </div>
             </div>


### PR DESCRIPTION
The main sentence otherwise doesn't change when loading a new random sentence.

Solves #2925.