### PR TITLE
User content reporting

### DIFF
--- a/config/app_local.php.template
+++ b/config/app_local.php.template
@@ -151,6 +151,12 @@ return [
          * Stylesheet for development website
          */
         'devStylesheet' => false,
+
+        /**
+         * Email recipient of inappropriate content reports,
+         * blocked users notifications etc.
+         */
+        'communityModeratorEmail' => 'community-admin@example.com',
     ],
 
     /**

--- a/config/auth_actions.php
+++ b/config/auth_actions.php
@@ -86,6 +86,7 @@ $config = [
             'save'          => [ User::ROLE_ADMIN ],
             'delete'        => [ User::ROLE_ADMIN ],
         ],
+        'report_content'       => [ '*' => User::ROLE_CONTRIBUTOR_OR_HIGHER ],
         'reviews'              => [ '*' => User::ROLE_CONTRIBUTOR_OR_HIGHER ],
         'favorites'            => [ '*' => User::ROLE_CONTRIBUTOR_OR_HIGHER ],
         'links'                => [ '*' => User::ROLE_ADV_CONTRIBUTOR_OR_HIGHER ],

--- a/src/Controller/ReportContentController.php
+++ b/src/Controller/ReportContentController.php
@@ -12,15 +12,8 @@ class ReportContentController extends AppController
 {
     public $components = ['Flash'];
 
-    public function wall_post($msgId)
+    private function process_report($entity)
     {
-        try {
-            $this->loadModel('Wall');
-            $entity = $this->Wall->getMessage($msgId);
-        } catch (RecordNotFoundException $e) {
-            throw new NotFoundException();
-        }
-
         $details = $this->request->getData('details', '');
         $origin = $this->request->getData('origin', $this->referer());
 
@@ -50,5 +43,34 @@ class ReportContentController extends AppController
 
         $this->set(compact('entity', 'details', 'origin'));
         return $this->render('report');
+    }
+
+    public function wall_post($msgId)
+    {
+        try {
+            $this->loadModel('Wall');
+            $wallPost = $this->Wall->getMessage($msgId);
+        } catch (RecordNotFoundException $e) {
+            throw new NotFoundException();
+        }
+
+        return $this->process_report($wallPost);
+    }
+
+    public function sentence_comment($id)
+    {
+        try {
+            $this->loadModel('SentenceComments');
+            $comment = $this->SentenceComments
+                ->findById($id)
+                ->contain(['Users' => function ($q) {
+                    return $q->select(['id', 'username', 'image']);
+                }])
+                ->firstOrFail();
+        } catch (RecordNotFoundException $e) {
+            throw new NotFoundException();
+        }
+
+        return $this->process_report($comment);
     }
 }

--- a/src/Controller/ReportContentController.php
+++ b/src/Controller/ReportContentController.php
@@ -26,7 +26,7 @@ class ReportContentController extends AppController
             );
             if ($report->send()) {
                 $this->Flash->set(__(
-                    'Thank you for your help, your report was sent to admins. '.
+                    'Thank you for your help. Your report was sent to the admins. '.
                     'If needed, they will reply to you by private message.'
                 ));
                 return $this->redirect($origin ?? '/');

--- a/src/Controller/ReportContentController.php
+++ b/src/Controller/ReportContentController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Controller;
+
+use App\Model\CurrentUser;
+use App\Model\ContentReport;
+use Cake\Core\Configure;
+use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\Http\Exception\NotFoundException;
+
+class ReportContentController extends AppController
+{
+    public $components = ['Flash'];
+
+    public function wall_post($msgId)
+    {
+        try {
+            $this->loadModel('Wall');
+            $entity = $this->Wall->getMessage($msgId);
+        } catch (RecordNotFoundException $e) {
+            throw new NotFoundException();
+        }
+
+        $details = $this->request->getData('details', '');
+        $origin = $this->request->getData('origin', $this->referer());
+
+        if ($this->request->is('post')) {
+            $report = new ContentReport(
+                CurrentUser::get('username'),
+                $entity,
+                $details,
+                Configure::read('Tatoeba.devStylesheet')
+            );
+            if ($report->send()) {
+                $this->Flash->set(__(
+                    'Thank you for your help, your report was sent to admins. '.
+                    'If needed, they will reply to you by private message.'
+                ));
+                return $this->redirect($origin ?? '/');
+            } else {
+                $email = Configure::read('Tatoeba.communityModeratorEmail');
+                $email = "<a href=\"mailto:$email\">$email</a>";
+                $this->Flash->set(format(
+                    __('Sorry, we were unable to send your report. Please '.
+                       'try again later, or instead contact {email}.'),
+                    compact('email')
+                ));
+            }
+        }
+
+        $this->set(compact('entity', 'details', 'origin'));
+        return $this->render('report');
+    }
+}

--- a/src/Controller/ReportContentController.php
+++ b/src/Controller/ReportContentController.php
@@ -15,7 +15,7 @@ class ReportContentController extends AppController
     private function process_report($entity)
     {
         $details = $this->request->getData('details', '');
-        $origin = $this->request->getData('origin', $this->referer());
+        $origin = $this->request->getQuery('origin', $this->referer());
 
         if ($this->request->is('post')) {
             $report = new ContentReport(

--- a/src/Controller/WallController.php
+++ b/src/Controller/WallController.php
@@ -182,8 +182,8 @@ class WallController extends AppController
         }
 
         $messagePermissions = $this->Permissions->getWallMessageOptions(
-            null,
-            $message->owner,
+            false,
+            $message,
             CurrentUser::get('id')
         );
         if ($messagePermissions['canEdit'] == false) {

--- a/src/Mailer/UserMailer.php
+++ b/src/Mailer/UserMailer.php
@@ -4,7 +4,6 @@ namespace App\Mailer;
 use App\Model\CurrentUser;
 use Cake\Mailer\Email;
 use Cake\Mailer\Mailer;
-use Cake\ORM\TableRegistry;
 
 /**
  * Mailer for User-related emails

--- a/src/Mailer/UserMailer.php
+++ b/src/Mailer/UserMailer.php
@@ -34,4 +34,12 @@ class UserMailer extends Mailer {
                 'newPassword' => $newPassword,
             ]);
     }
+
+    public function content_report($report) {
+        $this
+            ->setTo(Configure::read('Tatoeba.communityModeratorEmail'))
+            ->setSubject($report->getTitle())
+            ->setEmailFormat('html')
+            ->setViewVars(compact('report'));
+    }
 }

--- a/src/Mailer/UserMailer.php
+++ b/src/Mailer/UserMailer.php
@@ -4,6 +4,7 @@ namespace App\Mailer;
 use App\Model\CurrentUser;
 use Cake\Mailer\Email;
 use Cake\Mailer\Mailer;
+use Cake\Core\Configure;
 
 /**
  * Mailer for User-related emails
@@ -11,7 +12,7 @@ use Cake\Mailer\Mailer;
 class UserMailer extends Mailer {
 
     public function blocked_or_suspended_user($user, $isSuspended) {
-        $this->setTo('tatoeba-community-admins@googlegroups.com')
+        $this->setTo(Configure::read('Tatoeba.communityModeratorEmail'))
             ->setSubject("( ! ) {$user->username}")
             ->setEmailFormat('html')
             ->setViewVars([

--- a/src/Model/ContentReport.php
+++ b/src/Model/ContentReport.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Model;
+
+use App\Model\Entity\Wall;
+use Cake\Mailer\MailerAwareTrait;
+use Cake\Routing\Router;
+use Cake\Log\Log;
+use Cake\Network\Exception\SocketException;
+
+class ContentReport
+{
+    use MailerAwareTrait;
+
+    private $reporter;
+    private $entity;
+    private $details;
+    private $testPrefix;
+
+    public function __construct($reporter, $entity, $details, $testPrefix = false) {
+        if (!(
+                 $entity instanceof Wall
+            )) {
+            throw new \RuntimeException('Unsupported entity');
+        }
+        $this->reporter = $reporter;
+        $this->entity = $entity;
+        $this->details = $details;
+        $this->testPrefix = $testPrefix;
+    }
+
+    public function getTitle() : string {
+        $prefix = "[Content Report] ";
+        if ($this->entity instanceof Wall) {
+            $title = "Wall message #{$this->entity->id}";
+        }
+        if ($this->testPrefix) {
+            $prefix = "[TEST]".$prefix;
+        }
+        return $prefix.$title;
+    }
+
+    public function getContentUrl() : string {
+        if ($this->entity instanceof Wall) {
+            $url = [
+                'controller' => 'wall',
+                'action' => 'show_message',
+                $this->entity->id,
+                '#' => 'message_'.$this->entity->id,
+            ];
+        }
+        $url['_full'] = true;
+        $url['lang'] = '';
+        return Router::url($url);
+    }
+
+    public function getContentName() : string {
+        if ($this->entity instanceof Wall) {
+            return "a wall post";
+        }
+    }
+
+    public function getDetails() : string {
+        return $this->details;
+    }
+
+    public function getReporter() : string {
+        return $this->reporter;
+    }
+
+    public function send() {
+        try {
+            $this->getMailer('User')->send('content_report', [$this]);
+            return true;
+        } catch (SocketException $e) {
+            Log::error(
+                "Unable to send content report email by {$this->getReporter()}"
+               ." about {$this->getContentUrl()}: {$e->getMessage()}"
+            );
+            return false;
+        }
+    }
+}

--- a/src/Model/ContentReport.php
+++ b/src/Model/ContentReport.php
@@ -2,6 +2,7 @@
 
 namespace App\Model;
 
+use App\Model\Entity\SentenceComment;
 use App\Model\Entity\Wall;
 use Cake\Mailer\MailerAwareTrait;
 use Cake\Routing\Router;
@@ -20,6 +21,7 @@ class ContentReport
     public function __construct($reporter, $entity, $details, $testPrefix = false) {
         if (!(
                  $entity instanceof Wall
+              || $entity instanceof SentenceComment
             )) {
             throw new \RuntimeException('Unsupported entity');
         }
@@ -33,6 +35,8 @@ class ContentReport
         $prefix = "[Content Report] ";
         if ($this->entity instanceof Wall) {
             $title = "Wall message #{$this->entity->id}";
+        } elseif ($this->entity instanceof SentenceComment) {
+            $title = "Comment #{$this->entity->id} (on sentence #{$this->entity->sentence_id})";
         }
         if ($this->testPrefix) {
             $prefix = "[TEST]".$prefix;
@@ -48,6 +52,13 @@ class ContentReport
                 $this->entity->id,
                 '#' => 'message_'.$this->entity->id,
             ];
+        } elseif ($this->entity instanceof SentenceComment) {
+            $url = [
+                'controller' => 'sentences',
+                'action' => 'show',
+                $this->entity->sentence_id,
+                '#' => 'comment-'.$this->entity->id,
+            ];
         }
         $url['_full'] = true;
         $url['lang'] = '';
@@ -57,6 +68,8 @@ class ContentReport
     public function getContentName() : string {
         if ($this->entity instanceof Wall) {
             return "a wall post";
+        } elseif ($this->entity instanceof SentenceComment) {
+            return "a sentence comment";
         }
     }
 

--- a/src/Model/Entity/SentenceComment.php
+++ b/src/Model/Entity/SentenceComment.php
@@ -1,0 +1,8 @@
+<?php
+namespace App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+class SentenceComment extends Entity
+{
+}

--- a/src/Model/Entity/Wall.php
+++ b/src/Model/Entity/Wall.php
@@ -1,0 +1,8 @@
+<?php
+namespace App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+class Wall extends Entity
+{
+}

--- a/src/Model/Table/WallTable.php
+++ b/src/Model/Table/WallTable.php
@@ -303,15 +303,19 @@ class WallTable extends Table
             ]);
             $this->getEventManager()->dispatch($event);
 
-            return $this->get($savedMessage->id, [
-                'contain' => [
-                    'Users' => [
-                        'fields' => ['id', 'username', 'image']
-                    ]
-                ]
-            ]);
+            return $this->getMessage($savedMessage->id);
         } else {
             return null;
         }
+    }
+
+    public function getMessage($id) {
+        return $this->get($id, [
+            'contain' => [
+                'Users' => [
+                    'fields' => ['id', 'username', 'image']
+                ]
+            ]
+        ]);
     }
 }

--- a/src/Template/Email/html/content_report.ctp
+++ b/src/Template/Email/html/content_report.ctp
@@ -16,7 +16,7 @@ $reporterUrl = [
 <p>
     <?php if (strlen($details) > 0): ?>
         Below is what <?= $reporter ?> wrote about it:<br>
-        <?= h($details) ?>
+        <?= nl2br(h($details)) ?>
     <?php else: ?>
         <?= $reporter ?> did not provide any detail.
     <?php endif; ?>

--- a/src/Template/Email/html/content_report.ctp
+++ b/src/Template/Email/html/content_report.ctp
@@ -1,0 +1,23 @@
+<?php
+$reporter = $report->getReporter();
+$details = $report->getDetails();
+$reporterUrl = [
+    '_full' => true,
+    'lang' => '',
+    'controller' => 'user',
+    'action' => 'profile',
+    $reporter
+];
+?>
+<p>
+    Member <?= $this->Html->link($reporter, $reporterUrl) ?> reported <?= $report->getContentName() ?>:<br>
+    <?= $this->Html->link($report->getContentUrl()) ?>
+</p>
+<p>
+    <?php if (strlen($details) > 0): ?>
+        Below is what <?= $reporter ?> wrote about it:<br>
+        <?= h($details) ?>
+    <?php else: ?>
+        <?= $reporter ?> did not provide any detail.
+    <?php endif; ?>
+</p>

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -62,9 +62,10 @@ $isHomepage = $controller == 'pages' && $action == 'index';
         echo $this->AssetCompress->css('layout.css');
 
         // Specific
-        $specificCSS = "$controller/$action.css";
-        if (file_exists(Configure::read('App.cssBaseUrl') . $specificCSS)) {
-            echo $this->Html->css($specificCSS);
+        foreach (["$controller.css", "$controller/$action.css"] as $specificCSS) {
+            if (file_exists(Configure::read('App.cssBaseUrl') . $specificCSS)) {
+                echo $this->Html->css($specificCSS);
+            }
         }
 
         echo $this->element('seo_international_targeting');

--- a/src/Template/ReportContent/report.ctp
+++ b/src/Template/ReportContent/report.ctp
@@ -1,0 +1,45 @@
+<?php
+
+use App\Model\Entity\Wall;
+
+$this->set('title_for_layout', $this->Pages->formatTitle(__('Report content')));
+?>
+
+<?php /* @translators: title of the content reporting page */ ?>
+<?= $this->Html->tag('h2', __('Report problematic content')) ?>
+
+<div class="report">
+    <?= $this->Html->tag('p', format(
+        __('Use this form to let website admins know about content that goes against '.
+           '<a href="{}">our rules</a> or is otherwise problematic.'),
+        $this->Pages->getWikiLink('rules-against-bad-behavior')
+    )); ?>
+
+    <?php if ($entity instanceof Wall): ?>
+        <?= $this->Html->tag('h3', __('Report the following Wall message')) ?>
+        <div class="wall-message">
+            <?= $this->element('wall/message', ['message' => $entity]) ?>
+        </div>
+    <?php endif; ?>
+    
+    <?= $this->Html->tag('h3', __('What is the problem?')) ?>
+    <?= $this->Form->create() ?>
+    <?= $this->Form->textarea('details', [
+        'value' => $this->safeForAngular($details),
+        'lang' => '',
+        'dir' => 'auto',
+    ]) ?>
+    <?= $this->Form->hidden('origin', ['value' => $this->safeForAngular($origin)]) ?>
+    <div layout="row" layout-align="start center">
+        <md-button class="md-raised" onclick="history.back();">
+            <?php /* @translators: cancel button of content reporting form (verb) */ ?>
+            <?= __('Go back') ?>
+        </md-button>
+    
+        <md-button type="submit" class="md-raised md-primary">
+            <?php /* @translators: submit button of content reporting form (verb) */ ?>
+            <?= __('Report content') ?>
+        </md-button>
+    </div>
+    <?= $this->Form->end(); ?>
+</div>

