### PR TITLE
Fix strange formatting in collaborative lists, when using old layout

### DIFF
--- a/src/Template/SentencesLists/show.ctp
+++ b/src/Template/SentencesLists/show.ctp
@@ -154,7 +154,9 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
     );
 
     if ($permissions['canAddSentences']) {
-        echo $this->Html->div('edit-list-name', $editImage);
+        if($permissions['canEdit']){
+            echo $this->Html->div('edit-list-name', $editImage);
+        }
         $this->Lists->displayAddSentenceForm($listId);
     }
     ?>


### PR DESCRIPTION
Fix attempting to solve #2994 
based on @Yorwba observation of the `edit-list-name` div being shown even if user cannot edit the list name. Tested locally.

**before**
![image](https://user-images.githubusercontent.com/21044267/221428012-a5422cf6-257a-4cc4-a9e6-c742dbe9b42f.png)

**after**
![Screenshot from 2023-02-26 20-01-15](https://user-images.githubusercontent.com/21044267/221427952-7efe72a0-8b33-49a0-86b3-17cbe6d49e68.png)
