### PR TITLE
make tags lowercase before comparing them

### DIFF
--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -187,8 +187,8 @@ class SentencesSearchForm extends Form
             $tags = implode(',', $appliedTags);
 
             $ignoredTags = array_diff(
-                    array_reduce($tagsArray, function($carry,$item){$carry[] = strtolower($item); return $carry; }), 
-                    array_reduce($appliedTags, function($carry,$item){$carry[] = strtolower($item); return $carry; }), 
+                    array_reduce($tagsArray, function($carry,$item){$carry[] = strtolower($item); return $carry; },[]), 
+                    array_reduce($appliedTags, function($carry,$item){$carry[] = strtolower($item); return $carry; },[]), 
                 );
             foreach ($ignoredTags as $tagName) {
                 $this->ignored[] = format(

--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -186,7 +186,10 @@ class SentencesSearchForm extends Form
             $appliedTags = $this->search->filterByTags($tagsArray);
             $tags = implode(',', $appliedTags);
 
-            $ignoredTags = array_diff($tagsArray, $appliedTags);
+            $ignoredTags = array_diff(
+                    array_reduce($tagsArray, function($carry,$item){$carry[] = strtolower($item); return $carry; }), 
+                    array_reduce($appliedTags, function($carry,$item){$carry[] = strtolower($item); return $carry; }), 
+                );
             foreach ($ignoredTags as $tagName) {
                 $this->ignored[] = format(
                     /* @translators: This string will be preceded by


### PR DESCRIPTION
Attempt to fix #3050. Issue results in a false error.

Issue is due to the `applied tags` vs `user submitted tags` check being case sensitive even though the database search used to generate `applied tags` is case insentitive. 