### PR TITLE
Speedup background jobs startup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "cakephp/cakephp": "3.8.*",
         "cakephp/plugin-installer": "^1.0",
-        "dereuromark/cakephp-queue": "^3.11",
+        "dereuromark/cakephp-queue": "dev-cake3",
         "markstory/asset_compress": "^3.5",
         "patchwork/jsqueeze": "^2.0",
         "natxet/cssmin": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "AGPL-3.0-only",
     "description": "Code for tatoeba.org, a multilingual sentence and translation database",
     "require": {
-        "cakephp/cakephp": "3.7.*",
+        "cakephp/cakephp": "3.8.*",
         "cakephp/plugin-installer": "^1.0",
         "dereuromark/cakephp-queue": "^3.11",
         "markstory/asset_compress": "^3.5",
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0",
-        "cakephp/bake": "^1.8"
+        "cakephp/bake": "1.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a85bfdcc34e683bb78e0d91f2bc3539",
+    "content-hash": "253f8967c84827d4cc800f0760d6f095",
     "packages": [
         {
             "name": "aura/intl",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/auraphp/Aura.Intl.git",
-                "reference": "7fce228980b19bf4dee2d7bbd6202a69b0dde926"
+                "reference": "642cab45c9c88a217f89b65c2d7219a8cd7f803b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/auraphp/Aura.Intl/zipball/7fce228980b19bf4dee2d7bbd6202a69b0dde926",
-                "reference": "7fce228980b19bf4dee2d7bbd6202a69b0dde926",
+                "url": "https://api.github.com/repos/auraphp/Aura.Intl/zipball/642cab45c9c88a217f89b65c2d7219a8cd7f803b",
+                "reference": "642cab45c9c88a217f89b65c2d7219a8cd7f803b",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0"
+                "php": "^5.6 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "yoast/phpunit-polyfills": "~1.0"
             },
             "type": "library",
             "autoload": {
@@ -50,20 +53,24 @@
                 "l10n",
                 "localization"
             ],
-            "time": "2017-01-20T05:00:11+00:00"
+            "support": {
+                "issues": "https://github.com/auraphp/Aura.Intl/issues",
+                "source": "https://github.com/auraphp/Aura.Intl/tree/3.0.1"
+            },
+            "time": "2022-01-28T10:55:50+00:00"
         },
         {
             "name": "cakephp/cakephp",
-            "version": "3.7.9",
+            "version": "3.8.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/cakephp.git",
-                "reference": "1e89aa0399ce4c0f9af764e3b61aa24826278feb"
+                "reference": "1915d78f659d374224b2be0a5ad7822d96fb8366"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/1e89aa0399ce4c0f9af764e3b61aa24826278feb",
-                "reference": "1e89aa0399ce4c0f9af764e3b61aa24826278feb",
+                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/1915d78f659d374224b2be0a5ad7822d96fb8366",
+                "reference": "1915d78f659d374224b2be0a5ad7822d96fb8366",
                 "shasum": ""
             },
             "require": {
@@ -106,15 +113,15 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Cake\\": "src/"
-                },
                 "files": [
                     "src/Core/functions.php",
                     "src/Collection/functions.php",
                     "src/I18n/functions.php",
                     "src/Utility/bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Cake\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -139,7 +146,13 @@
                 "rapid-development",
                 "validation"
             ],
-            "time": "2019-06-20T01:33:59+00:00"
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp/issues",
+                "source": "https://github.com/cakephp/cakephp"
+            },
+            "time": "2020-06-19T18:52:08+00:00"
         },
         {
             "name": "cakephp/chronos",
@@ -166,12 +179,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Cake\\Chronos\\": "src/"
-                },
                 "files": [
                     "src/carbon_compat.php"
-                ]
+                ],
+                "psr-4": {
+                    "Cake\\Chronos\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -195,6 +208,11 @@
                 "datetime",
                 "time"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/chronos/issues",
+                "source": "https://github.com/cakephp/chronos"
+            },
             "time": "2019-11-30T02:33:19+00:00"
         },
         {
@@ -775,20 +793,23 @@
                 "request",
                 "response"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/master"
+            },
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/log",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
@@ -812,7 +833,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for logging libraries",
@@ -822,7 +843,10 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2020-03-23T09:12:05+00:00"
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -870,6 +894,9 @@
                 "psr-16",
                 "simple-cache"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/master"
