### PR TITLE
Allow transcriptions edits

### DIFF
--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -171,7 +171,7 @@ $sentenceUrl = $this->Url->build([
 
         echo $this->element('sentences/list_form');
 
-        echo $this->element('sentences/sentence_form');
+        echo $this->element('sentences/sentence_form',['hasAudio'=>isset($sentence->audios) && count($sentence->audios)]);
     }
     ?>
 

--- a/src/Template/Element/sentences/sentence_and_translations.ctp
+++ b/src/Template/Element/sentences/sentence_and_translations.ctp
@@ -171,7 +171,7 @@ $sentenceUrl = $this->Url->build([
 
         echo $this->element('sentences/list_form');
 
-        echo $this->element('sentences/sentence_form',['hasAudio'=>isset($sentence->audios) && count($sentence->audios)]);
+        echo $this->element('sentences/sentence_form');
     }
     ?>
 

--- a/src/Template/Element/sentences/sentence_form.ctp
+++ b/src/Template/Element/sentences/sentence_form.ctp
@@ -1,6 +1,6 @@
 <form layout="column" layout-margin ng-if="vm.visibility.sentence_form">
 
-<div ng-if="vm.sentence.audios && vm.sentence.audios.length > 0">
+<div ng-if="vm.sentence.audios && vm.sentence.audios.length > 0 && vm.sentence.transcriptions.length === 0">
     <p><?= __('You cannot edit this sentence because it has audio.'); ?>
 
     <div layout="row" layout-align="end center">
@@ -10,13 +10,13 @@
     </div>
 </div>
 
-<div name="sentenceForm" layout="column" ng-if="!(vm.sentence.audios && vm.sentence.audios.length > 0)">
+<div name="sentenceForm" layout="column" ng-if="!(vm.sentence.audios && vm.sentence.audios.length > 0 && vm.sentence.transcriptions.length === 0)">
 
     <div layout="row" layout-align="start center" ng-if="vm.sentence.permissions.canEdit">
         <md-input-container flex="50">
             <?php /* @translators: language field label on sentence addition form */ ?>
             <label><?= __('Language') ?></label>
-            <md-select ng-model="vm.sentence.lang">
+            <md-select ng-model="vm.sentence.lang" ng-disabled="<?php echo $hasAudio ?>">
                 <md-option value="unknown"><?= __('Other language') ?></md-option>
                 <md-option ng-repeat="(code, name) in vm.userLanguages" ng-value="code">
                     {{name}}
@@ -34,7 +34,7 @@
         <?php /* @translators: sentence text field label on new sentence addition form */ ?>
         <label><?= __('Sentence') ?></label>
         <textarea ng-attr-id="sentence-form-{{vm.sentence.id}}" ng-model="vm.sentence.text" 
-                  ng-enter="vm.editSentence()" ng-escape="vm.cancelEdit()"></textarea>
+                  ng-enter="vm.editSentence()" ng-escape="vm.cancelEdit()" ng-disabled="<?php echo $hasAudio ?>"></textarea>
     </md-input-container>
 
 

--- a/src/Template/Element/sentences/sentence_form.ctp
+++ b/src/Template/Element/sentences/sentence_form.ctp
@@ -16,7 +16,7 @@
         <md-input-container flex="50">
             <?php /* @translators: language field label on sentence addition form */ ?>
             <label><?= __('Language') ?></label>
-            <md-select ng-model="vm.sentence.lang" ng-disabled="<?php echo $hasAudio ?>">
+            <md-select ng-model="vm.sentence.lang" ng-disabled="vm.sentence.audios && vm.sentence.audios.length > 0">
                 <md-option value="unknown"><?= __('Other language') ?></md-option>
                 <md-option ng-repeat="(code, name) in vm.userLanguages" ng-value="code">
                     {{name}}
@@ -30,11 +30,11 @@
         </div>
     </div>
 
-    <md-input-container ng-if="vm.sentence.permissions.canEdit">
+    <md-input-container >
         <?php /* @translators: sentence text field label on new sentence addition form */ ?>
         <label><?= __('Sentence') ?></label>
         <textarea ng-attr-id="sentence-form-{{vm.sentence.id}}" ng-model="vm.sentence.text" 
-                  ng-enter="vm.editSentence()" ng-escape="vm.cancelEdit()" ng-disabled="<?php echo $hasAudio ?>"></textarea>
+                  ng-enter="vm.editSentence()" ng-escape="vm.cancelEdit()" ng-disabled="!vm.sentence.permissions.canEdit || (vm.sentence.audios && vm.sentence.audios.length > 0)"></textarea>
     </md-input-container>
 
 


### PR DESCRIPTION
Attempt to fix  #3006

Minor Interface Fix. The backend seems to already have adequate validation to stop sentences with audio from being changed, but allowing transcriptions to be edited. 

The` edit sentence` form/action now has three states

1) Sentence has Audio and no transcriptions (`edit sentence` form disabled)
![Screenshot from 2022-11-01 18-03-15](https://user-images.githubusercontent.com/21044267/199282641-7be2540a-08d3-4ef8-8d5d-c001074a7135.png)

2) Sentence has no Audio  (edit sentence form displayed)
![Screenshot from 2022-11-01 18-03-25](https://user-images.githubusercontent.com/21044267/199282715-0e8d01f3-da03-4655-b424-24840c12de49.png)

3) Sentence has Audio and transcriptions (language and sentence inputs disabled)
![Screenshot from 2022-11-01 18-03-38](https://user-images.githubusercontent.com/21044267/199282851-b874a493-a31c-45b3-80eb-158c2a666698.png)




Issue 3006 - Allow editing of transcriptions for sentences with audio