### PR TITLE
Optimize audio listing pages

### DIFF
--- a/config/Migrations/20230210083407_AddSentenceLangToAudios.php
+++ b/config/Migrations/20230210083407_AddSentenceLangToAudios.php
@@ -1,0 +1,33 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddSentenceLangToAudios extends AbstractMigration
+{
+    public function up()
+    {
+        foreach (['audios', 'disabled_audios'] as $tableName) {
+            $this
+                ->table($tableName)
+                ->addColumn('sentence_lang', 'string', [
+                    'after' => 'sentence_id',
+                    'limit' => 4,
+                    'null' => true,
+                    'default' => null,
+                    'comment' => 'Denormalized field from sentences table',
+                ])
+                ->update();
+
+            $this->execute("update $tableName a join sentences on sentences.id = a.sentence_id set a.sentence_lang = sentences.lang");
+        }
+    }
+
+    public function down()
+    {
+        foreach (['audios', 'disabled_audios'] as $tableName) {
+            $this
+                ->table($tableName)
+                ->removeColumn('sentence_lang')
+                ->update();
+        }
+    }
+}

--- a/src/Controller/AudioController.php
+++ b/src/Controller/AudioController.php
@@ -85,11 +85,12 @@ class AudioController extends AppController
     public function index($lang = null) {
         $this->loadModel('Audios');
 
+        $finder = ['sentences' => []];
         if (LanguagesLib::languageExists($lang)) {
-            $query = $query->where(compact('lang'));
+            $finder['sentences'] = compact('lang');
             $this->set(compact('lang'));
         }
-        $sentencesWithAudio = $this->paginate($this->Audios, ['finder' => 'sentences']);
+        $sentencesWithAudio = $this->paginate($this->Audios, compact('finder'));
 
         $this->set(compact('sentencesWithAudio'));
         

--- a/src/Controller/AudioController.php
+++ b/src/Controller/AudioController.php
@@ -94,7 +94,7 @@ class AudioController extends AppController
             })
             ->contain('Audios')
             ->contain('Transcriptions')
-            ->order(['Audios.modified' => 'DESC']);
+            ->order(['Audios.id' => 'DESC']);
 
         if (LanguagesLib::languageExists($lang)) {
             $query = $query->where(compact('lang'));

--- a/src/Controller/AudioController.php
+++ b/src/Controller/AudioController.php
@@ -102,27 +102,13 @@ class AudioController extends AppController
         $this->loadModel('Users');
         $userId = $this->Users->getIdFromUsername($username);
         if ($userId) {
-            $this->loadModel('Sentences');
-            $baseQuery = $this->Sentences
-                ->find()
-                ->innerJoinWith('Audios', function ($q) use ($userId) {
-                    return $q->where(['Audios.user_id' => $userId])
-                             ->contain('Users', function ($q) {
-                                 return $q->select(['username']);
-                             });
-                })
-                ->contain('Audios', function ($q) use ($userId) {
-                    return $q->where(['Audios.user_id' => $userId]);
-                })
-                ->contain('Transcriptions')
-                ->order(['Audios.modified' => 'DESC']);
+            $this->loadModel('Audios');
 
-            $audioCountQuery = clone $baseQuery;
-            $this->set('totalAudio', $audioCountQuery->count());
-
-            $query = $baseQuery->distinct('Sentences.id');
-            $sentencesWithAudio = $this->paginate($query);
+            $finder = ['sentences' => ['user_id' => $userId]];
+            $sentencesWithAudio = $this->paginate($this->Audios, compact('finder'));
             $this->set(compact('sentencesWithAudio'));
+
+            $this->set('totalAudio', $this->Audios->numberOfAudiosBy($userId));
 
             $audioSettings = $this->Users->getAudioSettings($userId);
             $this->set(compact('audioSettings'));

--- a/src/Controller/AudioController.php
+++ b/src/Controller/AudioController.php
@@ -83,24 +83,14 @@ class AudioController extends AppController
     }
 
     public function index($lang = null) {
-        $this->loadModel('Sentences');
-        $query = $this->Sentences
-            ->find()
-            ->distinct('Sentences.id')
-            ->innerJoinWith('Audios', function ($q) {
-                return $q->contain('Users', function ($q) {
-                             return $q->select(['username']);
-                         });
-            })
-            ->contain('Audios')
-            ->contain('Transcriptions')
-            ->order(['Audios.id' => 'DESC']);
+        $this->loadModel('Audios');
 
         if (LanguagesLib::languageExists($lang)) {
             $query = $query->where(compact('lang'));
             $this->set(compact('lang'));
         }
-        $sentencesWithAudio = $this->paginate($query);
+        $sentencesWithAudio = $this->paginate($this->Audios, ['finder' => 'sentences']);
+
         $this->set(compact('sentencesWithAudio'));
         
         $this->loadModel('Languages');

--- a/src/Model/Table/AudiosTable.php
+++ b/src/Model/Table/AudiosTable.php
@@ -191,6 +191,10 @@ class AudiosTable extends Table
             $subquery->where(['sentence_lang' => $options['lang']]);
         }
 
+        if (isset($options['user_id'])) {
+            $subquery->where(['user_id' => $options['user_id']]);
+        }
+
         $query = $this->Sentences
             ->find()
             ->join([
@@ -200,7 +204,12 @@ class AudiosTable extends Table
                     'conditions' => 'Sentences.id = Audios.sentence_id'
                 ],
             ])
