### PR TITLE
Rename the Russian translation for "Eastern Armenian" and "Western Armenian" in order to unify them

### DIFF
--- a/src/Locale/ru/languages.po
+++ b/src/Locale/ru/languages.po
@@ -242,7 +242,7 @@ msgstr "; nom: датский; prep: датском"
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Lib/LanguagesLib.php#L329
 msgid "Eastern Armenian"
-msgstr ""
+msgstr "восточноармянский"
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Lib/LanguagesLib.php#L330
 msgid "Iraqi Arabic"
@@ -1718,4 +1718,4 @@ msgstr "; nom: мапуче; prep: мапуче"
 
 #: github.com/Tatoeba/tatoeba2/tree/dev/src/Lib/LanguagesLib.php#L698
 msgid "Western Armenian"
-msgstr "западноармянский язык"
+msgstr "западноармянский"


### PR DESCRIPTION
Rename the Russian translation for "Eastern Armenian" and "Western Armenian" in order to unify them