### PR TITLE
Add word count filter criterion to search

### DIFF
--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -320,7 +320,10 @@ class SentencesSearchForm extends Form
             $setter = "setData$keyCamel";
             $this->_data[$key] = $this->$setter($value);
 
-            if(empty($this->_data[$key]) && !empty($this->defaultCriteria[$key])) {
+            $strippedParam = ($this->_data[$key] === null
+                              || $this->_data[$key] === false
+                              || $this->_data[$key] === '');
+            if ($strippedParam && !empty($this->defaultCriteria[$key])) {
                 /* Using Router::url() to reconstruct a URL for the given data
                  * strips out empty parameters, which would lead to a non-empty
                  * default being applied instead of the empty non-default value.

--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -32,6 +32,8 @@ class SentencesSearchForm extends Form
         'unapproved' => 'no',
         'native' => '',
         'has_audio' => '',
+        'word_count' => '0',
+        'word_count_op' => 'ge',
         'trans_to' => '',
         'trans_link' => '',
         'trans_user' => '',
@@ -222,6 +224,17 @@ class SentencesSearchForm extends Form
         $native = $native === 'yes' ? true : null;
         $native = $this->search->filterByNativeSpeaker($native);
         return $native ? 'yes' : '';
+    }
+
+    protected function setDataWordCount(string $count) {
+        $count = ctype_digit($count) ? (int)$count : 0;
+        $count = $this->search->filterByWordCount($count);
+        return (string)$count;
+    }
+
+    protected function setDataWordCountOp(string $operator) {
+        $op = $this->search->filterByWordCountOperator($operator);
+        return $op ?? 'eq';
     }
 
     protected function setDataSort(string $sort) {

--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -231,7 +231,9 @@ class SentencesSearchForm extends Form
         $count = $data['word_count'];
         $count = ctype_digit($count) ? (int)$count : 0;
 
-        list($op, $count) = $this->search->filterByWordCount($op, $count);
+        if ( !($op == 'ge' && $count == 0) ) {
+            list($op, $count) = $this->search->filterByWordCount($op, $count);
+        }
 
         $count = (string)($count ?? 0);
         $op = $op ?? 'ge';

--- a/src/Template/Element/advanced_search_form.ctp
+++ b/src/Template/Element/advanced_search_form.ctp
@@ -97,44 +97,40 @@ echo $this->Form->create('AdvancedSearch', [
 
             <div class="param word-count">
                 <div layout="row" layout-align="center">
-                    <label for="word_count_op" flex><?= __('Length:') ?></label>
-                    <label for="word_count">
-                    <?php
-                    $opField = $this->Form->select('word_count_op',
-                        [
-                            /* @translators: part of At least/At most/Exactly dropdown
-                               options in "Length" filter of search form */
-                            'ge' => __('At least'),
-                            /* @translators: part of At least/At most/Exactly dropdown
-                               options in "Length" filter of search form */
-                            'le' => __('At most'),
-                            /* @translators: part of At least/At most/Exactly dropdown
-                               options in "Length" filter of search form */
-                            'eq' => __('Exactly'),
-                        ],
-                        [
-                            'id' => 'word_count_op',
-                            'ng-model' => 'filters.word_count_op',
-                            'ng-model-init' => $word_count_op,
-                        ]
-                    );
-                    $numberField = $this->Form->number('word_count', [
-                        'id' => 'word_count',
-                        'min' => '0',
-                        'string-to-number' => '',
-                        'ng-model' => 'filters.word_count',
-                        'ng-model-init' => $word_count,
-                    ]);
-                    echo format(
-                        /* @translators: the value for the filter "Length" in the
-                           search form. {comparison} is the "At least/At most/Exactly"
-                           dropdown and {number} is the numeric field. You may change
-                           the order of the fields and add words around. */
-                        __('{comparison} {number} word(s)', true),
-                        ['comparison' => $opField, 'number' => $numberField]
-                    );
-                    ?>
-                    </label>
+                      <label flex><?= __('Length:') ?></label>
+                      <div layout="column" layout-align="end">
+                          <?php
+                              $fields = [
+                                  /* @translators: text inside the filter "Length" in the search form. */
+                                  'word_count_min' => __('At least'),
+                                  /* @translators: text inside the filter "Length" in the search form. */
+                                  'word_count_max' => __('At most'),
+                              ];
+                              foreach ($fields as $field => $label) {
+                                  $number = $this->Form->number($field, [
+                                      'id' => $field,
+                                      'min' => '0',
+                                      'string-to-number' => '',
+                                      'ng-model' => "filters.$field",
+                                      'ng-model-init' => $this->get($field),
+                                  ]);
+                                  ?>
+                                  <div layout="row" layout-align="end">
+                                      <label for="<?= $field ?>">
+                                      <?= format(
+                                          /* @translators: the value for the filter "Length" in the
+                                             search form. {label} is the "At least/At most"
+                                             text and {number} is the numeric field. You may change
+                                             the order of the fields and add words around. */
+                                          __('{label} {number} word(s)', true),
+                                          compact('label', 'number')
+                                      ) ?>
+                                      </label>
+                                  </div>
+                              <?php
+                              }
+                          ?>
+                      </div>
                 </div>
                 <div class="hint">
                     <?= __('For languages without word boundaries, the number of characters is assumed instead.') ?>