+            },
             "time": "2017-10-23T01:57:42+00:00"
         },
         {
@@ -1232,20 +1259,23 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.20.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -1253,7 +1283,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1261,12 +1291,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1290,7 +1320,24 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-20T20:35:02+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -1425,20 +1472,23 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.20.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531"
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/39d483bdf39be819deabf04ec872eb0b2410b531",
-                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -1446,7 +1496,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1454,12 +1504,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1484,7 +1534,24 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.25.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-30T18:21:41+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -1860,6 +1927,10 @@
                 "psr",
                 "psr-7"
             ],
+            "support": {
+                "issues": "https://github.com/zendframework/zend-diactoros/issues",
+                "source": "https://github.com/zendframework/zend-diactoros"
+            },
             "abandoned": "laminas/laminas-diactoros",
             "time": "2019-08-06T17:53:53+00:00"
         }
@@ -1867,26 +1938,27 @@
     "packages-dev": [
         {
             "name": "ajgl/breakpoint-twig-extension",
-            "version": "0.3.4",
+            "version": "0.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ajgarlag/AjglBreakpointTwigExtension.git",
-                "reference": "13ee39406dc3d959c5704b462a3dbc3cbf088f16"
+                "reference": "9875feea0ac4bc3c9f308c62bae4727669d6052a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ajgarlag/AjglBreakpointTwigExtension/zipball/13ee39406dc3d959c5704b462a3dbc3cbf088f16",
-                "reference": "13ee39406dc3d959c5704b462a3dbc3cbf088f16",
+                "url": "https://api.github.com/repos/ajgarlag/AjglBreakpointTwigExtension/zipball/9875feea0ac4bc3c9f308c62bae4727669d6052a",
+                "reference": "9875feea0ac4bc3c9f308c62bae4727669d6052a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.6",
-                "twig/twig": "^1.14|^2.0"
+                "twig/twig": "^1.34|^2.0|^3.0"
             },
             "require-dev": {
-                "symfony/framework-bundle": "^2.7|^3.2|^4.1",
-                "symfony/phpunit-bridge": "^3.4|^4.1",
-                "symfony/twig-bundle": "^2.7|^3.2|^4.1"
+                "friendsofphp/php-cs-fixer": "^2.18",
+                "symfony/framework-bundle": "^2.7|^3.4|^4.4|^5.2",
+                "symfony/phpunit-bridge": "^4.4|^5.2",
+                "symfony/twig-bundle": "^2.7|^3.4|^4.4|^5.2"
             },
             "suggest": {
                 "ext-xdebug": "The Xdebug extension is required for the breakpoint to work",
@@ -1923,7 +1995,11 @@
                 "breakpoint",
                 "twig"
             ],
-            "time": "2019-04-10T11:41:26+00:00"
+            "support": {
+                "issues": "https://github.com/ajgarlag/AjglBreakpointTwigExtension/issues",
+                "source": "https://github.com/ajgarlag/AjglBreakpointTwigExtension/tree/0.3.5"
+            },
+            "time": "2021-02-08T10:48:05+00:00"
         },
         {
             "name": "aptoma/twig-markdown",
@@ -1980,6 +2056,10 @@
                 "markdown",
                 "twig"
             ],
+            "support": {
+                "issues": "https://github.com/aptoma/twig-markdown/issues",
+                "source": "https://github.com/aptoma/twig-markdown/tree/master"
+            },
             "time": "2015-10-23T20:27:08+00:00"
         },
         {
@@ -2035,24 +2115,29 @@
                 "extension",
                 "twig"
             ],
