### PR TITLE
Issue 3192 - Replace CakePHP Error Messages with Translatable Strings

### DIFF
--- a/src/Template/Error/error400.ctp
+++ b/src/Template/Error/error400.ctp
@@ -31,8 +31,12 @@ endif;
 $this->end();
 endif;
 ?>
-<h2><?= h($message) ?></h2>
-<p class="error">
-    <strong><?= __d('cake', 'Error') ?>: </strong>
-    <?= __d('cake', 'The requested address {0} was not found on this server.', "<strong>'{$url}'</strong>") ?>
-</p>
+<h2><?= h(__($message)) ?></h2>
+<?php if ($code == 404): ?>
+    <h2><?= format(
+        __('The requested address {0} was not found on this server.'),
+        "<strong>'{$url}'</strong>"
+    ) ?></h2>
+<?php else: ?>
+    <h2><?= h(__("Client error")) ?></h2>
+<?php endif; ?>

--- a/src/Template/Error/error500.ctp
+++ b/src/Template/Error/error500.ctp
@@ -36,8 +36,9 @@ if (Configure::read('debug')) :
     $this->end();
 endif;
 ?>
-<h2><?= __d('cake', 'An Internal Error Has Occurred') ?></h2>
-<p class="error">
-    <strong><?= __d('cake', 'Error') ?>: </strong>
-    <?= h($message) ?>
-</p>
+<?php if ($code >= 500): ?>
+    <h2><?= h(__('Server error')) ?></h2>
+    <p><?= h(__('An internal error has occurred.')) ?></p>
+<?php else: ?>
+    <h2><?= h(__('Unexpected error')) ?></h2>
+<?php endif; ?>


### PR DESCRIPTION
CakePHP's default error messages were not translatable, making the pages display 400 and 500 errors in English, even if the page is in a different language. This PR converts the errors to use the translation system so they can be displayed in different languages.


<img width="2559" height="1346" alt="Screenshot 2025-08-04 110214" src="https://github.com/user-attachments/assets/1e04b6cb-e257-488d-a254-984d35862ef1" />