--- a/src/Template/ReportContent/report.ctp
+++ b/src/Template/ReportContent/report.ctp
@@ -71,8 +71,6 @@ if ($entity instanceof SentenceComment || $entity instanceof Sentence) {
         'rows' => '10',
     ]) ?>
 
-    <?= $this->Form->hidden('origin', ['value' => $this->safeForAngular($origin)]) ?>
-
     <div layout="row" layout-align="start center">
         <md-button class="md-raised" onclick="history.back();">
             <?php /* @translators: cancel button of content reporting form (verb) */ ?>

--- a/src/Template/ReportContent/report.ctp
+++ b/src/Template/ReportContent/report.ctp
@@ -49,6 +49,7 @@ if ($entity instanceof SentenceComment || $entity instanceof Sentence) {
                             'canEdit' => false,
                             'canHide' => false,
                             'canPM' => false,
+                            'canReport' => false,
                         ],
                         false
                     ),

--- a/src/Template/ReportContent/report.ctp
+++ b/src/Template/ReportContent/report.ctp
@@ -1,20 +1,29 @@
 <?php
 
+use App\Model\Entity\Sentence;
 use App\Model\Entity\SentenceComment;
 use App\Model\Entity\Wall;
 
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Report content')));
+
+$introText = format(
+    __('Use this form to let website admins know about content that goes against '.
+       '<a href="{}">our rules of community participation</a>.'),
+    $this->Pages->getWikiLink('rules-against-bad-behavior')
+);
+if ($entity instanceof SentenceComment || $entity instanceof Sentence) {
+    $introText .= " ".__(
+        'If you simply want to report a problem with the sentence, '.
+        'leave a comment on it instead.'
+    );
+}
 ?>
 
 <?php /* @translators: title of the content reporting page */ ?>