+            "support": {
+                "issues": "https://github.com/asm89/twig-cache-extension/issues",
+                "source": "https://github.com/asm89/twig-cache-extension/tree/1.4.0"
+            },
+            "abandoned": "twig/cache-extension",
             "time": "2020-01-01T20:47:37+00:00"
         },
         {
             "name": "cakephp/bake",
-            "version": "1.10.1",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/bake.git",
-                "reference": "b1fa1d2d4f3a6b74c69ab24c90c880dcc1f8751c"
+                "reference": "33e8ee8419ba36c13fa4074c208c93352b5530cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/bake/zipball/b1fa1d2d4f3a6b74c69ab24c90c880dcc1f8751c",
-                "reference": "b1fa1d2d4f3a6b74c69ab24c90c880dcc1f8751c",
+                "url": "https://api.github.com/repos/cakephp/bake/zipball/33e8ee8419ba36c13fa4074c208c93352b5530cf",
+                "reference": "33e8ee8419ba36c13fa4074c208c93352b5530cf",
                 "shasum": ""
             },
             "require": {
-                "cakephp/cakephp": "~3.7.0",
+                "cakephp/cakephp": "^3.8.0",
                 "cakephp/plugin-installer": "^1.0",
                 "php": ">=5.6.0",
                 "wyrihaximus/twig-view": "^4.3.7"
@@ -2064,7 +2149,7 @@
             "type": "cakephp-plugin",
             "autoload": {
                 "psr-4": {
-                    "Bake\\": "src"
+                    "Bake\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2083,7 +2168,13 @@
                 "bake",
                 "cakephp"
             ],
-            "time": "2019-07-01T21:34:33+00:00"
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/bake/issues",
+                "source": "https://github.com/cakephp/bake"
+            },
+            "time": "2019-12-07T20:34:43+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -2194,6 +2285,10 @@
                 "text",
                 "time"
             ],
+            "support": {
+                "issues": "https://github.com/jasny/twig-extensions/issues",
+                "source": "https://github.com/jasny/twig-extensions"
+            },
             "time": "2017-09-13T07:38:01+00:00"
         },
         {
@@ -3549,16 +3644,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.44.1",
+            "version": "v1.44.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "04b15d4c0bb18ddbf82626320ac07f6a73f199c9"
+                "reference": "ae39480f010ef88adc7938503c9b02d3baf2f3b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04b15d4c0bb18ddbf82626320ac07f6a73f199c9",
-                "reference": "04b15d4c0bb18ddbf82626320ac07f6a73f199c9",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ae39480f010ef88adc7938503c9b02d3baf2f3b3",
+                "reference": "ae39480f010ef88adc7938503c9b02d3baf2f3b3",
                 "shasum": ""
             },
             "require": {
@@ -3609,7 +3704,21 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2020-10-27T19:22:48+00:00"
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v1.44.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-25T13:31:46+00:00"
         },
         {
             "name": "umpirsky/twig-php-function",
@@ -3650,6 +3759,10 @@
                 }
             ],
             "description": "Call (almost) any PHP function from your Twig templates.",
+            "support": {
+                "issues": "https://github.com/umpirsky/twig-php-function/issues",
+                "source": "https://github.com/umpirsky/twig-php-function/tree/master"
+            },
             "time": "2016-03-12T16:36:32+00:00"
         },
         {
@@ -3703,23 +3816,23 @@
         },
         {
             "name": "wyrihaximus/twig-view",
-            "version": "4.3.8",
+            "version": "4.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WyriHaximus/TwigView.git",
-                "reference": "a5ec66690aa045d6eda17ab1c8a5baf0efdcfa45"
+                "url": "https://github.com/cakephp/legacy-twig-view.git",
+                "reference": "463e1a6ed493d4fe99eaeaaf39d80172b51fc0fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WyriHaximus/TwigView/zipball/a5ec66690aa045d6eda17ab1c8a5baf0efdcfa45",
-                "reference": "a5ec66690aa045d6eda17ab1c8a5baf0efdcfa45",
+                "url": "https://api.github.com/repos/cakephp/legacy-twig-view/zipball/463e1a6ed493d4fe99eaeaaf39d80172b51fc0fb",
+                "reference": "463e1a6ed493d4fe99eaeaaf39d80172b51fc0fb",
                 "shasum": ""
             },
             "require": {
                 "ajgl/breakpoint-twig-extension": "^0.3.0",
                 "aptoma/twig-markdown": "^2.0",
                 "asm89/twig-cache-extension": "^1.0",
-                "cakephp/cakephp": "^3.6",
+                "cakephp/cakephp": "^3.7",
                 "jasny/twig-extensions": "^1.0",
                 "php": "^5.6 || ^7.0",
                 "twig/twig": "^1.27",
@@ -3728,9 +3841,9 @@
             "require-dev": {
                 "cakephp/bake": "^1.5",
                 "cakephp/debug_kit": "^3.0",
-                "phake/phake": "^1.0.4",
+                "phake/phake": "^2.3.2",
                 "phpunit/phpunit": "^5.7.14",
-                "squizlabs/php_codesniffer": "^1.5.6",
+                "squizlabs/php_codesniffer": "^3.4.0",
                 "wyrihaximus/phpunit-class-reflection-helpers": "dev-master"
             },
             "type": "cakephp-plugin",
@@ -3757,7 +3870,11 @@
                 "twig",
                 "view"
             ],
