### PR TITLE
Fix user list sentence count overflow

### DIFF
--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1811,6 +1811,10 @@ md-autocomplete-wrap:not(.md-menu-showing) input.ng-invalid {
  * --------------------------------------------------------------------
  */
 
+.listSummary {
+    font-size: 16px;
+}
+
 .listSummary td {
     padding: 5px;
     border-top: 1px dotted #DDD;


### PR DESCRIPTION
This PR solves issue #3097 

Hard-coding the base font size for the sentence list table to 16px is the simplest solution, and it seems to be the most appropriate to keep the sentence list counts within the table boundary even if the user's browser is set to a larger font size.

It would be nice to keep the font-size responsive but that would require a bit of redesign of sentence list table and there seems to be plenty of hard-coded font-sizes elsewhere in the application anyway.

# Screenshots

## Before Fix (with default browser font size set to 24px)
![image](https://github.com/Tatoeba/tatoeba2/assets/19908880/3520ad1d-9322-49f1-955a-bf9c39113613)

## Before Fix (with default browser font size set to 20px)
![image](https://github.com/Tatoeba/tatoeba2/assets/19908880/1e942638-ab3f-435d-92b6-c62c21058d90)


## With Fix
![image](https://github.com/Tatoeba/tatoeba2/assets/19908880/0121d5d0-faf2-46dc-a5e1-abcf83a17113)