-            ->contain(['Audios' => ['Users' => ['fields' => ['username']]]])
+            ->contain('Audios', function ($q) use ($options) {
+                if (isset($options['user_id'])) {
+                    $q->where(['Audios.user_id' => $options['user_id']]);
+                }
+                return $q->contain(['Users' => ['fields' => ['username']]]);
+            })
             ->contain('Transcriptions');
 
         return $query;

--- a/src/Model/Table/AudiosTable.php
+++ b/src/Model/Table/AudiosTable.php
@@ -181,6 +181,10 @@ class AudiosTable extends Table
             ->select(['sentence_id' => 'sentence_id'])
             ->order(['id' => 'DESC']);
 
+        if (isset($options['lang'])) {
+            $subquery->where(['sentence_lang' => $options['lang']]);
+        }
+
         $query = $this->Sentences
             ->find()
             ->join([

--- a/src/Model/Table/AudiosTable.php
+++ b/src/Model/Table/AudiosTable.php
@@ -94,6 +94,12 @@ class AudiosTable extends Table
     }
 
     public function beforeSave($event, $entity, $options = array()) {
+        if ($entity->isNew()) {
+            if ($entity->sentence_id) {
+                $sentence = $this->Sentences->get($entity->sentence_id);
+                $entity->sentence_lang = $sentence->lang;
+            }
+        }
         return $this->isAuthorConsistent($entity);
     }
 

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -32,7 +32,7 @@ use App\Model\CurrentUser;
 use App\Model\Entity\User;
 use App\Model\Search;
 use App\Event\ContributionListener;
-use App\Event\LinksListener;
+use App\Event\DenormalizationListener;
 use Cake\Utility\Hash;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Cache\Cache;
@@ -101,7 +101,7 @@ class SentencesTable extends Table
         $this->addBehavior('NativeFinder');
 
         $this->getEventManager()->on(new ContributionListener());
-        $this->getEventManager()->on(new LinksListener());
+        $this->getEventManager()->on(new DenormalizationListener());
     }
 
     public function validationDefault(Validator $validator)

--- a/tests/Fixture/AudiosFixture.php
+++ b/tests/Fixture/AudiosFixture.php
@@ -67,6 +67,14 @@ class AudiosFixture extends TestFixture
                 'modified' => '2022-01-21 21:01:21'
             ],
             */
+            [
+                'id' => 5,
+                'sentence_id' => 4,
+                'user_id' => 3,
+                'external' => NULL,
+                'created' => '2023-02-01 02:23:33',
+                'modified' => '2023-02-01 02:23:33'
+            ],
         ];
         parent::init();
     }

--- a/tests/Fixture/AudiosFixture.php
+++ b/tests/Fixture/AudiosFixture.php
@@ -81,6 +81,15 @@ class AudiosFixture extends TestFixture
                 'created' => '2023-02-01 02:23:33',
                 'modified' => '2023-02-01 02:23:33'
             ],
+            [
+                'id' => 6,
+                'sentence_id' => 15,
+                'sentence_lang' => 'eng',
+                'user_id' => 3,
+                'external' => NULL,
+                'created' => '2023-02-02 02:23:33',
+                'modified' => '2023-02-02 02:23:33'
+            ],
         ];
         parent::init();
     }