-            "time": "2018-12-17T21:08:25+00:00"
+            "support": {
+                "issues": "https://github.com/cakephp/legacy-twig-view/issues",
+                "source": "https://github.com/cakephp/legacy-twig-view/tree/4.4.0"
+            },
+            "time": "2021-04-06T15:42:50+00:00"
         }
     ],
     "aliases": [],
@@ -3766,5 +3883,9 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.3.31"
+    },
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "253f8967c84827d4cc800f0760d6f095",
+    "content-hash": "a28a015b0ea6803959568c05a2b31994",
     "packages": [
         {
             "name": "aura/intl",
@@ -356,27 +356,30 @@
         },
         {
             "name": "dereuromark/cakephp-queue",
-            "version": "3.16.2",
+            "version": "dev-cake3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-queue.git",
-                "reference": "914bc5acaeac642c196e49d3bc5f53cfc7edc700"
+                "reference": "847e7ed7707562029fa5593880286f6bd1b1e6b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-queue/zipball/914bc5acaeac642c196e49d3bc5f53cfc7edc700",
-                "reference": "914bc5acaeac642c196e49d3bc5f53cfc7edc700",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-queue/zipball/847e7ed7707562029fa5593880286f6bd1b1e6b4",
+                "reference": "847e7ed7707562029fa5593880286f6bd1b1e6b4",
                 "shasum": ""
             },
             "require": {
-                "cakephp/cakephp": "^3.7",
+                "cakephp/cakephp": "^3.8",
                 "php": ">=5.6"
             },
+            "conflict": {
+                "dereuromark/cakephp-ide-helper": "<0.14"
+            },
             "require-dev": {
-                "cakephp/migrations": "^1.0",
-                "dereuromark/cakephp-ide-helper": "^0.12",
-                "dereuromark/cakephp-tools": "^1.5.6",
-                "fig-r/psr2r-sniffer": "dev-master",
+                "cakephp/migrations": "^2.0",
+                "dereuromark/cakephp-ide-helper": "0.*",
+                "dereuromark/cakephp-tools": "^1.9.7",
+                "fig-r/psr2r-sniffer": "^0.6",
                 "friendsofcake/search": "^5.0"
             },
             "suggest": {
@@ -415,7 +418,11 @@
                 "deferred tasks",
                 "queue"
             ],
-            "time": "2019-04-05T00:23:37+00:00"
+            "support": {
+                "issues": "https://github.com/dereuromark/cakephp-queue/issues",
+                "source": "https://github.com/dereuromark/cakephp-queue"
+            },
+            "time": "2021-03-09T19:44:02+00:00"
         },
         {
             "name": "league/climate",
@@ -3879,7 +3886,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "dereuromark/cakephp-queue": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/config/app_queue.php
+++ b/config/app_queue.php
@@ -49,6 +49,6 @@ return [
         // Allow workers to wake up from their "nothing to do, sleeping" state when using QueuedJobs->wakeUpWorkers().
         // This method sends a SIGUSR1 to workers to interrupt any sleep() operation like it was their time to finish.
         // This option breaks tasks expecting sleep() to always sleep for the provided duration without interrupting.
-        'canInterruptSleep' => false,
+        'canInterruptSleep' => true,
     ],
 ];

