### PR TITLE
Limit paging on long listings of sentences

### DIFF
--- a/src/Controller/AudioController.php
+++ b/src/Controller/AudioController.php
@@ -98,7 +98,11 @@ class AudioController extends AppController
         }
         $total = $total->count();
 
-        $sentencesWithAudio = $this->paginate($this->Audios, compact('finder'));
+        try {
+            $sentencesWithAudio = $this->paginate($this->Audios, compact('finder'));
+        } catch (\Cake\Http\Exception\NotFoundException $e) {
+            return $this->redirectPaginationToLastPage();
+        }
 
         $this->set(compact('sentencesWithAudio', 'totalLimit', 'total'));
         

--- a/src/Controller/AudioController.php
+++ b/src/Controller/AudioController.php
@@ -86,14 +86,21 @@ class AudioController extends AppController
     public function index($lang = null) {
         $this->loadModel('Audios');
 
-        $finder = ['sentences' => []];
+        $totalLimit = $this::PAGINATION_DEFAULT_TOTAL_LIMIT;
+        $finder = ['sentences' => [
+            'maxResults' => $totalLimit,
+        ]];
+        $total = $this->Audios->find()->select(['sentence_id'])->distinct();
         if (LanguagesLib::languageExists($lang)) {
-            $finder['sentences'] = compact('lang');
+            $total = $total->where(['sentence_lang' => $lang]);
+            $finder['sentences']['lang'] = $lang;
             $this->set(compact('lang'));
         }
+        $total = $total->count();
+
         $sentencesWithAudio = $this->paginate($this->Audios, compact('finder'));
 
-        $this->set(compact('sentencesWithAudio'));
+        $this->set(compact('sentencesWithAudio', 'totalLimit', 'total'));
         
         $this->loadModel('Languages');
         $this->set(array('stats' => $this->Languages->getAudioStats()));

--- a/src/Controller/AudioController.php
+++ b/src/Controller/AudioController.php
@@ -116,14 +116,18 @@ class AudioController extends AppController
         if ($userId) {
             $this->loadModel('Audios');
 
-            $finder = ['sentences' => ['user_id' => $userId]];
+            $totalLimit = $this::PAGINATION_DEFAULT_TOTAL_LIMIT;
+            $finder = ['sentences' => [
+                'user_id' => $userId,
+                'maxResults' => $totalLimit,
+            ]];
             $sentencesWithAudio = $this->paginate($this->Audios, compact('finder'));
             $this->set(compact('sentencesWithAudio'));
 
             $this->set('totalAudio', $this->Audios->numberOfAudiosBy($userId));
 
             $audioSettings = $this->Users->getAudioSettings($userId);
-            $this->set(compact('audioSettings'));
+            $this->set(compact('audioSettings', 'totalLimit'));
         }
         $this->set(compact('username'));
     }

--- a/src/Controller/AudioController.php
+++ b/src/Controller/AudioController.php
@@ -121,7 +121,11 @@ class AudioController extends AppController
                 'user_id' => $userId,
                 'maxResults' => $totalLimit,
             ]];
-            $sentencesWithAudio = $this->paginate($this->Audios, compact('finder'));
+            try {
+                $sentencesWithAudio = $this->paginate($this->Audios, compact('finder'));
+            } catch (\Cake\Http\Exception\NotFoundException $e) {
+                return $this->redirectPaginationToLastPage();
+            }
             $this->set(compact('sentencesWithAudio'));
 
             $this->set('totalAudio', $this->Audios->numberOfAudiosBy($userId));

--- a/src/Controller/AudioController.php
+++ b/src/Controller/AudioController.php
@@ -89,14 +89,13 @@ class AudioController extends AppController
         $totalLimit = $this::PAGINATION_DEFAULT_TOTAL_LIMIT;
         $finder = ['sentences' => [
             'maxResults' => $totalLimit,
+            'sentences' => [],
         ]];
-        $total = $this->Audios->find()->select(['sentence_id'])->distinct();
         if (LanguagesLib::languageExists($lang)) {
-            $total = $total->where(['sentence_lang' => $lang]);
             $finder['sentences']['lang'] = $lang;
             $this->set(compact('lang'));
         }
-        $total = $total->count();
+        $total = $this->Audios->find('sentencesCount', $finder['sentences']);
 
         try {
             $sentencesWithAudio = $this->paginate($this->Audios, compact('finder'));

--- a/src/Controller/SentenceCommentsController.php
+++ b/src/Controller/SentenceCommentsController.php
@@ -115,19 +115,20 @@ class SentenceCommentsController extends AppController
         $this->helpers[] = 'Messages';
         $this->helpers[] = 'Members';
 
-        $query = $this->SentenceComments->find();
+        $options = [
+            'maxResults' => $this::PAGINATION_DEFAULT_TOTAL_LIMIT,
+        ];
         $botsIds = Configure::read('Bots.userIds');
         if (!empty($botsIds)) {
-            $query->where(['SentenceComments.user_id NOT IN' => $botsIds]);
+            $options['conditions']['SentenceComments.user_id NOT IN'] = $botsIds;
         }
         if ($langFilter != 'und') {
-            $query->contain(['Sentences']);
-            $query->where(['Sentences.lang' => $langFilter]);
+            $options['contain'] = 'Sentences';
+            $options['conditions']['Sentences.lang'] = $langFilter;
         }
 
-        $totalLimit = $this::PAGINATION_DEFAULT_TOTAL_LIMIT;
-        $query->find('latest', ['maxResults' => $totalLimit]);
-        $latestComments = $this->paginateOrRedirect($query);
+        $finder = ['latest' => $options];
+        $latestComments = $this->paginateOrRedirect($this->SentenceComments, compact('finder'));
 
         $commentsPermissions = $this->Permissions->getCommentsOptions($latestComments);
 

--- a/src/Controller/SentencesListsController.php
+++ b/src/Controller/SentencesListsController.php
@@ -200,7 +200,11 @@ class SentencesListsController extends AppController
             'direction' => $this->request->getQuery('direction', 'desc'),
         ];
         $finder = ['latest' => $options];
-        $sentencesInList = $this->paginate($this->SentencesSentencesLists, compact('finder'));
+        try {
+            $sentencesInList = $this->paginate($this->SentencesSentencesLists, compact('finder'));
+        } catch (\Cake\Http\Exception\NotFoundException $e) {
+            return $this->redirectPaginationToLastPage();
+        }
 
         $total = $this->SentencesSentencesLists->find()->where(['sentences_list_id' => $id])->count();
 

