### PR TITLE
Make sentence page responsive

### DIFF
--- a/src/Template/Element/search_bar.ctp
+++ b/src/Template/Element/search_bar.ctp
@@ -115,7 +115,8 @@ echo $this->Form->create(
         </div>
     </div>
 
-    <div layout="row" layout-align="center end">
+    <div layout-gt-xs="row" layout-align-gt-xs="center end"
+         layout="column" layout-align="center center">
         <div layout="column">
             <?php /* @translators: search language field label in top search bar */ ?>
             <label for="SentenceFrom"><?= __('From') ?></label>

--- a/src/Template/Element/sentences/navigation.ctp
+++ b/src/Template/Element/sentences/navigation.ctp
@@ -23,7 +23,7 @@ $sentenceUrl = $this->Url->build([
                        ng-disabled="!vm.prev">
                 <md-icon>keyboard_arrow_left</md-icon>
                 <?php /* @translators: link to neighbour sentence on sentence page */ ?>
-                <?= __('previous') ?>
+                <span hide-xs><?= __('previous') ?></span>
             </md-button>
 
             <md-button ng-href="<?= $sentenceUrl ?>/{{vm.lang}}" class="md-primary">
@@ -34,7 +34,7 @@ $sentenceUrl = $this->Url->build([
             <md-button ng-href="<?= $sentenceUrl ?>/{{vm.next}}" class="md-primary"
                        ng-disabled="!vm.next">
                 <?php /* @translators: link to neighbour sentence on sentence page */ ?>
-                <?= __('next') ?>
+                <span hide-xs><?= __('next') ?></span>
                 <md-icon>keyboard_arrow_right</md-icon>
             </md-button>
         </div>
@@ -66,6 +66,7 @@ $sentenceUrl = $this->Url->build([
         'id' => 'go-to-form',
         'url' => ['action' => 'go_to_sentence'],
         'type' => 'get',
+        'hide-xs' => '',
         'layout' => 'row',
         'layout-align' => 'center center'
     ]);

--- a/src/Template/Element/sentences/navigation.ctp
+++ b/src/Template/Element/sentences/navigation.ctp
@@ -15,27 +15,29 @@ $sentenceUrl = $this->Url->build([
 ?>
 <div ng-app="app" ng-controller="SentencesNavigationController as vm" 
      ng-init="vm.init('<?= $selectedLanguage ?>', <?= $currentId ?>, <?= $prev ?>, <?= $next ?>)" 
-     class="navigation" layout="row" ng-cloak>
+     class="navigation" layout="row" layout-align="center center" layout-wrap ng-cloak>
 
-    <div layout="row" layout-align="space-around center" layout-margin flex>
-        <md-button ng-href="<?= $sentenceUrl ?>/{{vm.prev}}" class="md-primary"
-                   ng-disabled="!vm.prev">
-            <md-icon>keyboard_arrow_left</md-icon>
-            <?php /* @translators: link to neighbour sentence on sentence page */ ?>
-            <?= __('previous') ?>
-        </md-button>
+    <div layout="row" layout-align="space-around center" layout-margin layout-wrap flex="auto">
+        <div layout="row" layout-align="space-around center" flex="noshrink">
+            <md-button ng-href="<?= $sentenceUrl ?>/{{vm.prev}}" class="md-primary"
+                       ng-disabled="!vm.prev">
+                <md-icon>keyboard_arrow_left</md-icon>
+                <?php /* @translators: link to neighbour sentence on sentence page */ ?>
+                <?= __('previous') ?>
+            </md-button>
 
-        <md-button ng-href="<?= $sentenceUrl ?>/{{vm.lang}}" class="md-primary">
-            <?php /* @translators: link to a random sentence on sentence page */ ?>
-            <?= __('random') ?>
-        </md-button>
+            <md-button ng-href="<?= $sentenceUrl ?>/{{vm.lang}}" class="md-primary">
+                <?php /* @translators: link to a random sentence on sentence page */ ?>
+                <?= __('random') ?>
+            </md-button>
 
-        <md-button ng-href="<?= $sentenceUrl ?>/{{vm.next}}" class="md-primary"
-                   ng-disabled="!vm.next">
-            <?php /* @translators: link to neighbour sentence on sentence page */ ?>
-            <?= __('next') ?>
-            <md-icon>keyboard_arrow_right</md-icon>
-        </md-button>
+            <md-button ng-href="<?= $sentenceUrl ?>/{{vm.next}}" class="md-primary"
+                       ng-disabled="!vm.next">
+                <?php /* @translators: link to neighbour sentence on sentence page */ ?>
+                <?= __('next') ?>
+                <md-icon>keyboard_arrow_right</md-icon>
+            </md-button>
+        </div>
 
         <div>
         <md-tooltip md-direction="top">

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -77,7 +77,11 @@ $isHomepage = $controller == 'pages' && $action == 'index';
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <?php } ?>
 </head>
-<body ng-app="app">
+<body ng-app="app"
+    <?php if (isset($isResponsive) && $isResponsive) { ?>
+        class="responsive"
+    <?php } ?>
+>
     <!--  TOP  -->
     <?php echo $this->element('top_menu', ['htmlDir' => $htmlDir]); ?>
 

--- a/src/Template/Sentences/show.ctp
+++ b/src/Template/Sentences/show.ctp
@@ -71,7 +71,112 @@ echo $this->element('/sentences/navigation', [
 ]);
 ?>
 <br>
-<div id="annexe_content">
+
+<section layout="row" ng-cloak>
+<md-content class="md-whiteframe-1dp" flex>
+    <section>
+        <md-toolbar class="md-hue-2">
+            <div class="md-toolbar-tools">
+                <h2 flex><?= format(__('Sentence #{number}'), array('number' => $sentenceId)); ?></h2>
+                <md-button hide-gt-sm ng-controller="SidenavController" ng-click="toggle('metadata')">
+                    <md-icon>info_outline</md-icon>
+                    <?php /* @translators: button to open the sidebar on the sentence page on mobile */ ?>
+                    <?= __('Metadata') ?>
+                </md-button>
+            </div>
+        </md-toolbar>
+
+        <?php
+        if (isset($sentence)) {
+            if (CurrentUser::isMember() && !CurrentUser::getSetting('use_new_design')) {
+                ?><div class="section md-whiteframe-1dp"><?php
+                $this->Sentences->displaySentencesGroup($sentence);
+                ?></div><?php
+            } else {
+                echo $this->element(
+                    'sentences/sentence_and_translations',
+                    array(
+                        'sentence' => $sentence,
+                        'translations' => $sentence->translations,
+                        'user' => $sentence->user
+                    )
+                );
+            }
+        } else {
+            echo '<div class="error">';
+                echo format(
+                    __(
+                        'There is no sentence with id {number}',
+                        true
+                    ),
+                    array('number' => $this->request->params['pass'][0])
+                );
+            echo '</div>';
+        }
+        ?>
+    </section>
+
+    <section class="md-whiteframe-1dp">
+        <md-toolbar class="md-hue-2">
+            <div class="md-toolbar-tools">
+                <?php /* @translators: header text in sentence page */ ?>
+                <h2><?= __('Comments'); ?></h2>
+            </div>
+        </md-toolbar>
+
+        <md-content>
+        <?php
+        if (!$sentenceComments->isEmpty()) {
+            foreach ($sentenceComments as $i=>$comment) {
+                $menu = $this->Comments->getMenuForComment(
+                    $comment,
+                    $commentsPermissions[$i],
+                    false
+                );
+
+                echo '<a id="comment-'.$comment->id.'"></a>';
+
+                echo $this->element(
+                    'sentence_comments/comment',
+                    array(
+                        'comment' => $comment,
+                        'menu' => $menu,
+                        'replyIcon' => false,
+                        'hideSentence' => true
+                    )
+                );
+            }
+        } else {
+            ?>
+            <div layout-padding class="center">
+                <p><?= __('There are no comments for now.') ?></p>
+            </div>
+            <?php
+        }
+
+        if ($canComment) {
+            echo $this->element('sentence_comments/add_form', [
+                'sentenceId' => $sentenceId
+            ]);
+        }
+        ?>
+        </md-content>
+    </section>
+</md-content>
+
+<md-sidenav class="md-sidenav-right md-whiteframe-1dp"
+            md-component-id="metadata"
+            md-disable-scroll-target="body"
+            md-is-locked-open="$mdMedia('gt-sm')">
+    <md-toolbar>
+        <div class="md-toolbar-tools" ng-controller="SidenavController">
+            <?php /* @translators: title for the sidebar on the sentence page */ ?>
+            <h2 flex><?= __('Metadata'); ?></h2>
+            <md-button class="close md-icon-button" ng-click="toggle('metadata')">
+                <md-icon>close</md-icon>
+            </md-button>
+        </div>
+    </md-toolbar>
     <?php
     if (CurrentUser::get('settings.users_collections_ratings')) {
         echo '<div class="section correctness-info md-whiteframe-1dp">';
@@ -169,93 +274,8 @@ echo $this->element('/sentences/navigation', [
         }
         ?>
     </div>
-</div>
-
-<div id="main_content">
-    <section>
-        <md-toolbar class="md-hue-2">
-            <div class="md-toolbar-tools">
-                <h2><?= format(__('Sentence #{number}'), array('number' => $sentenceId)); ?></h2>
-            </div>
-        </md-toolbar>
-
-        <?php
-        if (isset($sentence)) {
-            if (CurrentUser::isMember() && !CurrentUser::getSetting('use_new_design')) {
-                ?><div class="section md-whiteframe-1dp"><?php
-                $this->Sentences->displaySentencesGroup($sentence);
-                ?></div><?php
-            } else {
-                echo $this->element(
-                    'sentences/sentence_and_translations',
-                    array(
-                        'sentence' => $sentence,
-                        'translations' => $sentence->translations,
-                        'user' => $sentence->user
-                    )
-                );
-            }
-        } else {
-            echo '<div class="error">';
-                echo format(
-                    __(
-                        'There is no sentence with id {number}',
-                        true
-                    ),
-                    array('number' => $this->request->params['pass'][0])
-                );
-            echo '</div>';
-        }
-        ?>
-    </section>
-
-    <section class="md-whiteframe-1dp">
-        <md-toolbar class="md-hue-2">
-            <div class="md-toolbar-tools">
-                <?php /* @translators: header text in sentence page */ ?>
-                <h2><?= __('Comments'); ?></h2>
-            </div>
-        </md-toolbar>
-        
-        <md-content>
-        <?php
-        if (!$sentenceComments->isEmpty()) {
-            foreach ($sentenceComments as $i=>$comment) {
-                $menu = $this->Comments->getMenuForComment(
-                    $comment,
-                    $commentsPermissions[$i],
-                    false
-                );
-
-                echo '<a id="comment-'.$comment->id.'"></a>';
-
-                echo $this->element(
-                    'sentence_comments/comment',
-                    array(
-                        'comment' => $comment,
-                        'menu' => $menu,
-                        'replyIcon' => false,
-                        'hideSentence' => true
-                    )
-                );
-            }
-        } else {
-            ?>
-            <div layout-padding class="center">
-                <p><?= __('There are no comments for now.') ?></p>
-            </div>
-            <?php
-        }
-
-        if ($canComment) {
-            echo $this->element('sentence_comments/add_form', [
-                'sentenceId' => $sentenceId
-            ]);
-        }
-        ?>
-        </md-content>
-    </section>
-</div>
+</md-sidenav>
+</section>
 <?php
 } else {
 ?>

--- a/src/Template/Sentences/show.ctp
+++ b/src/Template/Sentences/show.ctp
@@ -26,6 +26,10 @@
  */
 use App\Model\CurrentUser;
 
+if (!CurrentUser::isMember() || CurrentUser::getSetting('use_new_design')) {
+    $this->set('isResponsive', true);
+}
+
 if (!isset($searchProblem)) {
 if (isset($sentence)) {
     $sentenceId = $sentence->id;

--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -386,7 +386,7 @@ html[dir="rtl"] #user-menu .dropdown-content {
 }
 
 #SentenceQuery {
-    width: 400px;
+    max-width: 400px;
     font-size: 20px;
     padding: 5px 30px 5px 5px;
     border: 1px solid #DDDDDD;

--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -459,7 +459,38 @@ html[dir="rtl"] .search-bar-extra a:before {
     content: ' ◂';
 }
 
+/*
+ * Responsive search bar
+ */
+@media only screen and (max-width: 960px) {
+    .responsive #search-bar {
+        display: none;
+    }
 
+    .responsive #search-bar-minimal {
+        display: flex;
+    }
+    .responsive #search-bar-minimal md-input-container label {
+        color: red;
+    }
+    .responsive #search-bar-minimal .md-toolbar-tools {
+        padding: 0 5px 0 10px;
+    }
+    .responsive #search-bar-minimal .md-errors-spacer {
+        display: none;
+    }
+    .responsive #search-bar-minimal input {
+        color: #fff;
+    }
+
+    .responsive #content {
+        padding: 0;
+    }
+}
+
+/*
+ * Logo
+ */
 #logo {
     color: #EEEEEE;
     font-size: 24px;
@@ -540,6 +571,14 @@ html[dir="rtl"] .search-bar-extra a:before {
     list-style-type: none;
 }
 
+/*
+ * Sidebar
+ */
+@media only screen and (min-width: 960px) {
+    .md-sidenav-right .close {
+        display: none;
+    }
+}
 
 /*
  * Footer

--- a/webroot/css/sentences/search.css
+++ b/webroot/css/sentences/search.css
@@ -16,38 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-@media only screen and (max-width: 960px) {
-    #search-bar {
-        display: none;
-    }
-
-    #search-bar-minimal {
-        display: flex;
-    }
-    #search-bar-minimal md-input-container label {
-        color: red;
-    }
-    #search-bar-minimal .md-toolbar-tools {
-        padding: 0 5px 0 10px;
-    }
-    #search-bar-minimal .md-errors-spacer {
-        display: none;
-    }
-    #search-bar-minimal input {
-        color: #fff;
-    }
-    
-    #content {
-        padding: 0;
-    }
-}
-
-@media only screen and (min-width: 960px) {
-    .md-sidenav-right .close {
-        display: none;
-    }
-}
-
 /*
  * Search results
  */

--- a/webroot/css/sentences/show.css
+++ b/webroot/css/sentences/show.css
@@ -25,6 +25,11 @@
     border: 1px solid #f1f1f1;
     margin-top: -20px;
 }
+@media only screen and (max-width: 960px) {
+    .responsive .navigation {
+        margin-top: 0;
+    }
+}
 .navigation .md-errors-spacer {
     display: none;
 }

--- a/webroot/css/sentences/show.css
+++ b/webroot/css/sentences/show.css
@@ -43,6 +43,19 @@
     margin: 20px 5px 0 5px;
 }
 