--- a/config/app_queue.php
+++ b/config/app_queue.php
@@ -1,25 +1,54 @@
 <?php
 return [
     'Queue' => [
-        // seconds to sleep() when no executable job is found
-        'sleeptime' => 10,
-        // probability in percent of a old job cleanup happening
-        'gcprob' => 10,
         // time (in seconds) after which a job is requeued if the worker doesn't report back
         'defaultworkertimeout' => 120,
-        // number of retries if a job fails or times out.
-        'defaultworkerretries' => 4,
+
         // seconds of running time after which the worker will terminate (0 = unlimited)
         'workermaxruntime' => 20*60,
+
         // minimum time (in seconds) which a task remains in the database before being cleaned up.
         'cleanuptimeout' => 2000,
+
+        // number of retries if a job fails or times out.
+        'defaultworkerretries' => 4,
+
+        // seconds to sleep() when no executable job is found
+        'sleeptime' => 10,
+
+        // probability in percent of a old job cleanup happening
+        'gcprob' => 10,
+
+        // set to true for multi server setup, this will affect web backend possibilities to kill/end workers
+        'multiserver' => false,
+
+        // set this to a limit that can work with your memory limits and alike, 0 => no limit
+        'maxworkers' => 1,
+
         // instruct a Workerprocess quit when there are no more tasks for it to execute (true = exit, false = keep running)
         'exitwhennothingtodo' => false,
-        // pid file path directory (by default goes to the app/tmp/queue folder)
-        'pidfilepath' => TMP . 'queue' . DS,
+
+        // seconds of running time after which the PHP process will terminate, null uses workermaxruntime * 100
+        'workertimeout' => null,
+
         // determine whether logging is enabled
         'log' => true,
-        // set to false to disable (tmp = file in TMP dir)
-        'notify' => 'tmp',
+
+        // set default Mailer class
+        'mailerClass' => 'Cake\Mailer\Email',
+
+        // set default datasource connection
+        'connection' => null,
+
+        // enable Search. requires friendsofcake/search
+        'isSearchEnabled' => true,
+
+        // enable Search. requires frontend assets
+        'isStatisticEnabled' => false,
+
+        // Allow workers to wake up from their "nothing to do, sleeping" state when using QueuedJobs->wakeUpWorkers().
+        // This method sends a SIGUSR1 to workers to interrupt any sleep() operation like it was their time to finish.
+        // This option breaks tasks expecting sleep() to always sleep for the provided duration without interrupting.
+        'canInterruptSleep' => false,
     ],
 ];

--- a/src/Model/Licensing.php
+++ b/src/Model/Licensing.php
@@ -41,6 +41,7 @@ class Licensing {
                 compact('listId', 'userId'),
                 ['group' => $userId]
             );
+            $this->QueuedJobs->wakeUpWorkers();
         }
     }
 

--- a/src/Model/Licensing.php
+++ b/src/Model/Licensing.php
@@ -57,11 +57,15 @@ class Licensing {
             'listId' => $listId,
             'sendReport' => true,
         );
-        return (bool)$this->QueuedJobs->createJob(
+        $ok = (bool)$this->QueuedJobs->createJob(
             'SwitchSentencesLicense',
             $options,
             ['group' => $userId]
         );
+        if ($ok) {
+            $this->QueuedJobs->wakeUpWorkers();
+        }
+        return $ok;
     }
 
     public function is_refreshing($userId) {

--- a/src/Model/Table/AudiosTable.php
+++ b/src/Model/Table/AudiosTable.php
@@ -305,9 +305,11 @@ class AudiosTable extends Table
     }
 
     public function enqueueImportTask($author) {
-        return $this->QueuedJobs->createJob(
+        $job = $this->QueuedJobs->createJob(
             self::JOB_TYPE,
             compact('author')
         );
+        $this->QueuedJobs->wakeUpWorkers();
+        return $job;
     }
 }

