### PR TITLE
Disable jump to top

### DIFF
--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -580,11 +580,11 @@ html[dir="rtl"] .search-bar-extra a:before {
     }
 }
 
-.md-sidenav-right{
+.md-sidenav-right {
     position: fixed;
 }
 
-.md-sidenav-backdrop{
+.md-sidenav-backdrop {
     position: fixed;
 }
 

--- a/webroot/css/layouts/default.css
+++ b/webroot/css/layouts/default.css
@@ -580,6 +580,14 @@ html[dir="rtl"] .search-bar-extra a:before {
     }
 }
 
+.md-sidenav-right{
+    position: fixed;
+}
+
+.md-sidenav-backdrop{
+    position: fixed;
+}
+
 /*
  * Footer
  */

--- a/webroot/js/responsive/app.module.js
+++ b/webroot/js/responsive/app.module.js
@@ -67,7 +67,6 @@
         })
         .controller('SidenavController', ['$scope', '$mdSidenav', '$window', function($scope, $mdSidenav, $window) {
             $scope.toggle = function(id) {
-                $window.scrollTo(0, 0);
                 $mdSidenav(id).toggle();
             };
         }])


### PR DESCRIPTION
Attempt to fix #3011 

Steps to solve

- edit the controller so that it stops scrolling to top of `body`
- Edit `sidenav` so that it is fixed to viewport, not absolutely positioned relative to body

Tested on search `sentences/search` page and show `sentences sentences/show/:id` page

https://user-images.githubusercontent.com/21044267/200612482-ba0206fe-187e-47a8-bae6-c230edd33be0.mov