-<?= $this->Html->tag('h2', __('Report problematic content')) ?>
+<?= $this->Html->tag('h2', __('Report inappropriate content')) ?>
 
 <div class="report">
-    <?= $this->Html->tag('p', format(
-        __('Use this form to let website admins know about content that goes against '.
-           '<a href="{}">our rules</a> or is otherwise problematic.'),
-        $this->Pages->getWikiLink('rules-against-bad-behavior')
-    )); ?>
+    <?= $this->Html->tag('p', $introText) ?>
 
     <?php if ($entity instanceof Wall): ?>
         <?= $this->Html->tag('h3', __('Report the following Wall message')) ?>

--- a/src/Template/ReportContent/report.ctp
+++ b/src/Template/ReportContent/report.ctp
@@ -1,5 +1,6 @@
 <?php
 
+use App\Model\Entity\SentenceComment;
 use App\Model\Entity\Wall;
 
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Report content')));
@@ -19,6 +20,29 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Report content')));
         <?= $this->Html->tag('h3', __('Report the following Wall message')) ?>
         <div class="wall-message">
             <?= $this->element('wall/message', ['message' => $entity]) ?>
+        </div>
+    <?php elseif ($entity instanceof SentenceComment): ?>
+        <?= $this->Html->tag('h3', __('Report the following sentence comment')) ?>
+        <div class="">
+            <?= $this->element(
+                'sentence_comments/comment',
+                [
+                    'comment' => $entity,
+                    'menu' => $this->Comments->getMenuForComment(
+                        $entity,
+                        [
+                            'canDelete' => false,
+                            'canEdit' => false,
+                            'canHide' => false,
+                            'canPM' => false,
+                        ],
+                        false
+                    ),
+                    'replyIcon' => false,
+                    'hideSentence' => true,
+                ]
+            ) ?>
+
         </div>
     <?php endif; ?>
     