--- a/src/Model/Table/ExportsTable.php
+++ b/src/Model/Table/ExportsTable.php
@@ -124,6 +124,7 @@ class ExportsTable extends Table
                         $config,
                         ['group' => $export->user_id]
                     );
+                    $this->QueuedJobs->wakeUpWorkers();
                     $export->queued_job_id = $job->id;
                     if ($this->save($export)) {
                         return $export->extract(['id', 'name', 'status']);

--- a/tests/TestCase/Controller/ExportsControllerTest.php
+++ b/tests/TestCase/Controller/ExportsControllerTest.php
@@ -19,6 +19,7 @@ class ExportsControllerTest extends IntegrationTestCase
         'app.UsersLanguages',
         'app.PrivateMessages',
         'app.QueuedJobs',
+        'plugin.Queue.QueueProcesses',
     ];
 
     private $testExportDir = TMP.'export_tests'.DS;

--- a/tests/TestCase/Controller/ExportsControllerTest.php
+++ b/tests/TestCase/Controller/ExportsControllerTest.php
@@ -109,11 +109,10 @@ class ExportsControllerTest extends IntegrationTestCase
     private function assertFileDownload($filename, $filesize)
     {
         $this->assertResponseOk();
-        $this->assertContentType('application/zip');
+        $this->assertContentType('application/octet-stream');
         $this->assertHeader('Content-Length', (string)$filesize);
         $this->assertHeader('Accept-Ranges', 'bytes');
         $this->assertNoHeader('Content-Disposition');
-        $this->assertHeader('Content-Type', 'application/octet-stream');
         $this->assertHeader('X-Accel-Redirect', "/export_tests/$filename");
         $this->assertResponseEquals('');
     }

--- a/tests/TestCase/Model/Table/AudiosTableTest.php
+++ b/tests/TestCase/Model/Table/AudiosTableTest.php
@@ -235,8 +235,8 @@ class AudiosTableTest extends TestCase {
 
         $added = $this->Audio->assignAudioTo(2, 'contributor');
         $returned = $this->Audio->get($added->id);
-        $this->assertEquals($added->created, $returned->created);
-        $this->assertEquals($added->modified, $returned->modified);
+        $this->assertEquals($added->created->format('Y-m-d H:i:s'), $returned->created->format('Y-m-d H:i:s'));
+        $this->assertEquals($added->modified->format('Y-m-d H:i:s'), $returned->modified->format('Y-m-d H:i:s'));
 
         I18n::setLocale($prevLocale);
     }

--- a/tests/TestCase/Model/Table/SentenceCommentsTableTest.php
+++ b/tests/TestCase/Model/Table/SentenceCommentsTableTest.php
@@ -136,8 +136,8 @@ class SentenceCommentTest extends TestCase {
         ]);
         $added = $this->SentenceComment->save($comment);
         $returned = $this->SentenceComment->get($added->id);
-        $this->assertEquals($added->created, $returned->created);
-        $this->assertEquals($added->modified, $returned->modified);
+        $this->assertEquals($added->created->format('Y-m-d H:i:s'), $returned->created->format('Y-m-d H:i:s'));
+        $this->assertEquals($added->modified->format('Y-m-d H:i:s'), $returned->modified->format('Y-m-d H:i:s'));
 
         I18n::setLocale($prevLocale);
     }