--- a/src/Template/Element/advanced_search_form.ctp
+++ b/src/Template/Element/advanced_search_form.ctp
@@ -95,6 +95,52 @@ echo $this->Form->create('AdvancedSearch', [
                 ?>
             </div>
 
+            <div class="param word-count">
+                <div layout="row" layout-align="center">
+                    <label for="word_count_op" flex><?= __('Length:') ?></label>
+                    <label for="word_count">
+                    <?php
+                    $opField = $this->Form->select('word_count_op',
+                        [
+                            /* @translators: part of At least/At most/Exactly dropdown
+                               options in "Length" filter of search form */
+                            'ge' => __('At least'),
+                            /* @translators: part of At least/At most/Exactly dropdown
+                               options in "Length" filter of search form */
+                            'le' => __('At most'),
+                            /* @translators: part of At least/At most/Exactly dropdown
+                               options in "Length" filter of search form */
+                            'eq' => __('Exactly'),
+                        ],
+                        [
+                            'id' => 'word_count_op',
+                            'ng-model' => 'filters.word_count_op',
+                            'ng-model-init' => $word_count_op,
+                        ]
+                    );
+                    $numberField = $this->Form->number('word_count', [
+                        'id' => 'word_count',
+                        'min' => '0',
+                        'string-to-number' => '',
+                        'ng-model' => 'filters.word_count',
+                        'ng-model-init' => $word_count,
+                    ]);
+                    echo format(
+                        /* @translators: the value for the filter "Length" in the
+                           search form. {comparison} is the "At least/At most/Exactly"
+                           dropdown and {number} is the numeric field. You may change
+                           the order of the fields and add words around. */
+                        __('{comparison} {number} word(s)', true),
+                        ['comparison' => $opField, 'number' => $numberField]
+                    );
+                    ?>
+                    </label>
+                </div>
+                <div class="hint">
+                    <?= __('For languages without word boundaries, the number of characters is assumed instead.') ?>
+                </div>
+            </div>
+
             <md-input-container class="md-button-right">
                 <?php
                 echo $this->Form->input('user', array(

--- a/tests/TestCase/Form/SentencesSearchFormTest.php
+++ b/tests/TestCase/Form/SentencesSearchFormTest.php
@@ -119,7 +119,7 @@ class SentencesSearchFormTest extends TestCase
             [ ['native' => ''],        ['filterByNativeSpeaker', null],  ''    ],
 
             [ ['word_count_min' => ''],        ['filterByWordCount' => [['le', null], ['ge', null]]], 'any'],
-            [ ['word_count_min' => '0'],       ['filterByWordCount' => [['le', null], ['ge', 0   ]]], 'any'],
+            [ ['word_count_min' => '0'],       ['filterByWordCount' => [['le', null], ['ge', 0   ]]], '0'  ],
             [ ['word_count_min' => '01'],      ['filterByWordCount' => [['le', null], ['ge', 1   ]]], '1'  ],
             [ ['word_count_min' => '42'],      ['filterByWordCount' => [['le', null], ['ge', 42  ]]], '42' ],
             [ ['word_count_min' => 'invalid'], ['filterByWordCount' => [['le', null], ['ge', null]]], 'any'],

--- a/tests/TestCase/Form/SentencesSearchFormTest.php
+++ b/tests/TestCase/Form/SentencesSearchFormTest.php
@@ -33,6 +33,8 @@ class SentencesSearchFormTest extends TestCase
             'orphans' => 'no',
             'user' => '',
             'has_audio' => '',
+            'word_count' => '0',
+            'word_count_op' => 'ge',
             'tags' => '',
             'list' => '',
             'native' => '',

--- a/tests/TestCase/Form/SentencesSearchFormTest.php
+++ b/tests/TestCase/Form/SentencesSearchFormTest.php
@@ -60,121 +60,130 @@ class SentencesSearchFormTest extends TestCase
 
     public function searchParamsProvider() {
         return [
-            [ 'query',
-              'your proposal',
+            [ ['query' => 'your proposal'],
               ['filterByQuery', 'your proposal' ],
               'your proposal'
             ],
-            [ 'query',
-              '散りぬるを　我が世誰ぞ',
+            [ ['query' => '散りぬるを　我が世誰ぞ'],
               ['filterByQuery', '散りぬるを 我が世誰ぞ' ],
               '散りぬるを 我が世誰ぞ'
             ],
-            [ 'query',
-              "ceci\u{a0}; cela\u{a0}",
+            [ ['query' => "ceci\u{a0}; cela\u{a0}"],
               ['filterByQuery', 'ceci ; cela ' ],
               'ceci ; cela '
             ],
 
-            [ 'from', 'ain',         ['filterByLanguage', 'ain'        ], 'ain' ],
-            [ 'from', '',            ['filterByLanguage', ''           ], '' ],
-            [ 'from', 'invalidlang', ['filterByLanguage', 'invalidlang'], '' ],
+            [ ['from' => 'ain'],         ['filterByLanguage', 'ain'        ], 'ain' ],
+            [ ['from' => ''],            ['filterByLanguage', ''           ], '' ],
+            [ ['from' => 'invalidlang'], ['filterByLanguage', 'invalidlang'], '' ],
 
-            [ 'to', 'und',     [], '' ],
-            [ 'to', 'none',    [], 'none' ],
-            [ 'to', 'fra',     [], 'fra' ],
-            [ 'to', '',        [], '' ],
-            [ 'to', 'invalid', [], '' ],
+            [ ['to' => 'und'],     [], '' ],
+            [ ['to' => 'none'],    [], 'none' ],
+            [ ['to' => 'fra'],     [], 'fra' ],
+            [ ['to' => ''],        [], '' ],
+            [ ['to' => 'invalid'], [], '' ],
 
-            [ 'unapproved', 'yes',     ['filterByCorrectness', true],  'yes' ],
-            [ 'unapproved', 'no',      ['filterByCorrectness', false], 'no'  ],
-            [ 'unapproved', 'any',     ['filterByCorrectness', null],  'any' ],
-            [ 'unapproved', 'invalid', ['filterByCorrectness', null],  'any' ],
-            [ 'unapproved', '',        ['filterByCorrectness', null],  'any' ],
+            [ ['unapproved' => 'yes'],     ['filterByCorrectness', true],  'yes' ],
+            [ ['unapproved' => 'no'],      ['filterByCorrectness', false], 'no'  ],
+            [ ['unapproved' => 'any'],     ['filterByCorrectness', null],  'any' ],
+            [ ['unapproved' => 'invalid'], ['filterByCorrectness', null],  'any' ],
+            [ ['unapproved' => ''],        ['filterByCorrectness', null],  'any' ],
 
-            [ 'orphans', 'yes',     ['filterByOrphanship', true],  'yes' ],
-            [ 'orphans', 'no',      ['filterByOrphanship', false], 'no'  ],
-            [ 'orphans', 'any',     ['filterByOrphanship', null],  'any' ],
-            [ 'orphans', 'invalid', ['filterByOrphanship', null],  'any' ],
-            [ 'orphans', '',        ['filterByOrphanship', null],  'any' ],
+            [ ['orphans' => 'yes'],     ['filterByOrphanship', true],  'yes' ],
+            [ ['orphans' => 'no'],      ['filterByOrphanship', false], 'no'  ],
+            [ ['orphans' => 'any'],     ['filterByOrphanship', null],  'any' ],
+            [ ['orphans' => 'invalid'], ['filterByOrphanship', null],  'any' ],
+            [ ['orphans' => ''],        ['filterByOrphanship', null],  'any' ],
 
-            [ 'user', 'contributor', ['filterByOwnerId', 4], 'contributor' ],
-            [ 'user', 'invaliduser', ['filterByOwnerId'],    '', 1 ],
-            [ 'user', '',            ['filterByOwnerId'],    '' ],
+            [ ['user' => 'contributor'], ['filterByOwnerId', 4], 'contributor' ],
+            [ ['user' => 'invaliduser'], ['filterByOwnerId'],    '', 1 ],
+            [ ['user' => ''],            ['filterByOwnerId'],    '' ],
 
-            [ 'has_audio', 'yes',     ['filterByAudio', true],  'yes' ],
-            [ 'has_audio', 'no',      ['filterByAudio', false], 'no'  ],
-            [ 'has_audio', 'invalid', ['filterByAudio', null],  ''    ],
-            [ 'has_audio', '',        ['filterByAudio', null],  ''    ],
+            [ ['has_audio' => 'yes'],     ['filterByAudio', true],  'yes' ],
+            [ ['has_audio' => 'no'],      ['filterByAudio', false], 'no'  ],
+            [ ['has_audio' => 'invalid'], ['filterByAudio', null],  ''    ],
+            [ ['has_audio' => ''],        ['filterByAudio', null],  ''    ],
 
-            [ 'tags', 'OK',          ['filterByTags', ['OK']],            'OK'    ],
-            [ 'tags', 'invalid tag', ['filterByTags', ['invalid tag']],   '',   1 ],
-            [ 'tags', 'OK,invalid',  ['filterByTags', ['OK', 'invalid']], 'OK', 1 ],
+            [ ['tags' => 'OK'],          ['filterByTags', ['OK']],            'OK'    ],
+            [ ['tags' => 'invalid tag'], ['filterByTags', ['invalid tag']],   '',   1 ],
+            [ ['tags' => 'OK,invalid'],  ['filterByTags', ['OK', 'invalid']], 'OK', 1 ],
 
-            [ 'list', '2',       ['filterByListId', 2, null],       '2'   ],
-            [ 'list', '9999999', ['filterByListId', 9999999, null], '', 1 ],
-            [ 'list', '',        ['filterByListId', null, null],    ''    ],
-            [ 'list', '3',       ['filterByListId', 3, null],       '', 1 ],
+            [ ['list' => '2'],       ['filterByListId', 2, null],       '2'   ],
+            [ ['list' => '9999999'], ['filterByListId', 9999999, null], '', 1 ],
+            [ ['list' => ''],        ['filterByListId', null, null],    ''    ],
+            [ ['list' => '3'],       ['filterByListId', 3, null],       '', 1 ],
 
-            [ 'native', 'yes',     ['filterByNativeSpeaker', true],  'yes' ],
-            [ 'native', 'no',      ['filterByNativeSpeaker', null],  ''    ],
-            [ 'native', 'invalid', ['filterByNativeSpeaker', null],  ''    ],
-            [ 'native', '',        ['filterByNativeSpeaker', null],  ''    ],
+            [ ['native' => 'yes'],     ['filterByNativeSpeaker', true],  'yes' ],
+            [ ['native' => 'no'],      ['filterByNativeSpeaker', null],  ''    ],
+            [ ['native' => 'invalid'], ['filterByNativeSpeaker', null],  ''    ],
+            [ ['native' => ''],        ['filterByNativeSpeaker', null],  ''    ],
 
-            [ 'trans_filter', 'exclude',      ['filterByTranslation', 'exclude'], 'exclude' ],
-            [ 'trans_filter', 'invalidvalue', ['filterByTranslation'], 'limit' ],
+            [ ['word_count_op' => '', 'word_count' => ''],
+              [],
+              ['word_count_op' => 'ge', 'word_count' => '0'] ],
 
-            [ 'trans_to', 'ain',     ['filterByTranslationLanguage', 'ain'    ], 'ain' ],
-            [ 'trans_to', '',        ['filterByTranslationLanguage', ''       ], '' ],
-            [ 'trans_to', 'invalid', ['filterByTranslationLanguage', 'invalid'], '' ],
+            [ ['word_count_op' => 'aa', 'word_count' => '-1'],
+              [],
+              ['word_count_op' => 'ge', 'word_count' => '0'] ],
 
-            [ 'trans_link', 'direct',   ['filterByTranslationLink', 'direct'],  'direct'],
-            [ 'trans_link', 'indirect', ['filterByTranslationLink', 'indirect'],'indirect'],
-            [ 'trans_link', '',         ['filterByTranslationLink', ''],        ''],
-            [ 'trans_link', 'invalid',  ['filterByTranslationLink', 'invalid'], ''],
+            [ ['word_count_op' => 'eq', 'word_count' => '1'],
+              ['filterByWordCount', 'eq', 1],
+              ['word_count_op' => 'eq', 'word_count' => '1'] ],
 
-            [ 'trans_has_audio', 'yes',     ['filterByTranslationAudio', true],  'yes' ],
-            [ 'trans_has_audio', 'no',      ['filterByTranslationAudio', false], 'no'  ],
-            [ 'trans_has_audio', 'invalid', ['filterByTranslationAudio', null],  ''    ],
-            [ 'trans_has_audio', '',        ['filterByTranslationAudio', null],  ''    ],
+            [ ['trans_filter' => 'exclude'],      ['filterByTranslation', 'exclude'], 'exclude' ],
+            [ ['trans_filter' => 'invalidvalue'], ['filterByTranslation'], 'limit' ],
 
-            [ 'trans_unapproved', 'yes',     ['filterByTranslationCorrectness', true],  'yes' ],
-            [ 'trans_unapproved', 'no',      ['filterByTranslationCorrectness', false], 'no'  ],
-            [ 'trans_unapproved', 'invalid', ['filterByTranslationCorrectness', null],  ''    ],
-            [ 'trans_unapproved', '',        ['filterByTranslationCorrectness', null],  ''    ],
+            [ ['trans_to' => 'ain'],     ['filterByTranslationLanguage', 'ain'    ], 'ain' ],
+            [ ['trans_to' => ''],        ['filterByTranslationLanguage', ''       ], '' ],
+            [ ['trans_to' => 'invalid'], ['filterByTranslationLanguage', 'invalid'], '' ],
 
-            [ 'trans_orphan', 'yes',     ['filterByTranslationOrphanship', true],  'yes' ],
-            [ 'trans_orphan', 'no',      ['filterByTranslationOrphanship', false], 'no'  ],
-            [ 'trans_orphan', 'invalid', ['filterByTranslationOrphanship', null],  ''    ],
-            [ 'trans_orphan', '',        ['filterByTranslationOrphanship', null],  ''    ],
+            [ ['trans_link' => 'direct'],   ['filterByTranslationLink', 'direct'],  'direct'],
+            [ ['trans_link' => 'indirect'], ['filterByTranslationLink', 'indirect'],'indirect'],
+            [ ['trans_link' => ''],         ['filterByTranslationLink', ''],        ''],
+            [ ['trans_link' => 'invalid'],  ['filterByTranslationLink', 'invalid'], ''],
 
-            [ 'trans_user', 'contributor', ['filterByTranslationOwnerId', 4], 'contributor' ],
-            [ 'trans_user', 'invaliduser', ['filterByTranslationOwnerId'],    '', 1 ],
-            [ 'trans_user', '',            ['filterByTranslationOwnerId'],    ''    ],
+            [ ['trans_has_audio' => 'yes'],     ['filterByTranslationAudio', true],  'yes' ],
+            [ ['trans_has_audio' => 'no'],      ['filterByTranslationAudio', false], 'no'  ],
+            [ ['trans_has_audio' => 'invalid'], ['filterByTranslationAudio', null],  ''    ],
+            [ ['trans_has_audio' => ''],        ['filterByTranslationAudio', null],  ''    ],
 
-            [ 'sort', 'relevance', ['sort', 'relevance'], 'relevance' ],
-            [ 'sort', 'words',     ['sort', 'words'],     'words'     ],
-            [ 'sort', 'modified',  ['sort', 'modified'],  'modified'  ],
-            [ 'sort', 'created',   ['sort', 'created'],   'created'   ],
-            [ 'sort', 'random',    ['sort', 'random'],    'random'    ],
+            [ ['trans_unapproved' => 'yes'],     ['filterByTranslationCorrectness', true],  'yes' ],
+            [ ['trans_unapproved' => 'no'],      ['filterByTranslationCorrectness', false], 'no'  ],
+            [ ['trans_unapproved' => 'invalid'], ['filterByTranslationCorrectness', null],  ''    ],
+            [ ['trans_unapproved' => ''],        ['filterByTranslationCorrectness', null],  ''    ],
 
-            [ 'sort_reverse', 'yes',     ['reverseSort', true],  'yes' ],
-            [ 'sort_reverse', '',        ['reverseSort', false], '' ],
-            [ 'sort_reverse', 'invalid', ['reverseSort', false], '' ],
+            [ ['trans_orphan' => 'yes'],     ['filterByTranslationOrphanship', true],  'yes' ],
+            [ ['trans_orphan' => 'no'],      ['filterByTranslationOrphanship', false], 'no'  ],
+            [ ['trans_orphan' => 'invalid'], ['filterByTranslationOrphanship', null],  ''    ],
+            [ ['trans_orphan' => ''],        ['filterByTranslationOrphanship', null],  ''    ],
 
-            [ 'rand_seed', 'xrgU',          ['setRandSeed',  1358022], 'xrgU' ],
-            [ 'rand_seed', '3-_a',          ['setRandSeed', 14348255], '3-_a' ],
-            [ 'rand_seed', '',              ['setRandSeed',     null], ''     ],
-            [ 'rand_seed', 'longer string', ['setRandSeed', 14715286], 'long' ],
-            [ 'rand_seed', 'sml',           ['setRandSeed',     null], ''     ],
-            [ 'rand_seed', '.!"@',          ['setRandSeed',     null], ''     ],
+            [ ['trans_user' => 'contributor'], ['filterByTranslationOwnerId', 4], 'contributor' ],
+            [ ['trans_user' => 'invaliduser'], ['filterByTranslationOwnerId'],    '', 1 ],
+            [ ['trans_user' => ''],            ['filterByTranslationOwnerId'],    ''    ],
+
+            [ ['sort' => 'relevance'], ['sort', 'relevance'], 'relevance' ],
+            [ ['sort' => 'words'],     ['sort', 'words'],     'words'     ],
+            [ ['sort' => 'modified'],  ['sort', 'modified'],  'modified'  ],
+            [ ['sort' => 'created'],   ['sort', 'created'],   'created'   ],
+            [ ['sort' => 'random'],    ['sort', 'random'],    'random'    ],
+
+            [ ['sort_reverse' => 'yes'],     ['reverseSort', true],  'yes' ],
+            [ ['sort_reverse' => ''],        ['reverseSort', false], '' ],
+            [ ['sort_reverse' => 'invalid'], ['reverseSort', false], '' ],
+
+            [ ['rand_seed' => 'xrgU'],          ['setRandSeed',  1358022], 'xrgU' ],
+            [ ['rand_seed' => '3-_a'],          ['setRandSeed', 14348255], '3-_a' ],
+            [ ['rand_seed' => ''],              ['setRandSeed',     null], ''     ],
+            [ ['rand_seed' => 'longer string'], ['setRandSeed', 14715286], 'long' ],
+            [ ['rand_seed' => 'sml'],           ['setRandSeed',     null], ''     ],
+            [ ['rand_seed' => '.!"@'],          ['setRandSeed',     null], ''     ],
         ];
     }
 
     /**
      * @dataProvider searchParamsProvider
      */
-    public function testSearchParams($getParam, $getValue, $method, $getParamReturned, $ignored = 0) {
+    public function testSearchParams($getParams, $method, $getParamReturned, $ignored = 0) {
         if (count($method) == 1) {
             $this->Search->expects($this->never())
                          ->method($method[0]);
@@ -192,8 +201,14 @@ class SentencesSearchFormTest extends TestCase
                          ->method($methodName)
                          ->with(...$with);
         }
-        $this->Form->setData([$getParam => $getValue]);
-        $this->assertEquals($getParamReturned, $this->Form->getData()[$getParam]);
+
+        $this->Form->setData($getParams);
+        if (!is_array($getParamReturned)) {
+            $getParamReturned = [key($getParams) => $getParamReturned];
+        }
+        foreach ($getParamReturned as $getParam => $expectedValue) {
+            $this->assertEquals($expectedValue, $this->Form->getData()[$getParam]);
+        }
 
         $this->assertCount($ignored, $this->Form->getIgnoredFields());
     }

--- a/tests/TestCase/Form/SentencesSearchFormTest.php
+++ b/tests/TestCase/Form/SentencesSearchFormTest.php
@@ -126,6 +126,10 @@ class SentencesSearchFormTest extends TestCase
               [],
               ['word_count_op' => 'ge', 'word_count' => '0'] ],
 
+            [ ['word_count_op' => 'ge', 'word_count' => '0'],
+              ['filterByWordCount'],
+              ['word_count_op' => 'ge', 'word_count' => '0'] ],
+
             [ ['word_count_op' => 'eq', 'word_count' => '1'],
               ['filterByWordCount', 'eq', 1],
               ['word_count_op' => 'eq', 'word_count' => '1'] ],

--- a/tests/TestCase/Model/SearchTest.php
+++ b/tests/TestCase/Model/SearchTest.php
@@ -326,20 +326,17 @@ class SearchTest extends TestCase
     }
 
     public function testfilterByWordCount_count_as_str() {
-        list($resultOp, $resultCount) = $this->Search->filterByWordCount("eq", "1");
-        $this->assertNull($resultOp);
+        $resultCount = $this->Search->filterByWordCount("eq", "1");
         $this->assertNull($resultCount);
     }
 
     public function testfilterByWordCount_count_negative() {
-        list($resultOp, $resultCount) = $this->Search->filterByWordCount("eq", -1);
-        $this->assertNull($resultOp);
+        $resultCount = $this->Search->filterByWordCount("eq", -1);
         $this->assertNull($resultCount);
     }
 
     public function testfilterByWordCount_count_invalid() {
-        list($resultOp, $resultCount) = $this->Search->filterByWordCount("eq", "'");
-        $this->assertNull($resultOp);
+        $resultCount = $this->Search->filterByWordCount("eq", "'");
         $this->assertNull($resultCount);
 
         $expected = $this->makeSphinxParams();
@@ -348,8 +345,7 @@ class SearchTest extends TestCase
     }
 
     public function testfilterByWordCount_operator_invalid() {
-        list($resultOp, $resultCount) = $this->Search->filterByWordCount("=", 1);
-        $this->assertNull($resultOp);
+        $resultCount = $this->Search->filterByWordCount("=", 1);
         $this->assertNull($resultCount);
 
         $expected = $this->makeSphinxParams();
@@ -358,39 +354,36 @@ class SearchTest extends TestCase
     }
 
     public function testfilterByWordCount_eq_1() {
-        list($resultOp, $resultCount) = $this->Search->filterByWordCount("eq", 1);
-        $this->assertEquals($resultOp, "eq");
+        $resultCount = $this->Search->filterByWordCount("eq", 1);
         $this->assertEquals($resultCount, 1);
 
         $expected = $this->makeSphinxParams([
-            'select' => '*, (text_len = 1) as word_count_filter',
-            'filter' => [['word_count_filter', 1]],
+            'select' => '*, (text_len = 1) as word_count_filter_eq',
+            'filter' => [['word_count_filter_eq', 1]],
         ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
 
     public function testfilterByWordCount_le_10() {
-        list($resultOp, $resultCount) = $this->Search->filterByWordCount("le", 10);
-        $this->assertEquals($resultOp, "le");
+        $resultCount = $this->Search->filterByWordCount("le", 10);
         $this->assertEquals($resultCount, 10);
 
         $expected = $this->makeSphinxParams([
-            'select' => '*, (text_len <= 10) as word_count_filter',
-            'filter' => [['word_count_filter', 1]],
+            'select' => '*, (text_len <= 10) as word_count_filter_le',
+            'filter' => [['word_count_filter_le', 1]],
         ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
 
     public function testfilterByWordCount_ge_8() {
-        list($resultOp, $resultCount) = $this->Search->filterByWordCount("ge", 8);
-        $this->assertEquals($resultOp, "ge");
+        $resultCount = $this->Search->filterByWordCount("ge", 8);
         $this->assertEquals($resultCount, 8);
 
         $expected = $this->makeSphinxParams([
-            'select' => '*, (text_len >= 8) as word_count_filter',
-            'filter' => [['word_count_filter', 1]],
+            'select' => '*, (text_len >= 8) as word_count_filter_ge',
+            'filter' => [['word_count_filter_ge', 1]],
         ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);

--- a/tests/TestCase/Model/SearchTest.php
+++ b/tests/TestCase/Model/SearchTest.php
@@ -326,32 +326,31 @@ class SearchTest extends TestCase
     }
 
     public function testfilterByWordCount_count_as_str() {
-        $result = $this->Search->filterByWordCount("1");
-        $this->assertNull($result);
+        list($resultOp, $resultCount) = $this->Search->filterByWordCount("eq", "1");
+        $this->assertNull($resultOp);
+        $this->assertNull($resultCount);
     }
 
     public function testfilterByWordCount_count_negative() {
-        $result = $this->Search->filterByWordCount(-1);
-        $this->assertNull($result);
+        list($resultOp, $resultCount) = $this->Search->filterByWordCount("eq", -1);
+        $this->assertNull($resultOp);
+        $this->assertNull($resultCount);
     }
 
-    public function testfilterByWordCountOperator_invalid() {
-        $result = $this->Search->filterByWordCountOperator("'");
-        $this->assertNull($result);
-    }
-
-    public function testfilterByWord_only() {
-        $result = $this->Search->filterByWordCount(2);
-        $this->assertEquals($result, 2);
+    public function testfilterByWordCount_count_invalid() {
+        list($resultOp, $resultCount) = $this->Search->filterByWordCount("eq", "'");
+        $this->assertNull($resultOp);
+        $this->assertNull($resultCount);
 
         $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
 
-    public function testfilterByWordCountOperator_only() {
-        $result = $this->Search->filterByWordCountOperator('eq');
-        $this->assertEquals($result, 'eq');
+    public function testfilterByWordCount_operator_invalid() {
+        list($resultOp, $resultCount) = $this->Search->filterByWordCount("=", 1);
+        $this->assertNull($resultOp);
+        $this->assertNull($resultCount);
 
         $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
@@ -359,14 +358,38 @@ class SearchTest extends TestCase
     }
 
     public function testfilterByWordCount_eq_1() {
-        $result = $this->Search->filterByWordCount(1);
-        $this->assertEquals($result, 1);
-
-        $result = $this->Search->filterByWordCountOperator('eq');
-        $this->assertEquals($result, 'eq');
+        list($resultOp, $resultCount) = $this->Search->filterByWordCount("eq", 1);
+        $this->assertEquals($resultOp, "eq");
+        $this->assertEquals($resultCount, 1);
 
         $expected = $this->makeSphinxParams([
             'select' => '*, (text_len = 1) as word_count_filter',
+            'filter' => [['word_count_filter', 1]],
+        ]);
+        $result = $this->Search->asSphinx();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testfilterByWordCount_le_10() {
+        list($resultOp, $resultCount) = $this->Search->filterByWordCount("le", 10);
+        $this->assertEquals($resultOp, "le");
+        $this->assertEquals($resultCount, 10);
+
+        $expected = $this->makeSphinxParams([
+            'select' => '*, (text_len <= 10) as word_count_filter',
+            'filter' => [['word_count_filter', 1]],
+        ]);
+        $result = $this->Search->asSphinx();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testfilterByWordCount_ge_8() {
+        list($resultOp, $resultCount) = $this->Search->filterByWordCount("ge", 8);
+        $this->assertEquals($resultOp, "ge");
+        $this->assertEquals($resultCount, 8);
+
+        $expected = $this->makeSphinxParams([
+            'select' => '*, (text_len >= 8) as word_count_filter',
             'filter' => [['word_count_filter', 1]],
         ]);
         $result = $this->Search->asSphinx();

--- a/tests/TestCase/Model/SearchTest.php
+++ b/tests/TestCase/Model/SearchTest.php
@@ -25,8 +25,19 @@ class SearchTest extends TestCase
         unset($this->Search);
     }
 
+    private function makeSphinxParams($add = []) {
+        return array_merge(
+            [
+                'index' => ['und_index'],
+                'matchMode' => SPH_MATCH_EXTENDED2,
+                'select' => '*',
+            ],
+            $add
+        );
+    }
+
     public function testWithoutFilters() {
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -35,11 +46,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByQuery($query);
         $this->assertEquals($expectedQuery, $result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
-            'query' => $expectedQuery
-        ];
+        $expected = $this->makeSphinxParams(['query' => $expectedQuery]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -56,10 +63,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByLanguage('por');
         $this->assertEquals('por', $result);
 
-        $expected = [
-            'index' => ['por_main_index', 'por_delta_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2
-        ];
+        $expected = $this->makeSphinxParams([
+            'index' => ['por_main_index', 'por_delta_index']
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -68,7 +74,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByLanguage('und');
         $this->assertNull($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -77,7 +83,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByLanguage('1234567890');
         $this->assertNull($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -91,11 +97,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByOwnerId(4);
         $this->assertEquals(4, $result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'filter' => [['user_id', 4]]
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -104,7 +108,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByOwnerId(null);
         $this->assertNull($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -113,11 +117,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByOrphanship(true);
         $this->assertTrue($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'filter' => [['user_id', 0, false]]
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -126,11 +128,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByOrphanship(false);
         $this->assertFalse($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'filter' => [['user_id', 0, true]]
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -139,7 +139,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByOrphanship(null);
         $this->assertNull($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -148,11 +148,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByCorrectness(true);
         $this->assertTrue($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'filter' => [['ucorrectness', 127, false]]
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -161,11 +159,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByCorrectness(false);
         $this->assertFalse($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
-            'filter' => [['ucorrectness', 127, true]]
-        ];
+        $expected = $this->makeSphinxParams([
+            'filter' => [['ucorrectness', 127, true]],
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -174,7 +170,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByCorrectness(null);
         $this->assertNull($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -183,11 +179,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByAudio(true);
         $this->assertTrue($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'filter' => [['has_audio', 1]]
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -196,11 +190,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByAudio(false);
         $this->assertFalse($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'filter' => [['has_audio', 0]]
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -209,7 +201,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByAudio(null);
         $this->assertNull($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -220,7 +212,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByListId($listId, $currentUserId);
         $this->assertFalse($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -231,11 +223,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByListId($listId, $currentUserId);
         $this->assertTrue($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'filter' => [['lists_id', $listId]]
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -246,11 +236,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByListId($listId, $currentUserId);
         $this->assertTrue($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'filter' => [['lists_id', $listId]]
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -261,7 +249,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByListId($listId, $currentUserId);
         $this->assertFalse($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -272,11 +260,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByListId($listId, $currentUserId);
         $this->assertTrue($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'filter' => [['lists_id', $listId]]
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -287,7 +273,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByListId($listId, $currentUserId);
         $this->assertTrue($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -302,11 +288,10 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByNativeSpeaker(true);
         $this->assertTrue($result);
 
-        $expected = [
+        $expected = $this->makeSphinxParams([
             'index' => ['fra_main_index', 'fra_delta_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
             'filter' => [['user_id', [4, 3]]],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -316,10 +301,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByNativeSpeaker(null);
         $this->assertNull($result);
 
-        $expected = [
+        $expected = $this->makeSphinxParams([
             'index' => ['fra_main_index', 'fra_delta_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -333,11 +317,58 @@ class SearchTest extends TestCase
         $this->Search->filterByLanguage('fra');
         $this->Search->filterByNativeSpeaker(true);
         $this->Search->setSphinxFilterArrayLimit(1);
-        $expected = [
+        $expected = $this->makeSphinxParams([
             'index' => ['fra_main_index', 'fra_delta_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
             'filter' => [['user_id', [7], true]],
-        ];
+        ]);
+        $result = $this->Search->asSphinx();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testfilterByWordCount_count_as_str() {
+        $result = $this->Search->filterByWordCount("1");
+        $this->assertNull($result);
+    }
+
+    public function testfilterByWordCount_count_negative() {
+        $result = $this->Search->filterByWordCount(-1);
+        $this->assertNull($result);
+    }
+
+    public function testfilterByWordCountOperator_invalid() {
+        $result = $this->Search->filterByWordCountOperator("'");
+        $this->assertNull($result);
+    }
+
+    public function testfilterByWord_only() {
+        $result = $this->Search->filterByWordCount(2);
+        $this->assertEquals($result, 2);
+
+        $expected = $this->makeSphinxParams();
+        $result = $this->Search->asSphinx();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testfilterByWordCountOperator_only() {
+        $result = $this->Search->filterByWordCountOperator('eq');
+        $this->assertEquals($result, 'eq');
+
+        $expected = $this->makeSphinxParams();
+        $result = $this->Search->asSphinx();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testfilterByWordCount_eq_1() {
+        $result = $this->Search->filterByWordCount(1);
+        $this->assertEquals($result, 1);
+
+        $result = $this->Search->filterByWordCountOperator('eq');
+        $this->assertEquals($result, 'eq');
+
+        $expected = $this->makeSphinxParams([
+            'select' => '*, (text_len = 1) as word_count_filter',
+            'filter' => [['word_count_filter', 1]],
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -346,11 +377,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTags(['OK']);
         $this->assertEquals(['OK'], $result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'filter' => [['tags_id', 2]]
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -358,11 +387,9 @@ class SearchTest extends TestCase
     public function testfilterByTags_twoTags() {
         $result = $this->Search->filterByTags(['OK', '@needs native check']);
         $this->assertEquals(['OK', '@needs native check'], $result);
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'filter' => [['tags_id', 2], ['tags_id', 1]]
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -371,7 +398,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTags(['nonexsistenttag']);
         $this->assertEmpty($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -380,11 +407,9 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTags(['OK', 'nonexsistenttag']);
         $this->assertEquals(['OK'], $result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'filter' => [['tags_id', 2]]
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -393,7 +418,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTags([]);
         $this->assertEmpty($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -407,7 +432,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTags(["'"]);
         $this->assertEmpty($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -416,12 +441,10 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslation('limit');
         $this->assertEquals('limit', $result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'select' => '*, ANY(1 FOR t IN trans) as filter',
             'filter' => [['filter', 1]],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -430,12 +453,10 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslation('exclude');
         $this->assertEquals('exclude', $result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'select' => '*, ANY(1 FOR t IN trans) as filter',
             'filter' => [['filter', 0]],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -444,7 +465,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslation('invalid value');
         $this->assertNull($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -453,7 +474,7 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslation(null);
         $this->assertNull($result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -468,12 +489,10 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslationAudio(true);
         $this->assertTrue($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'select' => '*, ANY(t.a=1 FOR t IN trans) as filter',
             'filter' => [['filter', 1]],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -483,12 +502,10 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslationAudio(false);
         $this->assertFalse($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'select' => '*, ANY(t.a=0 FOR t IN trans) as filter',
             'filter' => [['filter', 1]],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -505,12 +522,10 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslationLanguage('ain');
         $this->assertEquals('ain', $result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'select' => "*, ANY(t.l='ain' FOR t IN trans) as filter",
             'filter' => [['filter', 1]],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -539,12 +554,10 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslationLink('direct');
         $this->assertEquals('direct', $result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'select' => '*, ANY(t.d=1 FOR t IN trans) as filter',
             'filter' => [['filter', 1]],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -554,12 +567,10 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslationLink('indirect');
         $this->assertEquals('indirect', $result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'select' => '*, ANY(t.d=2 FOR t IN trans) as filter',
             'filter' => [['filter', 1]],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -588,12 +599,10 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslationOwnerId(4);
         $this->assertEquals(4, $result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'select' => '*, ANY(t.u=4 FOR t IN trans) as filter',
             'filter' => [['filter', 1]],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -610,12 +619,10 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslationOrphanship(true);
         $this->assertTrue($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'select' => '*, ANY(t.u=0 FOR t IN trans) as filter',
             'filter' => [['filter', 1]],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -625,12 +632,10 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslationOrphanship(false);
         $this->assertFalse($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'select' => '*, ANY(t.u<>0 FOR t IN trans) as filter',
             'filter' => [['filter', 1]],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -652,12 +657,10 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslationCorrectness(true);
         $this->assertTrue($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'select' => '*, ANY(t.c=0 FOR t IN trans) as filter',
             'filter' => [['filter', 1]],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -667,12 +670,10 @@ class SearchTest extends TestCase
         $result = $this->Search->filterByTranslationCorrectness(false);
         $this->assertFalse($result);
 
-        $expected = [
-            'index' => ['und_index'],
-            'matchMode' => SPH_MATCH_EXTENDED2,
+        $expected = $this->makeSphinxParams([
             'select' => '*, ANY(t.c=1 FOR t IN trans) as filter',
             'filter' => [['filter', 1]],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -690,24 +691,20 @@ class SearchTest extends TestCase
     }
 
     private function assertSortByRank($sort, $rank) {
-        $expected = [
-            'index' => ['und_index'],
+        $expected = $this->makeSphinxParams([
             'query' => 'comme ci comme ça',
-            'matchMode' => SPH_MATCH_EXTENDED2,
             'sortMode' => [SPH_SORT_EXTENDED => $sort],
             'rankingMode' => [SPH_RANK_EXPR => $rank],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
 
     private function assertSortBy($sort) {
-        $expected = [
-            'index' => ['und_index'],
+        $expected = $this->makeSphinxParams([
             'query' => '',
-            'matchMode' => SPH_MATCH_EXTENDED2,
             'sortMode' => [SPH_SORT_EXTENDED => $sort],
-        ];
+        ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -895,7 +892,7 @@ class SearchTest extends TestCase
         $result = $this->Search->sort('invalidsortvalue');
         $this->assertEquals('', $result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
@@ -904,7 +901,7 @@ class SearchTest extends TestCase
         $result = $this->Search->sort('');
         $this->assertEquals('', $result);
 
-        $expected = ['index' => ['und_index'], 'matchMode' => SPH_MATCH_EXTENDED2];
+        $expected = $this->makeSphinxParams();
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }

--- a/webroot/css/sentences/search.css
+++ b/webroot/css/sentences/search.css
@@ -73,3 +73,7 @@
     color: #111;
     font-weight: bold;
 }
+
+#advanced-search .word-count input[type="number"] {
+    width: 3em;
+}

--- a/webroot/js/sentences/search.ctrl.js
+++ b/webroot/js/sentences/search.ctrl.js
@@ -36,7 +36,7 @@
                 require: 'ngModel',
                 link: function(scope, element, attrs, ngModel) {
                     ngModel.$parsers.push(function(value) {
-                        return '' + value;
+                        return '' + (value ?? '');
                     });
                     ngModel.$formatters.push(function(value) {
                         return parseFloat(value);

--- a/webroot/js/sentences/search.ctrl.js
+++ b/webroot/js/sentences/search.ctrl.js
@@ -30,6 +30,20 @@
                 }
             };
         }])
+        // This directive comes from https://code.angularjs.org/1.8.0/docs/error/ngModel/numfmt
+        .directive('stringToNumber', function() {
+            return {
+                require: 'ngModel',
+                link: function(scope, element, attrs, ngModel) {
+                    ngModel.$parsers.push(function(value) {
+                        return '' + value;
+                    });
+                    ngModel.$formatters.push(function(value) {
+                        return parseFloat(value);
+                    });
+                }
+            };
+        })
         .controller('SearchController', ['searchService', function(search) {
             var vm = this;
 


### PR DESCRIPTION
Closes #1954. No reindexation required for this to work since the word count is already indexed by Manticore. Some large chunks of code changes in `tests/` are just code refactoring.