### PR TITLE
Only list creator can add sentences to it despite setting

### DIFF
--- a/src/Model/Table/SentencesListsTable.php
+++ b/src/Model/Table/SentencesListsTable.php
@@ -81,7 +81,7 @@ class SentencesListsTable extends Table
         $permissions = array(
             'canView' => $visibility != 'private' || $belongsToUser,
             'canEdit' => $belongsToUser,
-            'canAddSentences' => $belongsToUser && $editableBy !== 'no_one',
+            'canAddSentences' => $editableBy == 'anyone' || $belongsToUser && $editableBy !== 'no_one',
             'canRemoveSentences' => $editableBy == 'anyone' || $belongsToUser && $editableBy == 'creator',
         );
 


### PR DESCRIPTION
This pull request addresses issue #2924.

Tested on local Tatoeba VM