### PR TITLE
Issue 3004 - Change input name for 'username' search to avoid signin auto-fill popup

### DIFF
--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -413,7 +413,8 @@ class UsersController extends AppController
      */
     public function search()
     {
-        $userId = $this->Users->getIdFromUsername($this->request->getData('username'));
+        $username = $this->request->getData('search_username');
+        $userId = $this->Users->getIdFromUsername($username);
 
         if ($userId != null) {
             return $this->redirect(array("action" => "show", $userId));
@@ -421,7 +422,7 @@ class UsersController extends AppController
             $this->flash(
                 __(
                     'No user with this username: ', true
-                ).$this->request->getData('username'),
+                ).$username,
                 '/users/all/'
             );
         }

--- a/src/Template/Users/all.ctp
+++ b/src/Template/Users/all.ctp
@@ -48,7 +48,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Members')));
     
     <md-input-container layout="column">
         <?php
-        echo $this->Form->input('username',[
+        echo $this->Form->input('search_username',[
             'id' => 'usernameInput',
             'label' => '',
         ]);

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -89,12 +89,12 @@ class UsersControllerTest extends IntegrationTestCase {
     }
 
     public function testSearch_found() {
-        $this->post('/en/users/search', [ 'username' => 'contributor' ]);
+        $this->post('/en/users/search', [ 'search_username' => 'contributor' ]);
         $this->assertRedirect('/en/users/show/4');
     }
 
     public function testSearch_notFound() {
-        $this->post('/en/users/search', [ 'username' => 'non existent' ]);
+        $this->post('/en/users/search', [ 'search_username' => 'non existent' ]);
         $this->assertRedirect('/en/users/all/');
     }
 


### PR DESCRIPTION
This PR is an attempt to fix #3004

**REQUIRES TESTING ON SAFARI BROWSER**
(I don't have a iOS device.)

Safari/iOS users face a disruptive sign-in suggestion pop-up when they land on or attempt to fill in the username search form on https://tatoeba.org/en/users/all. Same issue observed but not as disruptive on other browsers.

Attempt to solve by

- Avoiding common auth forms input names like `name`, `username` etc
- making the input name unique. `username` is also used on login and registration pages. This could be triggering autofill if password and username are saved and autofill active
- add `search` to input name to highlight it is a search field