--- a/tests/TestCase/Model/Table/SentencesListsTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesListsTableTest.php
@@ -512,8 +512,8 @@ class SentencesListsTableTest extends TestCase {
 
         $added = $this->SentencesList->createList('arabic', 1);
         $returned = $this->SentencesList->get($added->id);
-        $this->assertEquals($added->created, $returned->created);
-        $this->assertEquals($added->modified, $returned->modified);
+        $this->assertEquals($added->created->format('Y-m-d H:i:s'), $returned->created->format('Y-m-d H:i:s'));
+        $this->assertEquals($added->modified->format('Y-m-d H:i:s'), $returned->modified->format('Y-m-d H:i:s'));
 
         I18n::setLocale($prevLocale);
     }

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -1439,8 +1439,8 @@ class SentencesTableTest extends TestCase {
 
         $added = $this->Sentence->saveNewSentence('test', 'eng', 1);
         $returned = $this->Sentence->get($added->id);
-        $this->assertEquals($added->created, $returned->created);
-        $this->assertEquals($added->modified, $returned->modified);
+        $this->assertEquals($added->created->format('Y-m-d H:i:s'), $returned->created->format('Y-m-d H:i:s'));
+        $this->assertEquals($added->modified->format('Y-m-d H:i:s'), $returned->modified->format('Y-m-d H:i:s'));
 
         I18n::setLocale($prevLocale);
     }

--- a/tests/TestCase/Model/Table/TagsSentencesTableTest.php
+++ b/tests/TestCase/Model/Table/TagsSentencesTableTest.php
@@ -48,7 +48,7 @@ class TagsSentencesTableTest extends TestCase {
 
         $added = $this->TagsSentences->tagSentence(1, 2, 3);
         $returned = $this->TagsSentences->get($added->id);
-        $this->assertEquals($added->added_time, $returned->added_time);
+        $this->assertEquals($added->added_time->format('Y-m-d H:i:s'), $returned->added_time->format('Y-m-d H:i:s'));
 
         I18n::setLocale($prevLocale);
     }

--- a/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/tests/TestCase/Model/Table/TagsTableTest.php
@@ -165,7 +165,7 @@ class TagsTableTest extends TestCase {
 
         $added = $this->Tag->addTag('arabic', 4);
         $returned = $this->Tag->get($added->id);
-        $this->assertEquals($added->created, $returned->created);
+        $this->assertEquals($added->created->format('Y-m-d H:i:s'), $returned->created->format('Y-m-d H:i:s'));
 
         I18n::setLocale($prevLocale);
     }

--- a/tests/TestCase/Model/Table/TranscriptionsTableTest.php
+++ b/tests/TestCase/Model/Table/TranscriptionsTableTest.php
@@ -615,8 +615,8 @@ class TranscriptionsTableTest extends TestCase {
         $transcription = $this->Transcription->newEntity($data);
         $added = $this->Transcription->save($transcription);
         $returned = $this->Transcription->get($added->id);
-        $this->assertEquals($added->created, $returned->created);
-        $this->assertEquals($added->modified, $returned->modified);
+        $this->assertEquals($added->created->format('Y-m-d H:i:s'), $returned->created->format('Y-m-d H:i:s'));
+        $this->assertEquals($added->modified->format('Y-m-d H:i:s'), $returned->modified->format('Y-m-d H:i:s'));
 
         I18n::setLocale($prevLocale);
     }

--- a/tests/TestCase/Model/Table/UsersVocabularyTableTest.php
+++ b/tests/TestCase/Model/Table/UsersVocabularyTableTest.php
@@ -53,7 +53,7 @@ class UsersVocabularyTableTest extends TestCase
 
         $added = $this->UsersVocabulary->add(1, 3);
         $returned = $this->UsersVocabulary->get($added->id);
-        $this->assertEquals($added->created, $returned->created);
+        $this->assertEquals($added->created->format('Y-m-d H:i:s'), $returned->created->format('Y-m-d H:i:s'));
 
         I18n::setLocale($prevLocale);
     }

--- a/tests/TestCase/Model/Table/VocabularyTableTest.php
+++ b/tests/TestCase/Model/Table/VocabularyTableTest.php
@@ -62,7 +62,7 @@ class VocabularyTableTest extends TestCase
 
         $added = $this->Vocabulary->addItem('eng', 'test');
         $returned = $this->Vocabulary->get($added->id);
-        $this->assertEquals($added->created, $returned->created);
+        $this->assertEquals($added->created->format('Y-m-d H:i:s'), $returned->created->format('Y-m-d H:i:s'));
 
         I18n::setLocale($prevLocale);
     }

