### PR TITLE
Update the Silesian flag to use the Upper Silesian flag associated with the language.

### DIFF
--- a/src/Lib/LanguagesLib.php
+++ b/src/Lib/LanguagesLib.php
@@ -683,7 +683,7 @@ class LanguagesLib
                 'bom' => __d('languages', 'Berom'),
                 'sat' => __d('languages', 'Santali'),
                 'mik' => __d('languages', 'Hitchiti'),
-                'szl' => __d('languages', 'Silesian'),
+                'szl' => __d('languages', 'Silesian (Ślabikŏrz)'),
                 'igs' => __d('languages', 'Interglossa'),
                 'knc' => __d('languages', 'Central Kanuri'),
                 'nnb' => __d('languages', 'Nande'),

--- a/src/Lib/LanguagesLib.php
+++ b/src/Lib/LanguagesLib.php
@@ -683,7 +683,7 @@ class LanguagesLib
                 'bom' => __d('languages', 'Berom'),
                 'sat' => __d('languages', 'Santali'),
                 'mik' => __d('languages', 'Hitchiti'),
-                'szl' => __d('languages', 'Silesian (Ślabikŏrz)'),
+                'szl' => __d('languages', 'Silesian'),
                 'igs' => __d('languages', 'Interglossa'),
                 'knc' => __d('languages', 'Central Kanuri'),
                 'nnb' => __d('languages', 'Nande'),

--- a/webroot/img/flags/szl.svg
+++ b/webroot/img/flags/szl.svg
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" version="1.0" width="600" height="400" viewBox="0 0 600 400" xml:space="preserve"><defs id="defs8"/>
-<text transform="translate(21.6978,28.5215)" style="font-size:12px;fill:#1a161b;font-family:Myriad-Roman" id="text3">Flagge erstellt von: David S. Liuzzo 2006</text>
-
-<rect width="600" height="200" x="0" y="200" style="fill:#ffce08" id="Unten"/>
-<rect width="600" height="200" x="0" y="0" style="fill:#ffffff" id="Oben"/>
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="20">
+  <rect width="30" height="20" fill="#007cc2"/>
+  <rect width="30" height="10" fill="#f8ce00"/>
 </svg>


### PR DESCRIPTION
The flag used for Silesia is the one that was used for [the general Silesian region and/or Lower Silesia](https://en.wikipedia.org/wiki/Flag_of_Silesia_and_Lower_Silesia). The modern Silesian language is spoken in [Upper Silesia](https://en.wikipedia.org/wiki/Upper_Silesia), and the Upper Silesian flag is used pretty much predominantly used to represent Silesian these days. I'm correcting my mistake.

The updated flag also fixes sizing. The previous flag had dimensions 600x400, which breaks certain pages:
![image](https://github.com/user-attachments/assets/0ac16ce9-962d-4a71-a15d-fdba60b3e9f9)