--- a/tests/Fixture/AudiosFixture.php
+++ b/tests/Fixture/AudiosFixture.php
@@ -11,6 +11,7 @@ class AudiosFixture extends TestFixture
     public $fields = [
         'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
         'sentence_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        'sentence_lang' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 4, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'],
         'user_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
         'external' => ['type' => 'json', 'length' => 500, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
         'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
@@ -33,6 +34,7 @@ class AudiosFixture extends TestFixture
             [
                 'id' => 1,
                 'sentence_id' => 3,
+                'sentence_lang' => 'spa',
                 'user_id' => 4,
                 'external' => NULL,
                 'created' => '2014-01-20 09:23:49',
@@ -41,6 +43,7 @@ class AudiosFixture extends TestFixture
             [
                 'id' => 2,
                 'sentence_id' => 4,
+                'sentence_lang' => 'fra',
                 'user_id' => NULL,
                 'external' => [ 'username' => 'Philippe Petit' ],
                 'created' => '2001-12-02 06:47:30',
@@ -49,6 +52,7 @@ class AudiosFixture extends TestFixture
             [
                 'id' => 3,
                 'sentence_id' => 12,
+                'sentence_lang' => 'fra',
                 'user_id' => NULL,
                 'external' => [ 'username' => 'Philippe Petit' ],
                 'created' => '2001-12-02 06:47:30',
@@ -61,6 +65,7 @@ class AudiosFixture extends TestFixture
             [
                 'id' => 4,
                 'sentence_id' => 3,
+                'sentence_lang' => 'spa',
                 'user_id' => 2,
                 'external' => NULL,
                 'created' => '2022-01-20 09:23:49',
@@ -70,6 +75,7 @@ class AudiosFixture extends TestFixture
             [
                 'id' => 5,
                 'sentence_id' => 4,
+                'sentence_lang' => 'fra',
                 'user_id' => 3,
                 'external' => NULL,
                 'created' => '2023-02-01 02:23:33',

--- a/tests/Fixture/DisabledAudiosFixture.php
+++ b/tests/Fixture/DisabledAudiosFixture.php
@@ -11,6 +11,7 @@ class DisabledAudiosFixture extends TestFixture
     public $fields = [
         'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => null, 'precision' => null],
         'sentence_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        'sentence_lang' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 4, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'],
         'user_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
         'external' => ['type' => 'json', 'length' => 500, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
         'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
@@ -33,6 +34,7 @@ class DisabledAudiosFixture extends TestFixture
             [
                 'id' => 4,
                 'sentence_id' => 3,
+                'sentence_lang' => 'spa',
                 'user_id' => 2,
                 'external' => NULL,
                 'created' => '2022-01-20 09:23:49',

--- a/tests/TestCase/Command/EditLanguagesCommandTest.php
+++ b/tests/TestCase/Command/EditLanguagesCommandTest.php
@@ -14,6 +14,7 @@ class EditLanguagesCommandTest extends TestCase
 
     public $fixtures = [
         'app.audios',
+        'app.disabled_audios',
         'app.contributions',
         'app.languages',
         'app.links',

--- a/tests/TestCase/Model/Table/AudiosTableTest.php
+++ b/tests/TestCase/Model/Table/AudiosTableTest.php
@@ -342,16 +342,19 @@ class AudiosTableTest extends TestCase {
     function testSentencesFinder() {
         $result = $this->Audio->find('sentences')->all()->toList();
 
-        $this->assertEquals(3, count($result));
+        $this->assertEquals(4, count($result));
 
-        $this->assertEquals(12, $result[0]->id);
+        $this->assertEquals(15, $result[0]->id);
         $this->assertEquals(1, count($result[0]->audios));
 
-        $this->assertEquals(4, $result[1]->id);
-        $this->assertEquals(2, count($result[1]->audios));
+        $this->assertEquals(12, $result[1]->id);
+        $this->assertEquals(1, count($result[1]->audios));
 
-        $this->assertEquals(3, $result[2]->id);
-        $this->assertEquals(1, count($result[2]->audios));
+        $this->assertEquals(4, $result[2]->id);
+        $this->assertEquals(2, count($result[2]->audios));
+
+        $this->assertEquals(3, $result[3]->id);
+        $this->assertEquals(1, count($result[3]->audios));
     }
 
     function testSentencesFinder_lang() {
@@ -364,6 +367,20 @@ class AudiosTableTest extends TestCase {
 
         $this->assertEquals(4, $result[1]->id);
         $this->assertEquals(2, count($result[1]->audios));
+    }
+
+    function testSentencesFinder_user_id() {
+        $result = $this->Audio->find('sentences', ['user_id' => 3])->all()->toList();
+
+        $this->assertEquals(2, count($result));
+
+        $this->assertEquals(15, $result[0]->id);
+        $this->assertEquals(1, count($result[0]->audios));
+        $this->assertEquals(3, $result[0]->audios[0]->user_id);
+
+        $this->assertEquals(4, $result[1]->id);
+        $this->assertEquals(1, count($result[1]->audios));
+        $this->assertEquals(3, $result[1]->audios[0]->user_id);
     }
 
     function testChangeSentenceLangChangesAudioSentenceLang() {

--- a/tests/TestCase/Model/Table/AudiosTableTest.php
+++ b/tests/TestCase/Model/Table/AudiosTableTest.php
@@ -338,4 +338,19 @@ class AudiosTableTest extends TestCase {
         $this->assertNull($audio->user_id);
         $this->assertEquals('Barack Obama', $audio->external['username']);
     }
+
+    function testSentencesFinder() {
+        $result = $this->Audio->find('sentences')->all()->toList();
+
+        $this->assertEquals(3, count($result));
+
+        $this->assertEquals(12, $result[0]->id);
+        $this->assertEquals(1, count($result[0]->audios));
+
+        $this->assertEquals(4, $result[1]->id);
+        $this->assertEquals(2, count($result[1]->audios));
+
+        $this->assertEquals(3, $result[2]->id);
+        $this->assertEquals(1, count($result[2]->audios));
+    }
 }

--- a/tests/TestCase/Model/Table/AudiosTableTest.php
+++ b/tests/TestCase/Model/Table/AudiosTableTest.php
@@ -353,4 +353,50 @@ class AudiosTableTest extends TestCase {
         $this->assertEquals(3, $result[2]->id);
         $this->assertEquals(1, count($result[2]->audios));
     }
+
+    function testSentencesFinder_lang() {
+        $result = $this->Audio->find('sentences', ['lang' => 'fra'])->all()->toList();
+
+        $this->assertEquals(2, count($result));
+
+        $this->assertEquals(12, $result[0]->id);
+        $this->assertEquals(1, count($result[0]->audios));
+
+        $this->assertEquals(4, $result[1]->id);
+        $this->assertEquals(2, count($result[1]->audios));
+    }
+
+    function testChangeSentenceLangChangesAudioSentenceLang() {
+        $DisabledAudios = TableRegistry::getTableLocator()->get('DisabledAudios');
+        $sentenceId = 3;
+
+        $before = $this->Audio->findBySentenceId($sentenceId)->all()->toList();
+        $disabledBefore = $DisabledAudios->findBySentenceId($sentenceId)->all()->toList();
+
+        $sentence = $this->Audio->Sentences->get($sentenceId);
+        $sentence->lang = 'hun';
+        $this->Audio->Sentences->save($sentence);
+
+        $after = $this->Audio->findBySentenceId($sentenceId)->all()->toList();
+        $disabledAfter = $DisabledAudios->findBySentenceId($sentenceId)->all()->toList();
+
+        $this->assertEquals(1, count($before));
+        $this->assertEquals(1, count($disabledBefore));
+        $this->assertEquals(1, count($after));
+        $this->assertEquals(1, count($disabledAfter));
+
+        $this->assertEquals('spa', $before[0]->sentence_lang);
+        $this->assertEquals('spa', $disabledBefore[0]->sentence_lang);
+        $this->assertEquals('hun', $after[0]->sentence_lang);
+        $this->assertEquals('hun', $disabledAfter[0]->sentence_lang);
+    }
+
+    function testCreatingAudioSetsSentenceLang() {
+        $sentence_id = 2;
+        $audio = $this->Audio->newEntity(compact('sentence_id'));
+        $this->Audio->assignAuthor($audio, 'contributor');
+        $result = $this->Audio->save($audio);
+
+        $this->assertEquals('cmn', $this->Audio->get($result->id)->sentence_lang);
+    }
 }


### PR DESCRIPTION
Closes #2946. This PR optimizes the queries involved in the pages `/audio/index`, `/audio/index/<lang>` and `/audio/of/<user>`. These have been growing slower and slower as new audio recordings are getting added (total of 1045907 as of writing), taking between 10 and 30 seconds to complete. The slowness was also a result of the 
code introduced in #2880.