--- a/src/Controller/SentencesListsController.php
+++ b/src/Controller/SentencesListsController.php
@@ -198,6 +198,8 @@ class SentencesListsController extends AppController
             'limit' => CurrentUser::getSetting('sentences_per_page'),
             'sort' => $this->request->getQuery('sort', 'id'),
             'direction' => $this->request->getQuery('direction', 'desc'),
+            // keep "created" for backward compatibility
+            'sortWhitelist' => ['id', 'sentence_id', 'created'],
         ];
         $finder = ['latest' => $options];
         try {

--- a/src/Controller/SentencesListsController.php
+++ b/src/Controller/SentencesListsController.php
@@ -176,24 +176,34 @@ class SentencesListsController extends AppController
         $this->loadModel('Sentences');
         $this->loadModel('SentencesSentencesLists');
 
-        $query = $this->SentencesSentencesLists->find();
+        $totalLimit = $this::PAGINATION_DEFAULT_TOTAL_LIMIT;
+        $options = [
+            'conditions' => ['sentences_list_id' => $id],
+            'maxResults' => $totalLimit,
+            'contain' => [
+                'Sentences' => function (Query $q) use ($translationsLang) {
+                    return $q
+                      ->find('filteredTranslations', ['translationLang' => $translationsLang])
+                      ->find('hideFields')
+                      ->contain($this->Sentences->contain(['translations' => true]))
+                      ->select($this->Sentences->fields());
+                },
+            ],
+        ];
         if ($lang!="und") {
-            $query->where(['lang' => $lang == 'unknown' ? null : $lang]);
+            $options['conditions']['Sentences.lang'] = $lang == 'unknown' ? null : $lang;
         }
-        $query->where(['sentences_list_id' => $id])
-            ->contain(['Sentences' => function (Query $q) use ($translationsLang) {
-                $q->find('filteredTranslations', ['translationLang' => $translationsLang])
-                  ->find('hideFields')
-                  ->contain($this->Sentences->contain(['translations' => true]))
-                  ->select($this->Sentences->fields());
-                return $q;
-            }]);
 
         $this->paginate = [
             'limit' => CurrentUser::getSetting('sentences_per_page'),
-            'order' => ['created' => 'DESC'],
+            'sort' => $this->request->getQuery('sort', 'created'),
+            'direction' => $this->request->getQuery('direction', 'desc'),
         ];
-        $sentencesInList = $this->paginate($query);
+        $finder = ['latest' => $options];
+        $sentencesInList = $this->paginate($this->SentencesSentencesLists, compact('finder'));
+
+        $total = $this->SentencesSentencesLists->find()->where(['sentences_list_id' => $id])->count();
+
         $this->set('translationsLang', $translationsLang);
         $this->set('list', $list);
         $this->set('user', $list->user);
@@ -201,6 +211,7 @@ class SentencesListsController extends AppController
         $this->set('sentencesInList', $sentencesInList);
         $this->set('listId', $id);
         $this->set('filterLanguage', $lang);
+        $this->set(compact('total', 'totalLimit'));
 
         if (!CurrentUser::isMember() || CurrentUser::getSetting('use_new_design')) {
             $this->render('show_angular');

--- a/src/Controller/SentencesListsController.php
+++ b/src/Controller/SentencesListsController.php
@@ -196,7 +196,7 @@ class SentencesListsController extends AppController
 
         $this->paginate = [
             'limit' => CurrentUser::getSetting('sentences_per_page'),
-            'sort' => $this->request->getQuery('sort', 'created'),
+            'sort' => $this->request->getQuery('sort', 'id'),
             'direction' => $this->request->getQuery('direction', 'desc'),
         ];
         $finder = ['latest' => $options];

--- a/src/Controller/TagsController.php
+++ b/src/Controller/TagsController.php
@@ -216,6 +216,8 @@ class TagsController extends AppController
                 'limit' => CurrentUser::getSetting('sentences_per_page'),
                 'sort' => $this->request->getQuery('sort', 'id'),
                 'direction' => $this->request->getQuery('direction', 'desc'),
+                // keep added_time for backward compatibility
+                'sortWhitelist' => ['id', 'sentence_id', 'added_time'],
             ];
             $finder = ['latest' => $options];
             $sentences = $this->paginate($this->TagsSentences, compact('finder'));

--- a/src/Controller/TagsController.php
+++ b/src/Controller/TagsController.php
@@ -214,7 +214,7 @@ class TagsController extends AppController
 
             $this->paginate = [
                 'limit' => CurrentUser::getSetting('sentences_per_page'),
-                'sort' => $this->request->getQuery('sort', 'added_time'),
+                'sort' => $this->request->getQuery('sort', 'id'),
                 'direction' => $this->request->getQuery('direction', 'desc'),
             ];
             $finder = ['latest' => $options];

--- a/src/Model/Behavior/LimitResultsBehavior.php
+++ b/src/Model/Behavior/LimitResultsBehavior.php
@@ -144,10 +144,9 @@ class LimitResultsBehavior extends Behavior
             ->find('list', ['valueField' => 'i'])
             ->select(['i' => $orderField], true)
             ->contain($contain, true)
-            ->limit($options['maxResults'])
-            ->offset(null)
+            ->offset($options['maxResults'] - 1)
             ->group([], true)
-            ->last();
+            ->first();
 
         if ($lastValue) {
             $cmp = $direction == 'desc' ? '>=' : '<=';

--- a/src/Model/Behavior/LimitResultsBehavior.php
+++ b/src/Model/Behavior/LimitResultsBehavior.php
@@ -108,6 +108,9 @@ class LimitResultsBehavior extends Behavior
             ->group([], true)
             ->last();
 
-        return $query->where([$alias . '.id >=' => $lastId]);
+        if ($lastId) {
+            $query->where([$alias . '.id >=' => $lastId]);
+        }
+        return $query;
     }
 }