+/*
+ * Sentence content
+ */
+.sentence-and-translations,
+.sentences_set {
+    background: #fff;
+    margin: 20px 10px;
+}
+
+.sentences_set {
+    width: 610px;
+    margin: 20px auto;
+}
 
 /* 
  * Tags
@@ -128,12 +141,12 @@
 }
 
 
-#annexe_content .sentence-lists .public-list {
+md-sidenav .sentence-lists .public-list {
     list-style-type: disc;
     margin: 5px 5px 5px 10px;
 }
 
-#annexe_content .sentence-lists .personal-list {
+md-sidenav .sentence-lists .personal-list {
     list-style-type: circle;
     margin: 5px 5px 5px 10px;
 }


### PR DESCRIPTION
This PR attempts to address #2903 by making the sentence page layout adjust appropriately on smaller screens.

I started out by just making everything wrap, but that led to a serious shortage of vertical space, so in the end I opted to hide some elements on very small screens.
- the search bar behaves the same as on the search page (fully-featured on wide-enough pages, single input box otherwise)
- I put the sidebar inside a "metadata" sidenav modeled after the advanced search options on the search page
- the sentence navigation hides the input box for the sentence number (actually, I'm wondering whether we couldn't just remove it altogether, considering you could just edit the number in the browser's address bar) and the labels for the navigation arrows

## Screenshots:
### My phone
<img src="https://user-images.githubusercontent.com/6555947/173933859-dd12793d-84ea-4f23-a118-bf8bc53cf853.png" width="400">
With sidenav open:
<img src="https://user-images.githubusercontent.com/6555947/173934082-f5919cf9-2f0c-4bb3-a400-a00f7e43da53.png" width="400">

### From the Firefox responsive design tools at various widths
400px:
<img src="https://user-images.githubusercontent.com/6555947/173934287-93115f77-fcb5-442d-a1bf-2cce1c5fa630.png" width="400">
800px:
<img src="https://user-images.githubusercontent.com/6555947/173934365-f2b26712-4bb7-4fd1-911f-207bdbc8286e.png" width="600">
1200px:
<img src="https://user-images.githubusercontent.com/6555947/173934489-0018d1ac-5608-43c6-a266-5585041e02de.png" width="900">




