### PR TITLE
Add "unknown" audio contributor text when author is null

### DIFF
--- a/src/Template/Element/sentences/audio.ctp
+++ b/src/Template/Element/sentences/audio.ctp
@@ -94,7 +94,7 @@ $this->AngularTemplate->addTemplate(
                 ]) ?>
             </span>
             <span ng-if="audio.author == null" class="audio-author">
-                <?php echo format(__('Unknown author')) ?>
+                <?php echo __('Unknown author') ?>
             </span>
         </h3>
 

--- a/src/Template/Element/sentences/audio.ctp
+++ b/src/Template/Element/sentences/audio.ctp
@@ -94,9 +94,7 @@ $this->AngularTemplate->addTemplate(
                 ]) ?>
             </span>
             <span ng-if="audio.author == null" class="audio-author">
-                <?= format(__('by {username}'), [
-                    'username' => format(__('unknown'))
-                ]) ?>
+                <?php echo format(__('Unknown author')) ?>
             </span>
         </h3>
 

--- a/src/Template/Element/sentences/audio.ctp
+++ b/src/Template/Element/sentences/audio.ctp
@@ -74,6 +74,7 @@ $this->AngularTemplate->addTemplate(
     $this->element('sentence_buttons/audio'),
     'audio-button-template'
 );
+
 ?>
 <div ng-controller="AudioDetailsController as vm"
      ng-init="vm.init(<?= h($audiosJson) ?>, <?= h($audioLicenses) ?>)"
@@ -87,9 +88,14 @@ $this->AngularTemplate->addTemplate(
     <div ng-repeat="audio in vm.audios" ng-class="{'disabled': !audio.enabled}">
         <h3>
             <audio-button class="audio-button" audios="[audio]"></audio-button>
-            <span class="audio-author">
+            <span ng-if="audio.author != null" class="audio-author">
                 <?= format(__('by {username}'), [
                     'username' => '<a ng-href="{{audio.attribution_url}}">{{audio.author}}</a>'
+                ]) ?>
+            </span>
+            <span ng-if="audio.author == null" class="audio-author">
+                <?= format(__('by {username}'), [
+                    'username' => format(__('unknown'))
                 ]) ?>
             </span>
         </h3>


### PR DESCRIPTION
This PR solves issue #2551 
On the `sentences/show/<id>` page conditionally render "unknown" for the audio contributor field when an `audio` has no associated user.

## Before
![image](https://github.com/Tatoeba/tatoeba2/assets/19908880/4e71ad77-9432-432c-acfa-476b366fec0a)


## After
![image](https://github.com/Tatoeba/tatoeba2/assets/19908880/1caf02d9-a80d-44bc-b5ca-424a63bfa64e)
