### PR TITLE
Remove footer link to Google group

### DIFF
--- a/src/Template/Element/foot.ctp
+++ b/src/Template/Element/foot.ctp
@@ -101,15 +101,6 @@
                 );
                 ?>
             </li>
-            <li>
-                <?php
-                echo $this->Html->link(
-                    /* @translators: link text to the Google group page in the footer (noun) */
-                    __('Google group'),
-                    'https://groups.google.com/forum/#!forum/tatoebaproject'
-                );
-                ?>
-            </li>
         </ul>
     </div>
     


### PR DESCRIPTION
The Google group link was removed from the README a while ago in this commit: b67af4e, so it probably makes sense to remove it from the site footer as well.