--- a/src/Template/ReportContent/report.ctp
+++ b/src/Template/ReportContent/report.ctp
@@ -5,6 +5,7 @@ use App\Model\Entity\SentenceComment;
 use App\Model\Entity\Wall;
 
 $this->set('title_for_layout', $this->Pages->formatTitle(__('Report content')));
+$this->set('isResponsive', true);
 
 $introText = format(
     __('Use this form to let website admins know about content that goes against '.
@@ -18,11 +19,15 @@ if ($entity instanceof SentenceComment || $entity instanceof Sentence) {
     );
 }
 ?>
+<md-toolbar class="md-hue-2">
+    <div class="md-toolbar-tools">
+        <?php /* @translators: title of the content reporting page */ ?>
+        <?= $this->Html->tag('h2', __('Report inappropriate content')) ?>
+    </div>
+</md-toolbar>
 
-<?php /* @translators: title of the content reporting page */ ?>
-<?= $this->Html->tag('h2', __('Report inappropriate content')) ?>
-
-<div class="report">
+<md-content class="report md-whiteframe-1dp">
+    <?= $this->Html->tag('div', null, ['layout' => 'column', 'layout-margin' => '']) ?>
     <?= $this->Html->tag('p', $introText) ?>
 
     <?php if ($entity instanceof Wall): ?>
@@ -32,7 +37,7 @@ if ($entity instanceof SentenceComment || $entity instanceof Sentence) {
         </div>
     <?php elseif ($entity instanceof SentenceComment): ?>
         <?= $this->Html->tag('h3', __('Report the following sentence comment')) ?>
-        <div class="">
+        <div>
             <?= $this->element(
                 'sentence_comments/comment',
                 [
@@ -51,18 +56,22 @@ if ($entity instanceof SentenceComment || $entity instanceof Sentence) {
                     'hideSentence' => true,
                 ]
             ) ?>
-
         </div>
     <?php endif; ?>
     
     <?= $this->Html->tag('h3', __('What is the problem?')) ?>
-    <?= $this->Form->create() ?>
+
+    <?= $this->Form->create(null, ['layout-margin' => '']) ?>
+
     <?= $this->Form->textarea('details', [
         'value' => $this->safeForAngular($details),
         'lang' => '',
         'dir' => 'auto',
+        'rows' => '10',
     ]) ?>
+
     <?= $this->Form->hidden('origin', ['value' => $this->safeForAngular($origin)]) ?>
+
     <div layout="row" layout-align="start center">
         <md-button class="md-raised" onclick="history.back();">
             <?php /* @translators: cancel button of content reporting form (verb) */ ?>
@@ -75,4 +84,5 @@ if ($entity instanceof SentenceComment || $entity instanceof Sentence) {
         </md-button>
     </div>
     <?= $this->Form->end(); ?>
-</div>
+    <?= $this->Html->tag('/div') ?>
+</md-content>

--- a/src/View/Helper/CommentsHelper.php
+++ b/src/View/Helper/CommentsHelper.php
@@ -75,6 +75,16 @@ class CommentsHelper extends AppHelper
         //send message
         if ($permissions['canPM']) {
             $menu[] = array(
+                /* @translators: flag button to report a sentence comment (verb) */
+                'text' => __('Report'),
+                'icon' => 'flag',
+                'url' => array(
+                    'controller' => 'report_content',
+                    'action' => 'sentence_comment',
+                    $comment->id,
+                )
+            );
+            $menu[] = array(
                 'text' => __('Send message'),
                 'icon' => 'mail',
                 'url' => array(

--- a/src/View/Helper/CommentsHelper.php
+++ b/src/View/Helper/CommentsHelper.php
@@ -73,7 +73,7 @@ class CommentsHelper extends AppHelper
         $commentId = $comment['id'];
 
         //send message
-        if ($permissions['canPM']) {
+        if ($permissions['canReport']) {
             $menu[] = array(
                 /* @translators: flag button to report a sentence comment (verb) */
                 'text' => __('Report'),
@@ -84,6 +84,8 @@ class CommentsHelper extends AppHelper
                     $comment->id,
                 )
             );
+        }
+        if ($permissions['canPM']) {
             $menu[] = array(
                 'text' => __('Send message'),
                 'icon' => 'mail',

--- a/src/View/Helper/CommentsHelper.php
+++ b/src/View/Helper/CommentsHelper.php
@@ -82,6 +82,7 @@ class CommentsHelper extends AppHelper
                     'controller' => 'report_content',
                     'action' => 'sentence_comment',
                     $comment->id,
+                    '?' => ['origin' => $this->getView()->getRequest()->getRequestTarget()],
                 )
             );
         }

--- a/src/View/Helper/WallHelper.php
+++ b/src/View/Helper/WallHelper.php
@@ -188,6 +188,7 @@ class WallHelper extends AppHelper
                     'controller' => 'report_content',
                     'action' => 'wall_post',
                     $messageId,
+                    '?' => ['origin' => $this->getView()->getRequest()->getRequestTarget()],
                 )
             );
         }

--- a/src/View/Helper/WallHelper.php
+++ b/src/View/Helper/WallHelper.php
@@ -181,6 +181,16 @@ class WallHelper extends AppHelper
 
         if ($permissions['canPM']) {
             $menu[] = array(
+                /* @translators: flag button to report a wall post (verb) */
+                'text' => __('Report'),
+                'icon' => 'flag',
+                'url' => array(
+                    'controller' => 'report_content',
+                    'action' => 'wall_post',
+                    $messageId,
+                )
+            );
+            $menu[] = array(
                 'text' => __('Send message'),
                 'icon' => 'mail',
                 'url' => array(

--- a/src/View/Helper/WallHelper.php
+++ b/src/View/Helper/WallHelper.php
@@ -179,7 +179,7 @@ class WallHelper extends AppHelper
         $messageId = $message['id'];
         $hidden = $message['hidden'];
 
-        if ($permissions['canPM']) {
+        if ($permissions['canReport']) {
             $menu[] = array(
                 /* @translators: flag button to report a wall post (verb) */
                 'text' => __('Report'),
@@ -190,6 +190,8 @@ class WallHelper extends AppHelper
                     $messageId,
                 )
             );
+        }
+        if ($permissions['canPM']) {
             $menu[] = array(
                 'text' => __('Send message'),
                 'icon' => 'mail',

--- a/tests/TestCase/Controller/ReportContentControllerTest.php
+++ b/tests/TestCase/Controller/ReportContentControllerTest.php
@@ -33,10 +33,14 @@ class ReportContentControllerTest extends TestCase
         return [
             // url; user; is accessible or redirection url
             [ '/en/report_content/wall_post/1', null, '/en/users/login?redirect=%2Fen%2Freport_content%2Fwall_post%2F1' ],
+            [ '/en/report_content/wall_post/1?origin=/en/wall/index', null, '/en/users/login?redirect=%2Fen%2Freport_content%2Fwall_post%2F1%3Forigin%3D%2Fen%2Fwall%2Findex' ],
             [ '/en/report_content/wall_post/1', 'contributor', true ],
+            [ '/en/report_content/wall_post/1?origin=/en/wall/index', 'contributor', true ],
             [ '/en/report_content/wall_post/9999', 'contributor', 404 ],
             [ '/en/report_content/sentence_comment/1', null, '/en/users/login?redirect=%2Fen%2Freport_content%2Fsentence_comment%2F1' ],
+            [ '/en/report_content/sentence_comment/1?origin=/en/sentences/show/4', null, '/en/users/login?redirect=%2Fen%2Freport_content%2Fsentence_comment%2F1%3Forigin%3D%2Fen%2Fsentences%2Fshow%2F4' ],
             [ '/en/report_content/sentence_comment/1', 'contributor', true ],
+            [ '/en/report_content/sentence_comment/1?origin=/en/sentences/show/4', 'contributor', true ],
             [ '/en/report_content/sentence_comment/9999', 'contributor', 404 ],
         ];
     }
@@ -57,8 +61,7 @@ class ReportContentControllerTest extends TestCase
         $this->enableRetainFlashMessages();
         $this->logInAs('contributor');
 
-        $this->post('http://example.net/en/report_content/wall_post/1', [
-            'origin' => '/en/wall/index',
+        $this->post('http://example.net/en/report_content/wall_post/1?origin=/en/wall/index', [
             'details' => 'this is spam',
         ]);
 
@@ -72,8 +75,7 @@ class ReportContentControllerTest extends TestCase
         $this->enableRetainFlashMessages();
         $this->logInAs('contributor');
 
-        $this->post('http://example.net/en/report_content/wall_post/1', [
-            'origin' => '/en/wall/index',
+        $this->post('http://example.net/en/report_content/wall_post/1?origin=/en/wall/index', [
             'details' => 'this is spam',
         ]);
 
@@ -86,8 +88,7 @@ class ReportContentControllerTest extends TestCase
         $this->enableRetainFlashMessages();
         $this->logInAs('contributor');
 
-        $this->post('http://example.net/en/report_content/sentence_comment/1', [
-            'origin' => '/en/sentences/show/4',
+        $this->post('http://example.net/en/report_content/sentence_comment/1?origin=/en/sentences/show/4', [
             'details' => 'this is spam',
         ]);
 

--- a/tests/TestCase/Controller/ReportContentControllerTest.php
+++ b/tests/TestCase/Controller/ReportContentControllerTest.php
@@ -1,0 +1,80 @@
+<?php
+namespace App\Test\TestCase\Controller;
+
+use App\Test\TestCase\Controller\TatoebaControllerTestTrait;
+use App\Test\TestCase\FaultyMailerTrait;
+use Cake\Core\Configure;
+use Cake\TestSuite\EmailTrait;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+class ReportContentControllerTest extends TestCase
+{
+    use EmailTrait;
+    use FaultyMailerTrait;
+    use IntegrationTestTrait;
+    use TatoebaControllerTestTrait;
+
+    public $fixtures = [
+        'app.private_messages',
+        'app.users',
+        'app.users_languages',
+        'app.walls',
+        'app.wiki_articles',
+    ];
+
+    public function setUp() {
+        Configure::write('App.fullBaseUrl', 'https://example.org');
+        parent::setUp();
+    }
+
+    public function accessesProvider() {
+        return [
+            // url; user; is accessible or redirection url
+            [ '/en/report_content/wall_post/1', null, '/en/users/login?redirect=%2Fen%2Freport_content%2Fwall_post%2F1' ],
+            [ '/en/report_content/wall_post/1', 'contributor', true ],
+            [ '/en/report_content/wall_post/9999', 'contributor', 404 ],
+        ];
+    }
+
+    /**
+     * @dataProvider accessesProvider
+     */
+    public function testControllerAccess($url, $user, $response) {
+        $this->assertAccessUrlAs($url, $user, $response);
+        $this->assertMailCount(0);
+    }
+
+    private function assertFlashMessageContains($expected, $message = '') {
+        $this->assertContains($expected, $this->_requestSession->read('Flash.flash.0.message'));
+    }
+
+    public function testWallPost() {
+        $this->enableRetainFlashMessages();
+        $this->logInAs('contributor');
+
+        $this->post('http://example.net/en/report_content/wall_post/1', [
+            'origin' => '/en/wall/index',
+            'details' => 'this is spam',
+        ]);
+
+        $this->assertRedirect('/en/wall/index');
+        $this->assertFlashMessageContains('Thank you');
+        $this->assertMailCount(1);
+    }
+
+    public function testWallPost_fail() {
+        $this->enableFaultyMailer();
+        $this->enableRetainFlashMessages();
+        $this->logInAs('contributor');
+
+        $this->post('http://example.net/en/report_content/wall_post/1', [
+            'origin' => '/en/wall/index',
+            'details' => 'this is spam',
+        ]);
+
+        $this->assertNoRedirect();
+        $this->assertFlashMessageContains('Sorry');
+        $this->assertMailCount(0);
+    }
+}

--- a/tests/TestCase/Controller/ReportContentControllerTest.php
+++ b/tests/TestCase/Controller/ReportContentControllerTest.php
@@ -17,6 +17,7 @@ class ReportContentControllerTest extends TestCase
 
     public $fixtures = [
         'app.private_messages',
+        'app.sentence_comments',
         'app.users',
         'app.users_languages',
         'app.walls',
@@ -34,6 +35,9 @@ class ReportContentControllerTest extends TestCase
             [ '/en/report_content/wall_post/1', null, '/en/users/login?redirect=%2Fen%2Freport_content%2Fwall_post%2F1' ],
             [ '/en/report_content/wall_post/1', 'contributor', true ],
             [ '/en/report_content/wall_post/9999', 'contributor', 404 ],
+            [ '/en/report_content/sentence_comment/1', null, '/en/users/login?redirect=%2Fen%2Freport_content%2Fsentence_comment%2F1' ],
+            [ '/en/report_content/sentence_comment/1', 'contributor', true ],
+            [ '/en/report_content/sentence_comment/9999', 'contributor', 404 ],
         ];
     }
 
@@ -76,5 +80,19 @@ class ReportContentControllerTest extends TestCase
         $this->assertNoRedirect();
         $this->assertFlashMessageContains('Sorry');
         $this->assertMailCount(0);
+    }
+
+    public function testSentenceComment() {
+        $this->enableRetainFlashMessages();
+        $this->logInAs('contributor');
+
+        $this->post('http://example.net/en/report_content/sentence_comment/1', [
+            'origin' => '/en/sentences/show/4',
+            'details' => 'this is spam',
+        ]);
+
+        $this->assertRedirect('/en/sentences/show/4');
+        $this->assertFlashMessageContains('Thank you');
+        $this->assertMailCount(1);
     }
 }

--- a/tests/TestCase/FaultyMailerTrait.php
+++ b/tests/TestCase/FaultyMailerTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Test\TestCase;
+
+trait FaultyMailerTrait
+{
+    private function enableFaultyMailer() {
+        $faultyTransport = $this
+             ->getMockBuilder(\Cake\Mailer\Transport\DebugTransport::class)
+             ->setMethods(['send'])
+             ->getMock();
+        $faultyTransport
+             ->method('send')
+             ->willThrowException(
+                 new \Cake\Network\Exception\SocketException('Connection timed out')
+             );
+        \Cake\Mailer\TransportFactory::getRegistry()->set('debug', $faultyTransport);
+    }
+}

--- a/tests/TestCase/Mailer/UserMailerTest.php
+++ b/tests/TestCase/Mailer/UserMailerTest.php
@@ -3,6 +3,7 @@ namespace App\Test\Mailer;
 
 use App\Mailer\UserMailer;
 use App\Model\Entity\User;
+use Cake\Core\Configure;
 use Cake\Mailer\Email;
 use Cake\TestSuite\EmailTrait;
 use Cake\TestSuite\TestCase;
@@ -17,6 +18,8 @@ class UserMailerTest extends TestCase {
     protected $mailer = null;
 
     public function setUp() {
+        Configure::write('Tatoeba.communityModeratorEmail', 'moderator@example.net');
+
         $this->email = new Email([
             'from' => 'sender@example.com',
             'emailFormat' => 'html',
@@ -46,7 +49,7 @@ class UserMailerTest extends TestCase {
             [$user, $isSuspended]
         );
 
-        $this->assertMailSentTo('tatoeba-community-admins@googlegroups.com');
+        $this->assertMailSentTo('moderator@example.net');
         $this->assertMailSentWith('( ! ) kazuki', 'subject');
         $this->assertMailContainsHtml($snippet);
     }

--- a/tests/TestCase/Mailer/UserMailerTest.php
+++ b/tests/TestCase/Mailer/UserMailerTest.php
@@ -3,6 +3,7 @@ namespace App\Test\Mailer;
 
 use App\Mailer\UserMailer;
 use App\Model\ContentReport;
+use App\Model\Entity\SentenceComment;
 use App\Model\Entity\User;
 use App\Model\Entity\Wall;
 use Cake\Core\Configure;
@@ -100,5 +101,22 @@ class UserMailerTest extends TestCase {
         $this->mailer->send('content_report', [$report]);
 
         $this->assertMailContainsHtml('&lt;img src=&quot;http://example.com/oops&quot; /&gt;');
+    }
+
+    public function test_content_report_sentence_comment() {
+        $comment = new SentenceComment([
+            'id' => 5,
+            'content' => 'spam spam spam...',
+            'sentence_id' => 19,
+        ]);
+        $report = new ContentReport('kazuki', $comment, 'please remove spam');
+
+        $this->mailer->send('content_report', [$report]);
+
+        $this->assertMailSentTo('moderator@example.net');
+        $this->assertMailSentWith('[Content Report] Comment #5 (on sentence #19)', 'subject');
+        $this->assertMailContainsHtml('Member <a href="https://example.net/user/profile/kazuki">kazuki</a> reported a sentence comment');
+        $this->assertMailContainsHtml('https://example.net/sentences/show/19#comment-5');
+        $this->assertMailContainsHtml('please remove spam');
     }
 }

--- a/tests/TestCase/Mailer/UserMailerTest.php
+++ b/tests/TestCase/Mailer/UserMailerTest.php
@@ -74,7 +74,7 @@ class UserMailerTest extends TestCase {
 
     public function test_content_report_wall_post() {
         $wallPost = new Wall(['id' => 3, 'content' => 'spam spam spam...']);
-        $report = new ContentReport('kazuki', $wallPost, 'this is spam');
+        $report = new ContentReport('kazuki', $wallPost, "line1\nline2");
 
         $this->mailer->send('content_report', [$report]);
 
@@ -82,7 +82,7 @@ class UserMailerTest extends TestCase {
         $this->assertMailSentWith('[Content Report] Wall message #3', 'subject');
         $this->assertMailContainsHtml('Member <a href="https://example.net/user/profile/kazuki">kazuki</a> reported a wall post');
         $this->assertMailContainsHtml('https://example.net/wall/show_message/3#message_3');
-        $this->assertMailContainsHtml('this is spam');
+        $this->assertMailContainsHtml("line1<br />\nline2");
     }
 
     public function test_content_report_wall_post_no_details() {

--- a/tests/TestCase/Mailer/UserMailerTest.php
+++ b/tests/TestCase/Mailer/UserMailerTest.php
@@ -2,7 +2,9 @@
 namespace App\Test\Mailer;
 
 use App\Mailer\UserMailer;
+use App\Model\ContentReport;
 use App\Model\Entity\User;
+use App\Model\Entity\Wall;
 use Cake\Core\Configure;
 use Cake\Mailer\Email;
 use Cake\TestSuite\EmailTrait;
@@ -18,6 +20,7 @@ class UserMailerTest extends TestCase {
     protected $mailer = null;
 
     public function setUp() {
+        Configure::write('App.fullBaseUrl', 'https://example.net');
         Configure::write('Tatoeba.communityModeratorEmail', 'moderator@example.net');
 
         $this->email = new Email([
@@ -66,5 +69,36 @@ class UserMailerTest extends TestCase {
         $this->assertMailSentFrom('sender@example.com');
         $this->assertMailSentWith('Tatoeba, new password', 'subject');
         $this->assertMailContainsHtml('Your new password: secret');
+    }
+
+    public function test_content_report_wall_post() {
+        $wallPost = new Wall(['id' => 3, 'content' => 'spam spam spam...']);
+        $report = new ContentReport('kazuki', $wallPost, 'this is spam');
+
+        $this->mailer->send('content_report', [$report]);
+
+        $this->assertMailSentTo('moderator@example.net');
+        $this->assertMailSentWith('[Content Report] Wall message #3', 'subject');
+        $this->assertMailContainsHtml('Member <a href="https://example.net/user/profile/kazuki">kazuki</a> reported a wall post');
+        $this->assertMailContainsHtml('https://example.net/wall/show_message/3#message_3');
+        $this->assertMailContainsHtml('this is spam');
+    }
+
+    public function test_content_report_wall_post_no_details() {
+        $wallPost = new Wall(['id' => 3, 'content' => 'spam spam spam...']);
+        $report = new ContentReport('kazuki', $wallPost, '');
+
+        $this->mailer->send('content_report', [$report]);
+
+        $this->assertMailContainsHtml('kazuki did not provide any detail.');
+    }
+
+    public function test_content_report_wall_post_html_injection() {
+        $wallPost = new Wall(['id' => 3, 'content' => 'spam spam spam...']);
+        $report = new ContentReport('kazuki', $wallPost, '<img src="http://example.com/oops" />');
+
+        $this->mailer->send('content_report', [$report]);
+
+        $this->assertMailContainsHtml('&lt;img src=&quot;http://example.com/oops&quot; /&gt;');
     }
 }

--- a/webroot/css/layouts/elements.css
+++ b/webroot/css/layouts/elements.css
@@ -1582,6 +1582,7 @@ html[dir="rtl"] .sentence-and-translations .translation.trusted-user.expanded .t
     margin: 40px 0;
 }
 
+.report .wall-message md-card-header,
 .wall.form md-card-header,
 .wall-thread md-card-header {
     background: #fafafa;

--- a/webroot/css/report_content.css
+++ b/webroot/css/report_content.css
@@ -1,0 +1,8 @@
+
+.report form {
+  display: grid;
+}
+
+.report textarea {
+  field-sizing: normal;
+}


### PR DESCRIPTION
Solves #2904.

* New button allows to report content: 
![image](https://github.com/user-attachments/assets/daaaceed-b8f1-4b95-afe1-4da6f3b3747a)

* Content that can be reported so far:
    - wall messages
    - sentence comments

* Tentative design:
![image](https://github.com/user-attachments/assets/a3cbc04e-4f02-4ab0-a333-fdef5acdc81f)

* Submitting the above form sends an email to community admins and redirect to the page the user came from with a confirmation message:
![image](https://github.com/user-attachments/assets/7bc59b25-b299-4acb-9fdf-a6c8af5afbd3)

* And in the rare yet [possible](https://github.com/Tatoeba/tatoeba2/issues/3066) event of an email delivery failure:
![image](https://github.com/user-attachments/assets/b96dbb79-fc73-4a20-bcc0-922a0a0847df)
