### PR TITLE
Truncate sentence list title to two lines with ellipsis

### DIFF
--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1993,6 +1993,16 @@ md-autocomplete-wrap:not(.md-menu-showing) input.ng-invalid {
     margin: 6px 0px;
 }
 
+.md-toolbar-tools > h2 {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2; /* number of lines to show */
+    line-height: 1.25rem; /* fallback */
+    height: calc(1.35rem * 2); /* fallback */
+}
+
 /*
  * --------------------------------------------------------------------
  *

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1999,8 +1999,8 @@ md-autocomplete-wrap:not(.md-menu-showing) input.ng-invalid {
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2; /* number of lines to show */
-    line-height: 1.25rem; /* fallback */
-    height: calc(1.35rem * 2); /* fallback */
+    line-height: 1.55rem; /* fallback */
+    height: calc(1.55rem * 2); /* fallback */
 }
 
 /*


### PR DESCRIPTION
This PR addresses issue #3118 

It truncates sentence list titles to two lines using the solution outlined [here](https://stackoverflow.com/a/32585024) on StackOverflow.

~I still need to do some testing for other languages (Chinese, Japanese, etc) as mentioned in the issue discussion.~


Edit:
## Chinese (Simplified)
![image](https://github.com/Tatoeba/tatoeba2/assets/19908880/c181160f-8177-4fc9-b5b0-50fa66c18730)

## Chinese (Traditional)
![image](https://github.com/Tatoeba/tatoeba2/assets/19908880/cc8ea9d1-9500-4096-a3f8-e42fcec5ad65)

## Japanese
![image](https://github.com/Tatoeba/tatoeba2/assets/19908880/997886a4-5353-4d81-8a6a-3fb4a17f1567)