--- a/src/Model/Behavior/LimitResultsBehavior.php
+++ b/src/Model/Behavior/LimitResultsBehavior.php
@@ -86,30 +86,67 @@ class LimitResultsBehavior extends Behavior
     }
 
     /**
+     * Retrieve field and direction used in ORDER BY clause of a query.
+     *
+     * Helper function for findLatest.
+     * Only supports ORDER BY on a single field.
+     *
+     * @param array $query The query to retrieve from.
+     *
+     * @return array Field name and direction.
+     **/
+    private function getOrderValues(Query $query) {
+        $direction = null;
+        $orderField = null;
+
+        $order = $query->clause('order');
+        if ($order) {
+            $order->iterateParts(function($v, $k) use (&$direction, &$orderField) {
+                if (is_numeric($k)) {
+                    $orderField = $v;
+                } else {
+                    $orderField = $k;
+                    $direction = strtolower($v);
+                }
+                return $v;
+            });
+        }
+
+        return [$orderField, $direction];
+    }
+
+    /**
      * This custom finder is used to add a strong and efficient
-     * limit to a query by adding a WHERE id > n clause.
+     * limit to a query by adding a WHERE _field_ > n clause,
+     * _field_ being the field used in ORDER BY, typically it is id.
      * It is used as a safeguard for paginated results because
      * browsing pages of high numbers results in very poor
      * performance.
      */
     public function findLatest(Query $query, array $options) {
+        list($orderField, $direction) = $this->getOrderValues($query);
+        if (!$orderField) {
+            return $query;
+        }
+
         $alias = $query->repository()->getAlias();
 
         $contain = $this->getMinimalContain($query);
 
         $internalQuery = clone $query;
         $this->removeLeftJoins($internalQuery);
-        $lastId = $internalQuery->find('list')
-            ->select([$alias . '.id'], true)
+        $lastValue = $internalQuery
+            ->find('list', ['valueField' => 'i'])
+            ->select(['i' => $orderField], true)
             ->contain($contain, true)
-            ->order([$alias . '.id' => 'DESC'], true)
             ->limit($options['maxResults'])
             ->offset(null)
             ->group([], true)
             ->last();
 
-        if ($lastId) {
-            $query->where([$alias . '.id >=' => $lastId]);
+        if ($lastValue) {
+            $cmp = $direction == 'desc' ? '>=' : '<=';
+            $query->where(["$orderField $cmp" => $lastValue]);
         }
         return $query;
     }

--- a/src/Model/Behavior/LimitResultsBehavior.php
+++ b/src/Model/Behavior/LimitResultsBehavior.php
@@ -94,7 +94,6 @@ class LimitResultsBehavior extends Behavior
      */
     public function findLatest(Query $query, array $options) {
         $alias = $query->repository()->getAlias();
-        $additionalOrder = [$alias . '.id' => 'DESC'];
 
         $contain = $this->getMinimalContain($query);
 
@@ -103,8 +102,10 @@ class LimitResultsBehavior extends Behavior
         $lastId = $internalQuery->find('list')
             ->select([$alias . '.id'], true)
             ->contain($contain, true)
-            ->order($additionalOrder)
+            ->order([$alias . '.id' => 'DESC'], true)
             ->limit($options['maxResults'])
+            ->offset(null)
+            ->group([], true)
             ->last();
 
         return $query->where([$alias . '.id >=' => $lastId]);

--- a/src/Model/Behavior/LimitResultsBehavior.php
+++ b/src/Model/Behavior/LimitResultsBehavior.php
@@ -18,6 +18,7 @@
  */
 namespace App\Model\Behavior;
 
+use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\Behavior;
 use Cake\ORM\Query;
 
@@ -126,7 +127,11 @@ class LimitResultsBehavior extends Behavior
     public function findLatest(Query $query, array $options) {
         list($orderField, $direction) = $this->getOrderValues($query);
         if (!$orderField) {
-            return $query;
+            // We cannot limit the results without a sort order. If there is
+            // no sort order, it means the programmer forgot to set one, or
+            // the client is playing tricks requesting a non-whitelisted
+            // order. Both are good reasons to bail out.
+            throw new BadRequestException("Invalid sort order");
         }
 
         $alias = $query->repository()->getAlias();

--- a/src/Model/Table/AudiosTable.php
+++ b/src/Model/Table/AudiosTable.php
@@ -193,8 +193,7 @@ class AudiosTable extends Table
         $subquery = $query
             ->applyOptions($options)
             ->select(['sentence_id' => 'sentence_id'])
-            ->group(['sentence_id'])
-            ->order(['MAX(Audios.id)' => 'DESC']);
+            ->order(['Audios.id' => 'DESC']);
 
         if (isset($options['lang'])) {
             $subquery->where(['sentence_lang' => $options['lang']]);
@@ -207,6 +206,10 @@ class AudiosTable extends Table
         if (isset($options['maxResults'])) {
             $subquery = $subquery->find('latest', $options);
         }
+
+        $subquery = $subquery
+            ->group(['sentence_id'])
+            ->order(['MAX(Audios.id)' => 'DESC'], true);
 
         $query = $this->Sentences
             ->find()

--- a/src/Model/Table/AudiosTable.php
+++ b/src/Model/Table/AudiosTable.php
@@ -231,6 +231,25 @@ class AudiosTable extends Table
     }
 
     /**
+     * Custom finder for optimized count of total sentences having audio
+     */
+    public function findSentencesCount(Query $query, array $options) {
+        $cache_key = 'audio_sentences_count_';
+
+        if (isset($options['lang'])) {
+            $query->where(['sentence_lang' => $options['lang']]);
+            $cache_key .= $options['lang'];
+        }
+
+        return $query
+            ->cache($cache_key)
+            ->disableHydration()
+            ->select(['cnt' => 'COUNT(DISTINCT sentence_id)'])
+            ->first()
+            ['cnt'];
+    }
+
+    /**
      * Assign author to an audio entity.
      *
      * @param Audio   $entity                      Entity of the audio.

--- a/src/Model/Table/SentencesSentencesListsTable.php
+++ b/src/Model/Table/SentencesSentencesListsTable.php
@@ -32,6 +32,7 @@ class SentencesSentencesListsTable extends Table
         $this->belongsTo('Sentences');
         $this->belongsTo('SentencesLists');
         
+        $this->addBehavior('LimitResults');
         $this->addBehavior('Timestamp');
         if (Configure::read('Search.enabled')) {
             $this->addBehavior('Sphinx', ['alias' => $this->getAlias()]);

--- a/src/Model/Table/TagsSentencesTable.php
+++ b/src/Model/Table/TagsSentencesTable.php
@@ -35,6 +35,7 @@ class TagsSentencesTable extends Table
             $this->addBehavior('Sphinx', ['alias' => $this->getAlias()]);
         }
 
+        $this->addBehavior('LimitResults');
         $this->addBehavior('Timestamp', [
             'events' => [
                 'Model.beforeSave' => ['added_time' => 'new']

--- a/src/Template/Audio/index.ctp
+++ b/src/Template/Audio/index.ctp
@@ -58,16 +58,7 @@ if (isset($sentencesWithAudio)) {
 
         <md-content layout-padding>
         <?php
-        if ($total > $this->Paginator->param('count')) {
-            ?>
-            <div layout-padding>
-            <?= format(
-                __('Only sentences having the last {n} audios are displayed here.'),
-                ['n' => $this->Number->format($totalLimit)]
-            ); ?>
-            </div>
-            <?php
-        }
+        $this->Pagination->warnLimitedResults($totalLimit, $total > $this->Paginator->param('count'));
 
         $this->Pagination->display();
 

--- a/src/Template/Audio/index.ctp
+++ b/src/Template/Audio/index.ctp
@@ -49,20 +49,26 @@ if (isset($sentencesWithAudio)) {
             __('There are no sentences with audio')
         ));
     } else {
-        $title = $this->Paginator->counter(
-            array(
-                'format' => $title . ' ' . __("(total {{count}})")
-            )
-        );
         ?>        
         <md-toolbar class="md-hue-2">
             <div class="md-toolbar-tools">
-                <h2><?= $title ?></h2>
+                <?= $this->Pages->formatTitleWithResultCount($this->Paginator, $title, $total, true); ?>
             </div>
         </md-toolbar>
 
         <md-content layout-padding>
         <?php
+        if ($total > $this->Paginator->param('count')) {
+            ?>
+            <div layout-padding>
+            <?= format(
+                __('Only sentences having the last {n} audios are displayed here.'),
+                ['n' => $this->Number->format($totalLimit)]
+            ); ?>
+            </div>
+            <?php
+        }
+
         $this->Pagination->display();
 
         $type = 'mainSentence';

--- a/src/Template/Audio/of.ctp
+++ b/src/Template/Audio/of.ctp
@@ -95,6 +95,17 @@ if (isset($sentencesWithAudio)) {
 
         $this->Pagination->display();
 
+        if ($totalAudio > $totalLimit) {
+            ?>
+            <div layout-padding>
+            <?= format(
+                __('Only sentences having the last {n} audios are displayed here.'),
+                ['n' => $this->Number->format($totalLimit)]
+            ); ?>
+            </div>
+            <?php
+        }
+
         $type = 'mainSentence';
         $parentId = null;
         $withAudio = true;

--- a/src/Template/Audio/of.ctp
+++ b/src/Template/Audio/of.ctp
@@ -93,18 +93,9 @@ if (isset($sentencesWithAudio)) {
             $this->safeForAngular($licenceMessage)
         );
 
-        $this->Pagination->display();
+        $this->Pagination->warnLimitedResults($totalLimit, $totalAudio > $totalLimit);
 
-        if ($totalAudio > $totalLimit) {
-            ?>
-            <div layout-padding>
-            <?= format(
-                __('Only sentences having the last {n} audios are displayed here.'),
-                ['n' => $this->Number->format($totalLimit)]
-            ); ?>
-            </div>
-            <?php
-        }
+        $this->Pagination->display();
 
         $type = 'mainSentence';
         $parentId = null;

--- a/src/Template/Contributions/of_user.ctp
+++ b/src/Template/Contributions/of_user.ctp
@@ -63,15 +63,12 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
         <md-content>
         <?php
         if (isset($contributions)) {
-            ?>
-            <div layout-padding>
-                <?= format(
-                    __('Only the last {n} contributions are displayed here.'),
-                    ['n' => $this->Number->format($totalLimit)]
-                ); ?>
-            </div>
+            // We don't know the total without limit, so instead, assume that
+            // if the number of results equals the limit, results are truncated
+            $this->Pagination->warnLimitedResults($totalLimit, $totalLimit <= $this->Paginator->param('count'));
 
-            <?php $this->Pagination->display(['last' => false]); ?>
+            $this->Pagination->display(['last' => false]);
+            ?>
 
             <md-list id="logs">
             <?php

--- a/src/Template/Sentences/show_all_in.ctp
+++ b/src/Template/Sentences/show_all_in.ctp
@@ -57,16 +57,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
     <md-content>
     <?php
     if (!empty($results)) {
-        if ($total > $totalLimit) {
-            ?>
-            <div layout-padding>
-            <?= format(
-                __('Only the last {n} sentences are displayed here.'),
-                ['n' => $this->Number->format($totalLimit)]
-            ); ?>
-            </div>
-            <?php
-        }
+        $this->Pagination->warnLimitedResults($totalLimit, $total);
 
         $this->Pagination->display();
 

--- a/src/Template/SentencesLists/show.ctp
+++ b/src/Template/SentencesLists/show.ctp
@@ -34,7 +34,6 @@ $this->Html->script(
     JS_PATH . 'sentences_lists.remove_sentence_from_list.js', array('block' => 'scriptBottom')
 );
 
-$listCount = $this->Paginator->param('count');
 $listId = $list['id'];
 $listVisibility = $list['visibility'];
 $listName = h($list['name']);
@@ -72,10 +71,10 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
                 /* @translators: number of sentences contained in the list */
                 'Contains {n}&nbsp;sentence',
                 'Contains {n}&nbsp;sentences',
-                $listCount,
+                $total,
                 true
             ),
-            array('n' => $this->Number->format($listCount))
+            array('n' => $this->Number->format($total))
         );
         echo $this->Html->tag('p', $numberOfSentencesMsg);
         ?>
@@ -174,6 +173,18 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
          data-list-id="<?php echo $listId; ?>">
     <?php
     $this->Pagination->display();
+
+    if ($total > $this->Paginator->param('count') && $this->Paginator->param('count') >= $totalLimit) {
+        ?>
+        <div layout-padding>
+        <?= format(
+            __('Only the first {n} sentences of the selected sort are displayed here.'),
+            ['n' => $this->Number->format($totalLimit)]
+        ); ?>
+        </div>
+        <?php
+    }
+
     foreach ($sentencesInList as $item) {
         $sentence = $item->sentence;
         $this->Lists->displaySentence(

--- a/src/Template/SentencesLists/show.ctp
+++ b/src/Template/SentencesLists/show.ctp
@@ -163,7 +163,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
     <div class="sortBy" id="sortBy">
      <strong><?php echo __("Sort by:") ?> </strong>
             <?php
-            echo $this->Paginator->sort('created', __('date added to list'));
+            echo $this->Paginator->sort('id', __('date added to list'));
             echo ' | ';
             echo $this->Paginator->sort('sentence_id', __('date created'));
     ?>

--- a/src/Template/SentencesLists/show.ctp
+++ b/src/Template/SentencesLists/show.ctp
@@ -172,18 +172,9 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
     <div class="sentencesList" id="sentencesList"
          data-list-id="<?php echo $listId; ?>">
     <?php
-    $this->Pagination->display();
+    $this->Pagination->warnLimitedResults($totalLimit, $total);
 
-    if ($total > $this->Paginator->param('count') && $this->Paginator->param('count') >= $totalLimit) {
-        ?>
-        <div layout-padding>
-        <?= format(
-            __('Only the first {n} sentences of the selected sort are displayed here.'),
-            ['n' => $this->Number->format($totalLimit)]
-        ); ?>
-        </div>
-        <?php
-    }
+    $this->Pagination->display();
 
     foreach ($sentencesInList as $item) {
         $sentence = $item->sentence;

--- a/src/Template/SentencesLists/show_angular.ctp
+++ b/src/Template/SentencesLists/show_angular.ctp
@@ -4,7 +4,6 @@ use App\Model\Entity\SentencesList;
 
 $this->Html->script('/js/sentences_lists/show.ctrl.js', ['block' => 'scriptBottom']);
 
-$listCount = $this->Paginator->param('count');
 $listId = $list['id'];
 $listVisibility = $list['visibility'];
 $listName = h($list['name']);
@@ -67,10 +66,10 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
                 /* @translators: number of sentences contained in the list */
                 'Contains {n}&nbsp;sentence',
                 'Contains {n}&nbsp;sentences',
-                $listCount,
+                $total,
                 true
             ),
-            array('n' => $this->Number->format($listCount))
+            array('n' => $this->Number->format($total))
         );
         echo $this->Html->tag('p', $numberOfSentencesMsg);
         ?>
@@ -238,6 +237,17 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
     <?php $this->Pagination->display(); ?>
 
     <?php
+    if ($total > $this->Paginator->param('count') && $this->Paginator->param('count') >= $totalLimit) {
+        ?>
+        <div layout-padding>
+        <?= format(
+            __('Only the first {n} sentences of the selected sort are displayed here.'),
+            ['n' => $this->Number->format($totalLimit)]
+        ); ?>
+        </div>
+        <?php
+    }
+
     if ($permissions['canAddSentences']) {
         echo $this->element('sentences_lists/sentence_in_list', [
             'sentenceAndTranslationsParams' => [

--- a/src/Template/SentencesLists/show_angular.ctp
+++ b/src/Template/SentencesLists/show_angular.ctp
@@ -136,9 +136,9 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
             <?php 
                 $options = array(
                     /* @translators: sort option in a list page */
-                    array('param' => 'created', 'direction' => 'desc', 'label' => __('Most recently added')),
+                    array('param' => 'id', 'direction' => 'desc', 'label' => __('Most recently added')),
                     /* @translators: sort option in a list page */
-                    array('param' => 'created', 'direction' => 'asc', 'label' => __('Least recently added')),
+                    array('param' => 'id', 'direction' => 'asc', 'label' => __('Least recently added')),
                     /* @translators: sort option in a list page */
                     array('param' => 'sentence_id', 'direction' => 'desc', 'label' => __('Newest sentences')),
                     /* @translators: sort option in a list page */

--- a/src/Template/SentencesLists/show_angular.ctp
+++ b/src/Template/SentencesLists/show_angular.ctp
@@ -231,22 +231,10 @@ $this->set('title_for_layout', $this->Pages->formatTitle($listName));
         </div>
         <?php
     }
-    ?>
-    
-    
-    <?php $this->Pagination->display(); ?>
 
-    <?php
-    if ($total > $this->Paginator->param('count') && $this->Paginator->param('count') >= $totalLimit) {
-        ?>
-        <div layout-padding>
-        <?= format(
-            __('Only the first {n} sentences of the selected sort are displayed here.'),
-            ['n' => $this->Number->format($totalLimit)]
-        ); ?>
-        </div>
-        <?php
-    }
+    $this->Pagination->warnLimitedResults($totalLimit, $total);
+
+    $this->Pagination->display();
 
     if ($permissions['canAddSentences']) {
         echo $this->element('sentences_lists/sentence_in_list', [

--- a/src/Template/Tags/show_sentences_with_tag.ctp
+++ b/src/Template/Tags/show_sentences_with_tag.ctp
@@ -71,9 +71,9 @@ $tagsIndexUrl = $this->Url->build([
                     /* @translators: sort option in a "Sentences with tag" page */
                     array('param' => 'sentence_id', 'direction' => 'asc', 'label' => __('Oldest sentences first')),
                     /* @translators: sort option in a "Sentences with tag" page */
-                    array('param' => 'added_time', 'direction' => 'desc', 'label' => __('Most recently tagged')),
+                    array('param' => 'id', 'direction' => 'desc', 'label' => __('Most recently tagged')),
                     /* @translators: sort option in a "Sentences with tag" page */
-                    array('param' => 'added_time', 'direction' => 'asc', 'label' => __('Least recently tagged'))
+                    array('param' => 'id', 'direction' => 'asc', 'label' => __('Least recently tagged'))
                 );
                 echo $this->element('sort_menu', array('options' => $options));
             ?>

--- a/src/Template/Tags/show_sentences_with_tag.ctp
+++ b/src/Template/Tags/show_sentences_with_tag.ctp
@@ -51,7 +51,7 @@ $tagsIndexUrl = $this->Url->build([
         <div class="md-toolbar-tools">
             <h2 flex>
             <?php
-            $n = $this->Paginator->param('count');
+            $n = $total;
             echo format(
                 __n('{tagName} ({n} sentence)', '{tagName} ({n} sentences)', $n),
                 array(
@@ -84,6 +84,15 @@ $tagsIndexUrl = $this->Url->build([
     <md-content>
 
         <?php $this->Pagination->display(); ?>
+
+        <?php if ($total > $totalLimit): ?>
+            <div layout-padding>
+            <?= format(
+                __('Only the first {n} sentences of the selected sort are displayed here.'),
+                ['n' => $this->Number->format($totalLimit)]
+            ); ?>
+            </div>
+        <?php endif; ?>
 
         <div class="sentencesList" id="sentencesList">
             <?php

--- a/src/Template/Tags/show_sentences_with_tag.ctp
+++ b/src/Template/Tags/show_sentences_with_tag.ctp
@@ -83,16 +83,10 @@ $tagsIndexUrl = $this->Url->build([
 
     <md-content>
 
-        <?php $this->Pagination->display(); ?>
-
-        <?php if ($total > $totalLimit): ?>
-            <div layout-padding>
-            <?= format(
-                __('Only the first {n} sentences of the selected sort are displayed here.'),
-                ['n' => $this->Number->format($totalLimit)]
-            ); ?>
-            </div>
-        <?php endif; ?>
+        <?php
+            $this->Pagination->warnLimitedResults($totalLimit, $total);
+            $this->Pagination->display();
+        ?>
 
         <div class="sentencesList" id="sentencesList">
             <?php

--- a/src/View/Helper/PaginationHelper.php
+++ b/src/View/Helper/PaginationHelper.php
@@ -40,7 +40,7 @@ use App\View\Helper\AppHelper;
  */
 class PaginationHelper extends AppHelper
 {
-    public $helpers = array('Paginator', 'Html');
+    public $helpers = array('Paginator', 'Html', 'Number');
 
     /**
      * Wraps Paginator->sort with default order
@@ -131,6 +131,59 @@ class PaginationHelper extends AppHelper
             ?>
         </ul>
         <?php
+    }
+
+    /**
+     * Display warning about limited number of results, if applicable.
+     *
+     * @param int $totalLimit Hard limit on the number of results displayed
+     * @param mixed $total If boolean: display message or not. If int: number
+     *                     of results that could be displayed if no limit
+     *
+     * @return void
+     */
+    public function warnLimitedResults($totalLimit, $total = true)
+    {
+        if ((is_bool($total) && $total)
+            ||
+            (is_int($total) && $total > $this->Paginator->param('count'))) {
+            switch ($this->_View->getName()) {
+                case 'Audio':
+                    $msg = __n(
+                        'Only the sentence having the last audio is displayed here.',
+                        'Only sentences having the last {n} audios are displayed here.',
+                        $totalLimit
+                    );
+                    break;
+                case 'Contributions':
+                    $msg = __n(
+                        'Only the last contribution is displayed here.',
+                        'Only the last {n} contributions are displayed here.',
+                        $totalLimit
+                    );
+                    break;
+                case 'SentencesLists':
+                case 'Tags':
+                    $msg = __n(
+                        'Only the first sentence of the selected sort is displayed here.',
+                        'Only the first {n} sentences of the selected sort are displayed here.',
+                        $totalLimit
+                    );
+                    break;
+                default:
+                    $msg = __n(
+                        'Only the last sentence is displayed here.',
+                        'Only the last {n} sentences are displayed here.',
+                        $totalLimit
+                    );
+            }
+            ?>
+            <div layout-margin layout="row" layout-align="start center">
+                <md-icon>info</md-icon>
+                <span layout-fill><?= h(format($msg, ['n' => $this->Number->format($totalLimit)])) ?></span>
+            </div>
+            <?php
+        }
     }
 }
 ?>

--- a/tests/TestCase/Controller/AudioControllerTest.php
+++ b/tests/TestCase/Controller/AudioControllerTest.php
@@ -99,6 +99,9 @@ class AudioControllerTest extends IntegrationTestCase
 
         $this->get("/en/audio/index/eng?page=9999999");
         $this->assertRedirect("/en/audio/index/eng?page=$expectedLastPage");
+
+        $this->get("/en/audio/of/kazuki?page=9999999");
+        $this->assertRedirect("/en/audio/of/kazuki?page=$expectedLastPage");
     }
 
     public function testAudioDownload_missingFile() {

--- a/tests/TestCase/Controller/AudioControllerTest.php
+++ b/tests/TestCase/Controller/AudioControllerTest.php
@@ -16,6 +16,7 @@ class AudioControllerTest extends IntegrationTestCase
 
     public $fixtures = [
         'app.audios',
+        'app.contributions',
         'app.disabled_audios',
         'app.languages',
         'app.private_messages',
@@ -64,6 +65,40 @@ class AudioControllerTest extends IntegrationTestCase
      */
     public function testAudioControllerAccess($url, $user, $response) {
         $this->assertAccessUrlAs($url, $user, $response);
+    }
+
+    private function addSentencesWithAudio($nbSentences) {
+        $sentences = TableRegistry::getTableLocator()->get('Sentences');
+        $kazukiUserId = 7;
+        $newSentences = [];
+        for ($i = 1; $i <= $nbSentences; $i++) {
+            $newSentences[] = [
+                'lang' => 'eng',
+                'text' => "Ay ay ay $i.",
+                'user_id' => $kazukiUserId,
+                'audios' => [
+                    ['user_id' => $kazukiUserId],
+                ],
+            ];
+        }
+        $entities = $sentences->newEntities($newSentences, [
+            // 'validate' => false is to avoid triggering
+            // "sentence_id required on create" validation rule
+            'associated' => ['Audios' => ['validate' => false]]
+        ]);
+        $sentences->saveMany($entities);
+    }
+
+    public function testPaginateRedirectsPageOutOfBoundsToLastPage_asGuest() {
+        $defaultNbPerPage = (new \App\Controller\AudioController())->paginate['limit'];
+        $nbSentences = $this->addSentencesWithAudio($defaultNbPerPage + 1);
+        $expectedLastPage = 2;
+
+        $this->get("/en/audio/index?page=9999999");
+        $this->assertRedirect("/en/audio/index?page=$expectedLastPage");
+
+        $this->get("/en/audio/index/eng?page=9999999");
+        $this->assertRedirect("/en/audio/index/eng?page=$expectedLastPage");
     }
 
     public function testAudioDownload_missingFile() {

--- a/tests/TestCase/Controller/SentencesListsControllerTest.php
+++ b/tests/TestCase/Controller/SentencesListsControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Test\TestCase\Controller;
 
+use App\Model\Entity\User;
 use App\Test\TestCase\Controller\TatoebaControllerTestTrait;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestCase;
@@ -12,6 +13,7 @@ class SentencesListsControllerTest extends IntegrationTestCase
     public $fixtures = [
         'app.audios',
         'app.contributions',
+        'app.disabled_audios',
         'app.favorites_users',
         'app.languages',
         'app.links',
@@ -237,4 +239,54 @@ class SentencesListsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(301);
         $this->assertRedirectContains("/en/sentences_lists/show/$lastId/und/cmn");
     }
+
+    private function addSentencesToList($listId, $nbSentences, $userId = 1) {
+        $newSentences = [];
+        for ($i = 1; $i <= $nbSentences; $i++) {
+            $newSentences[] = [
+                'lang' => 'eng',
+                'text' => "Test sentence number $i.",
+                'user_id' => $userId,
+            ];
+        }
+        $sentences = TableRegistry::getTableLocator()->get('Sentences');
+        $entities = $sentences->newEntities($newSentences);
+        $sentences->saveMany($entities);
+
+        $sentencesLists = TableRegistry::getTableLocator()->get('SentencesLists');
+        $sentencesLists->addSentencesToList($entities, $listId, $userId);
+
+        return $sentencesLists->getNumberOfSentences($listId);
+    }
+
+    public function testPaginateRedirectsPageOutOfBoundsToLastPage_asGuest() {
+        $listId = 5;
+        $defaultNbPerPage = User::$defaultSettings['sentences_per_page'];
+
+        $nbSentences = $this->addSentencesToList($listId, $defaultNbPerPage * 2 + 1);
+
+        $lastPage = ceil($nbSentences / $defaultNbPerPage);
+        $this->assertEquals(3, $lastPage);
+
+        $this->get("/en/sentences_lists/show/$listId/und/und?page=9999999");
+        $this->assertRedirect("/en/sentences_lists/show/$listId/und/und?page=$lastPage");
+    }
+
+    public function testPaginateRedirectsPageOutOfBoundsToLastPage_withUserSetting() {
+        $listId = 5;
+        $user = 'kazuki';
+        $userId = 7;
+        $users = TableRegistry::getTableLocator()->get('Users');
+        $nbPerPageSetting = $users->getSettings($userId)['settings']['sentences_per_page'];
+
+        $nbSentences = $this->addSentencesToList($listId, $nbPerPageSetting * 2 + 1);
+
+        $lastPage = ceil($nbSentences / $nbPerPageSetting);
+        $this->assertEquals(3, $lastPage);
+
+        $this->logInAs($user);
+        $this->get("/en/sentences_lists/show/$listId/und/und?page=9999999");
+        $this->assertRedirect("/en/sentences_lists/show/$listId/und/und?page=$lastPage");
+    }
+
 }

--- a/tests/TestCase/Model/Behavior/LimitResultsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LimitResultsBehaviorTest.php
@@ -84,7 +84,19 @@ class LimitResultsBehaviorTest extends TestCase
         $this->query
              ->expects($this->once())
              ->method('where')
-             ->with(['Sentences.id >=' => 2]);
+             ->with(['Sentences.id >=' => 24]);
+
+        $this->behavior->findLatest($this->query, ['maxResults' => 2]);
+    }
+
+    public function testFindLatest_whereOnMainTable_noLimitNeeded()
+    {
+        $this->query
+             ->where(['Sentences.lang' => 'cmn']);
+
+        $this->query
+             ->expects($this->never())
+             ->method('where');
 
         $this->behavior->findLatest($this->query, ['maxResults' => 20]);
     }
@@ -121,9 +133,8 @@ class LimitResultsBehaviorTest extends TestCase
              ->where(['Sentences.lang IS' => null]);
 
         $this->query
-             ->expects($this->once())
-             ->method('where')
-             ->with(['Sentences.id >=' => 9]);
+             ->expects($this->never())
+             ->method('where');
 
         $this->behavior->findLatest($this->query, ['maxResults' => 20]);
     }

--- a/tests/TestCase/Model/Behavior/LimitResultsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LimitResultsBehaviorTest.php
@@ -79,9 +79,8 @@ class LimitResultsBehaviorTest extends TestCase
              ->where(['Sentences.id' => 0]);
 
         $this->query
-             ->expects($this->once())
-             ->method('where')
-             ->with(['Sentences.id >=' => null]);
+             ->expects($this->never())
+             ->method('where');
 
         $this->behavior->findLatest($this->query, ['maxResults' => 20]);
     }

--- a/tests/TestCase/Model/Behavior/LimitResultsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LimitResultsBehaviorTest.php
@@ -46,6 +46,38 @@ class LimitResultsBehaviorTest extends TestCase
         $this->behavior->findLatest($this->query, ['maxResults' => 20]);
     }
 
+    public function testFindLatest_reverse()
+    {
+        $this->query->order(['Sentences.id' => 'ASC'], true);
+        $this->query
+             ->expects($this->once())
+             ->method('where')
+             ->with(['Sentences.id <=' => 21]);
+
+        $this->behavior->findLatest($this->query, ['maxResults' => 20]);
+    }
+
+    public function testFindLatest_noOrder()
+    {
+        $this->query->order(false, true);
+        $this->query
+             ->expects($this->never())
+             ->method('where');
+
+        $this->behavior->findLatest($this->query, ['maxResults' => 20]);
+    }
+
+    public function testFindLatest_noExplicitDirection()
+    {
+        $this->query->order('Sentences.id', true);
+        $this->query
+             ->expects($this->once())
+             ->method('where')
+             ->with(['Sentences.id <=' => 21]);
+
+        $this->behavior->findLatest($this->query, ['maxResults' => 20]);
+    }
+
     public function testFindLatest_whereOnMainTable()
     {
         $this->query

--- a/tests/TestCase/Model/Behavior/LimitResultsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LimitResultsBehaviorTest.php
@@ -60,9 +60,7 @@ class LimitResultsBehaviorTest extends TestCase
     public function testFindLatest_noOrder()
     {
         $this->query->order(false, true);
-        $this->query
-             ->expects($this->never())
-             ->method('where');
+        $this->expectException(\Cake\Http\Exception\BadRequestException::class);
 
         $this->behavior->findLatest($this->query, ['maxResults' => 20]);
     }

--- a/tests/TestCase/Model/Table/AudiosTableTest.php
+++ b/tests/TestCase/Model/Table/AudiosTableTest.php
@@ -423,6 +423,18 @@ class AudiosTableTest extends TestCase {
         $this->assertEquals(3, $result[0]->audios[0]->user_id);
     }
 
+    function testSentencesCountFinder() {
+        $result = $this->Audio->find('sentencesCount');
+
+        $this->assertEquals(5, $result);
+    }
+
+    function testSentencesCountFinder_withLang() {
+        $result = $this->Audio->find('sentencesCount', ['lang' => 'fra']);
+
+        $this->assertEquals(2, $result);
+    }
+
     function testChangeSentenceLangChangesAudioSentenceLang() {
         $DisabledAudios = TableRegistry::getTableLocator()->get('DisabledAudios');
         $sentenceId = 3;

--- a/tests/TestCase/Model/Table/AudiosTableTest.php
+++ b/tests/TestCase/Model/Table/AudiosTableTest.php
@@ -350,14 +350,32 @@ class AudiosTableTest extends TestCase {
         $this->assertEquals(15, $result[1]->id);
         $this->assertEquals(1, count($result[1]->audios));
 
-        $this->assertEquals(12, $result[2]->id);
-        $this->assertEquals(1, count($result[2]->audios));
+        $this->assertEquals(4, $result[2]->id);
+        $this->assertEquals(2, count($result[2]->audios));
 
-        $this->assertEquals(4, $result[3]->id);
-        $this->assertEquals(2, count($result[3]->audios));
+        $this->assertEquals(12, $result[3]->id);
+        $this->assertEquals(1, count($result[3]->audios));
 
         $this->assertEquals(3, $result[4]->id);
         $this->assertEquals(1, count($result[4]->audios));
+    }
+
+    function testSentencesFinder_maxResults() {
+        $result = $this->Audio->find('sentences', ['maxResults' => 5])->all()->toList();
+
+        $this->assertEquals(4, count($result));
+
+        $this->assertEquals(57, $result[0]->id);
+        $this->assertEquals(1, count($result[0]->audios));
+
+        $this->assertEquals(15, $result[1]->id);
+        $this->assertEquals(1, count($result[1]->audios));
+
+        $this->assertEquals(4, $result[2]->id);
+        $this->assertEquals(2, count($result[2]->audios));
+
+        $this->assertEquals(12, $result[3]->id);
+        $this->assertEquals(1, count($result[3]->audios));
     }
 
     function testSentencesFinder_lang() {
@@ -365,11 +383,20 @@ class AudiosTableTest extends TestCase {
 
         $this->assertEquals(2, count($result));
 
-        $this->assertEquals(12, $result[0]->id);
-        $this->assertEquals(1, count($result[0]->audios));
+        $this->assertEquals(4, $result[0]->id);
+        $this->assertEquals(2, count($result[0]->audios));
 
-        $this->assertEquals(4, $result[1]->id);
-        $this->assertEquals(2, count($result[1]->audios));
+        $this->assertEquals(12, $result[1]->id);
+        $this->assertEquals(1, count($result[1]->audios));
+    }
+
+    function testSentencesFinder_lang_maxResults() {
+        $result = $this->Audio->find('sentences', ['lang' => 'fra', 'maxResults' => 1])->all()->toList();
+
+        $this->assertEquals(1, count($result));
+
+        $this->assertEquals(4, $result[0]->id);
+        $this->assertEquals(2, count($result[0]->audios));
     }
 
     function testSentencesFinder_user_id() {
@@ -384,6 +411,16 @@ class AudiosTableTest extends TestCase {
         $this->assertEquals(4, $result[1]->id);
         $this->assertEquals(1, count($result[1]->audios));
         $this->assertEquals(3, $result[1]->audios[0]->user_id);
+    }
+
+    function testSentencesFinder_user_id_maxResults() {
+        $result = $this->Audio->find('sentences', ['user_id' => 3, 'maxResults' => 1])->all()->toList();
+
+        $this->assertEquals(1, count($result));
+
+        $this->assertEquals(15, $result[0]->id);
+        $this->assertEquals(1, count($result[0]->audios));
+        $this->assertEquals(3, $result[0]->audios[0]->user_id);
     }
 
     function testChangeSentenceLangChangesAudioSentenceLang() {


### PR DESCRIPTION
This PR limits the total number of results on listings of sentences that go over 1000.

We already have such limitation on "show all sentences in {language}" and "latest contributions by {user}" (#1353). This PR additionally limits the following listings, that can easily go over thousands of pages, thanks to the contributions of prolific members:

* `/audio/index`
* `/audio/of/{user}`
* `/sentences_lists/show/{n}`
* `/tags/show_sentences_with_tag/{n}`

The rationale for this PR is that we are seeing increasingly aggressive and numerous crawlers going through all these listings. The higher the page number, the more burden for the server. The current workaround is to use nginx to limit the number of requests on high-numbered pages. This workaround is only enabled on tatoeba.org and produces "429 Too Many Requests" error pages. This PR makes these limits more integrated, configurable and user-friendly.

## Notable changes
* On "sentences with tag" and "sentence list" listings, sorts that are not listed in the menu can no longer be used.
* Audio listing is slightly different (corrected). For sentences having multiple audios, the oldest audio was used to rank the sentence. Now, the newest audio is used. This means uploading a new audio or enabling an existing audio to a sentence will immediately push it on the top of the listing.
* Audio listing is further optimized and should load faster

## Audio
<a href="https://dev.tatoeba.org/en/audio/index">
<img width="678" height="283" alt="image" src="https://github.com/user-attachments/assets/9e3701a1-448e-4ab1-8b31-5de366ea5987" />
</a>
<a href="https://dev.tatoeba.org/en/audio/index/eng">
<img width="673" height="289" alt="image" src="https://github.com/user-attachments/assets/b24c4962-fab4-440d-9fec-be26d24f266b" />
</a>
<a href="https://dev.tatoeba.org/en/audio/of/CK">
<img width="673" height="292" alt="image" src="https://github.com/user-attachments/assets/0ed77e87-b763-476e-a71d-c7d409955db8" />
</a>

## Sentence list
<a href="https://dev.tatoeba.org/en/sentences_lists/show/907">
<img width="673" height="265" alt="image" src="https://github.com/user-attachments/assets/15842ff9-a6bc-4452-ba54-681e8a3e9ba5" />
</a>

## Sentences with tag
<a href="https://dev.tatoeba.org/en/tags/show_sentences_with_tag/4970">
<img width="674" height="260" alt="image" src="https://github.com/user-attachments/assets/e79c3510-041f-43e9-8fc6-05255adc4323" />
</a>