--- a/tests/TestCase/Model/Table/WallTableTest.php
+++ b/tests/TestCase/Model/Table/WallTableTest.php
@@ -281,8 +281,8 @@ class WallTest extends TestCase {
         $post = $this->Wall->newEntity(['content' => 'test', 'owner' => 1]);
         $added = $this->Wall->save($post);
         $returned = $this->Wall->get($added->id);
-        $this->assertEquals($added->date, $returned->date);
-        $this->assertEquals($added->modified, $returned->modified);
+        $this->assertEquals($added->date->format('Y-m-d H:i:s'), $returned->date->format('Y-m-d H:i:s'));
+        $this->assertEquals($added->modified->format('Y-m-d H:i:s'), $returned->modified->format('Y-m-d H:i:s'));
 
         I18n::setLocale($prevLocale);
     }

--- a/tests/TestCase/Model/Table/WallTableTest.php
+++ b/tests/TestCase/Model/Table/WallTableTest.php
@@ -62,8 +62,8 @@ class WallTest extends TestCase {
         ]);
         $saved = $this->Wall->save($newPost);
         
-        $this->assertEquals($saved->date, $saved->modified);
         $this->assertNotNull($saved->date);
+        $this->assertEquals($saved->date->format('Y-m-d H:i:s'), $saved->modified->format('Y-m-d H:i:s'));
     }
 
     public function testSave_doesNotSaveNewPostIfContentIsEmpty() {

--- a/webroot/js/downloads/export.ctrl.js
+++ b/webroot/js/downloads/export.ctrl.js
@@ -14,7 +14,7 @@
             $scope.preparingDownload = false;
         }
 
-        $scope.tryToDownloadExport = function() {
+        $scope.tryToDownloadExport = function(waitForMs = 5000) {
             $timeout.cancel($scope.tryAgainPromise);
             $scope.tryAgainPromise = $timeout(function() {
                 $http.get(rootUrl + "/exports/get/" + $scope.export.id)
@@ -33,7 +33,7 @@
                         $scope.preparingDownload = false;
                     }
                 );
-            }, 5000);
+            }, waitForMs);
         }
 
         $scope.addExport = function (type, fields, extraParams = {}) {
@@ -51,7 +51,7 @@
                  .then(
                     function(response) {
                         $scope.export = response.data.export;
-                        $scope.tryToDownloadExport();
+                        $scope.tryToDownloadExport(0);
                     },
                     function(errorResponse) {
                         $scope.preparingDownload = false;

--- a/webroot/js/sentences_lists/download.ctrl.js
+++ b/webroot/js/sentences_lists/download.ctrl.js
@@ -12,7 +12,7 @@
             $scope.preparingDownload = false;
         }
 
-        $scope.tryToDownloadList = function() {
+        $scope.tryToDownloadList = function(waitForMs = 5000) {
             $timeout.cancel($scope.tryAgainPromise);
             $scope.tryAgainPromise = $timeout(function() {
                 $http.get(rootUrl + "/exports/get/" + $scope.export.id)
@@ -31,7 +31,7 @@
                         $scope.preparingDownload = false;
                     }
                 );
-            }, 5000);
+            }, waitForMs);
         }
 
         $scope.addListExport = function (listId) {
@@ -53,7 +53,7 @@
                  .then(
                     function(response) {
                         $scope.export = response.data.export;
-                        $scope.tryToDownloadList();
+                        $scope.tryToDownloadList(0);
                     },
                     function(errorResponse) {
                         $scope.preparingDownload = false;


### PR DESCRIPTION
This is a minor improvement I have been wanting to do for a while. It allows background jobs (currently audio import, list download and language pair export download) to start immediately when the worker is idle, instead of having to wait for up to 10 seconds that the worker pick up the newly-enqueued task. This brings a substantial speedup for the user when the job execution time is nearly instant (e.g. download of a small list, audio import of a few files, or language pair export involving a language with few sentences).

I had to update from CakePHP 3.7 to 3.8 because the dependency dereuromark/cakephp-queue requires it.

:warning: This PR could cause various regressions on Tatoeba because of the CakePHP update. Needs testing.