### PR TITLE
Reassigned Baluchi direction to "auto"

### DIFF
--- a/src/Lib/LanguagesLib.php
+++ b/src/Lib/LanguagesLib.php
@@ -760,7 +760,6 @@ class LanguagesLib
             "syc",
             "phn",
             "jpa",
-            "bal",
             "hbo",
             "ajp",
             "ayl",
@@ -784,6 +783,7 @@ class LanguagesLib
             "swc",
             "rhg",
             "mfa",
+            "bal",
         );
 
         $lang = self::locale_To_Iso639_3($lang);


### PR DESCRIPTION
This PR solves #2992 
It removes Baluchi as a RTL language and adds it as an "auto" direction language.