### PR TITLE
Add audio source count per sentence for user audio contributions page

### DIFF
--- a/src/View/Helper/SentenceButtonsHelper.php
+++ b/src/View/Helper/SentenceButtonsHelper.php
@@ -180,6 +180,8 @@ class SentenceButtonsHelper extends AppHelper
         $total = count($sentenceAudios);
         if ($total) {
             $startIn = rand(0, $total-1);
+            $audioCount = 1;
+            $audioLinks = "";
             foreach ($sentenceAudios as $audio) {
                 $author = $this->_View->safeForAngular($audio->author);
                 if (empty($author)) {
@@ -193,8 +195,9 @@ class SentenceButtonsHelper extends AppHelper
                 $class = 'audioButton audioAvailable';
                 if ($startIn == 0) {
                     $class .= ' nextAudioToPlay';
+                    $audioCount = $this->Html->div("audioButtonCount", $total);
                 }
-                echo $this->Html->Link(
+                $audioLink = $this->Html->Link(
                     null,
                     $this->Url->build([
                         'controller' => 'audio',
@@ -207,8 +210,12 @@ class SentenceButtonsHelper extends AppHelper
                         'onclick' => 'return false',
                     )
                 );
+
+                $audioLinks .= $audioLink;
                 $startIn--;
             }
+
+            echo $this->Html->div("audioButtonWrapper", $audioLinks . $audioCount);
         } else {
             echo $this->Html->Link(
                 null,

--- a/src/View/Helper/SentencesHelper.php
+++ b/src/View/Helper/SentencesHelper.php
@@ -531,18 +531,18 @@ class SentencesHelper extends AppHelper
             );
         }
 
-        // Copy
-	echo '<div class="copy column">';
-	$this->SentenceButtons->displayCopyButton($sentence->text);
-	echo '</div>';
-
         // Sentence
         $hasAudio = isset($sentence->audios) && count($sentence->audios);
         $canEdit = $isEditable && !$hasAudio;
         $this->displaySentenceContent($sentence, $canEdit);
         echo '</div>';
 
-        // audio
+        // Copy
+        echo '<div class="copy column">';
+        $this->SentenceButtons->displayCopyButton($sentence->text);
+        echo '</div>';
+
+        // Audio
         if ($withAudio && isset($sentence->audios)) {
             echo '<div class="audio column">';
             $this->SentenceButtons->audioButton(

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -758,6 +758,8 @@ html[dir="rtl"] .comment-sentence .text {
 }
 
 .sentence {
+    display: flex;
+    align-items: center;
     padding: 4px 0px;
     background: #fff;
 }
@@ -826,10 +828,6 @@ html[dir="rtl"] .comment-sentence .text {
     margin-top: 2px;
     border-top: 1px solid #FFF;
     border-left: 1px solid #FFF;
-}
-
-.sentence .audioButton {
-    margin-top: 3px;
 }
 
 .sentence .favorite-page.column{
@@ -1198,6 +1196,17 @@ input.sentenceId {
 
 .md-icon-button.audioUnavailable {
     opacity: 0.3;
+}
+
+.audioButtonWrapper {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 2px;
+}
+
+.audioButtonCount {
+    font-size: 0.8rem;
 }
 
 /*

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -769,8 +769,8 @@ html[dir="rtl"] .comment-sentence .text {
 }
 
 .sentence .column {
-    display: inline-block;
-    vertical-align: text-top;
+    display: flex;
+    align-items: center;
     margin: 0 4px;
 }
 
@@ -798,10 +798,6 @@ html[dir="rtl"] .comment-sentence .text {
     width: 515px;
 }
 
-
-.sentence .audio.column {
-}
-
 .sentence .link.button {
     float: left;
     margin: 4px 7px 0 5px;
@@ -816,8 +812,6 @@ html[dir="rtl"] .comment-sentence .text {
     width: 16px;
     height: 16px;
     cursor: pointer;
-    margin-top: 5px;
-    margin-left: 5px;
 }
 
 .sentence .copy-btn.copied {

--- a/webroot/js/sentences.play_audio.js
+++ b/webroot/js/sentences.play_audio.js
@@ -21,7 +21,7 @@ $(document).ready(function () {
     $('.audioAvailable').off();
     $('.audioAvailable').click(function () {
       $(this).removeClass('nextAudioToPlay');
-      var next = $(this).next();
+      var next = $(this).next(".audioButton");
       if (!next.length) {
           next = $(this).parent().children().first();
       }


### PR DESCRIPTION
This PR solves issue #2944

So far I've only tested on a couple audio sources as shown in the screenshot, but this solution should work for any number of audio sources. I'll do some more testing when I get a script working to import audio files automatically.
![image](https://github.com/Tatoeba/tatoeba2/assets/19908880/49bb6867-ea2e-44da-a348-db8ff1236788)
