### PR TITLE
Allow to edit vocabulary requests

### DIFF
--- a/src/Controller/AngularTemplatesController.php
+++ b/src/Controller/AngularTemplatesController.php
@@ -29,4 +29,8 @@ class AngularTemplatesController extends AppController
             $this->set(compact('code'));
         }
     }
+
+    public function edit_vocabulary()
+    {
+    }
 }

--- a/src/Controller/VocabularyController.php
+++ b/src/Controller/VocabularyController.php
@@ -158,6 +158,8 @@ class VocabularyController extends AppController
         $this->paginate = $this->Vocabulary->getPaginatedVocabulary($lang);
         $vocabulary = $this->paginate('Vocabulary');
 
+        $vocabulary = $this->Vocabulary->addCanEditPermission($vocabulary);
+
         $this->set('vocabulary', $vocabulary);
         $this->set('langFilter', $lang);
     }

--- a/src/Controller/VocabularyController.php
+++ b/src/Controller/VocabularyController.php
@@ -94,10 +94,11 @@ class VocabularyController extends AppController
         $results = $this->paginate('UsersVocabulary');
 
         $vocabulary = $this->Vocabulary->syncNumSentences($results);
+        $vocabulary = $this->Vocabulary->addCanEditPermission($vocabulary);
 
         $this->set('vocabulary', $vocabulary);
         $this->set('username', $username);
-        $this->set('canEdit', $username == CurrentUser::get('username'));
+        $this->set('canDelete', $username == CurrentUser::get('username'));
     }
 
 

--- a/src/Controller/VocabularyController.php
+++ b/src/Controller/VocabularyController.php
@@ -124,7 +124,8 @@ class VocabularyController extends AppController
             return $this->response->withStatus(404);
         }
 
-        $canEdit = $usersVocab->count() == 1 && $usersVocab->first()->user_id == CurrentUser::get('id');
+        $canEdit = CurrentUser::isModerator() ||
+                   ($usersVocab->count() == 1 && $usersVocab->first()->user_id == CurrentUser::get('id'));
         if (!$canEdit) {
             return $this->response->withStatus(403);
         }

--- a/src/Model/Table/UsersVocabularyTable.php
+++ b/src/Model/Table/UsersVocabularyTable.php
@@ -67,10 +67,10 @@ class UsersVocabularyTable extends Table
 
         $result = [
             'conditions' => $conditions,
-            'fields' => ['created'],
+            'fields' => ['created', 'user_id'],
             'contain' => [
                 'Vocabulary' => [
-                    'fields' => ['id', 'lang', 'text', 'numSentences']
+                    'fields' => ['id', 'lang', 'text', 'numSentences', 'numAdded']
                 ]
             ],
             'limit' => 50,

--- a/src/Model/Table/VocabularyTable.php
+++ b/src/Model/Table/VocabularyTable.php
@@ -233,7 +233,8 @@ class VocabularyTable extends Table
         return $results->map(function ($item) {
             $vocabulary = $item->vocabulary;
             if ($vocabulary->has('numAdded')) {
-                $canEdit = $item->user_id == CurrentUser::get('id') && $vocabulary->numAdded <= 1;
+                $canEdit = CurrentUser::isModerator() ||
+                           ($item->user_id == CurrentUser::get('id') && $vocabulary->numAdded <= 1);
                 $item->vocabulary->canEdit = $canEdit;
             }
             return $item;

--- a/src/Model/Table/VocabularyTable.php
+++ b/src/Model/Table/VocabularyTable.php
@@ -228,6 +228,18 @@ class VocabularyTable extends Table
         });
     }
 
+    public function addCanEditPermission($results)
+    {
+        return $results->map(function ($item) {
+            $vocabulary = $item->vocabulary;
+            if ($vocabulary->has('numAdded')) {
+                $canEdit = $item->user_id == CurrentUser::get('id') && $vocabulary->numAdded <= 1;
+                $item->vocabulary->canEdit = $canEdit;
+            }
+            return $item;
+        });
+    }
+
     /**
      * Updates the number of sentences for a vocabulary item.
      *

--- a/src/Template/AngularTemplates/edit_vocabulary.ctp
+++ b/src/Template/AngularTemplates/edit_vocabulary.ctp
@@ -1,0 +1,63 @@
+<?php
+$langs = $this->loadHelper('Languages')->onlyLanguagesArray(false);
+?>
+
+<md-dialog id="vocab-edit"
+           aria-label="<?= __('Edit vocabulary item') ?>"
+           style="max-width: 500px"
+           ng-cloak>
+    <md-toolbar>
+        <div class="md-toolbar-tools">
+            <h2 flex><?= __('Edit vocabulary item'); ?></h2>
+            <md-button class="md-icon-button" ng-click="ctrl.close()">
+              <md-icon>close</md-icon>
+            </md-button>
+        </div>
+    </md-toolbar>
+
+    <md-dialog-content layout-margin>
+        <div layout="row" layout-margin layout-align="start center" ng-if="!ctrl.canEdit">
+            <md-icon>info</md-icon>
+            <span layout-fill><?= h(
+                __('You cannot edit this vocabulary item because other members '.
+                   'happen to have added it, too. You may remove it from your own '.
+                   'list of vocabulary items.')
+            ) ?></span>
+        </div>
+
+        <div layout="row" layout-margin layout-align="center end" ng-if="ctrl.canEdit">
+            <div layout="column">
+                <label for="lang"><?= __('Language:') ?></label>
+                <?= $this->element(
+                    'language_dropdown',
+                    array(
+                        'name' => 'lang',
+                        'languages' => $langs,
+                        'initialSelection' => '{{ctrl.vocab.lang}}',
+                        'selectedLanguage' => 'ctrl.selected_lang',
+                    )
+                ) ?>
+            </div>
+            <md-input-container>
+                <label for="text"><?= __('Vocabulary item') ?></label>
+                <input name="text" ng-attr-lang="{{ctrl.selected_lang.code}}" dir="auto"
+                       ng-model="ctrl.vocab.text" />
+            </md-input-container>
+        </div>
+    </md-dialog-content>
+
+    <md-dialog-actions layout-margin>
+        <md-button flex="33" type="submit" class="md-raised md-warn"
+                   ng-click="ctrl.remove(ctrl.vocab)">
+            <?php /* @translators: button to delete a vocabulary request */ ?>
+            <?= __('Remove'); ?>
+        </md-button>
+        <div flex />
+        <md-button flex="33" type="submit" class="md-raised md-primary"
+                   ng-disabled="!ctrl.canEdit || !ctrl.selected_lang || !ctrl.vocab.text"
+                   ng-click="ctrl.save(ctrl.vocab)">
+            <?php /* @translators: button to save a vocabulary request after edit */ ?>
+            <?= __('Save'); ?>
+        </md-button>
+    </md-dialog-actions>
+</md-dialog>

--- a/src/Template/AngularTemplates/edit_vocabulary.ctp
+++ b/src/Template/AngularTemplates/edit_vocabulary.ctp
@@ -2,8 +2,7 @@
 $langs = $this->loadHelper('Languages')->onlyLanguagesArray(false);
 ?>
 
-<md-dialog id="vocab-edit"
-           aria-label="<?= __('Edit vocabulary item') ?>"
+<md-dialog aria-label="<?= __('Edit vocabulary item') ?>"
            style="max-width: 500px"
            ng-cloak>
     <md-toolbar>

--- a/src/Template/AngularTemplates/edit_vocabulary.ctp
+++ b/src/Template/AngularTemplates/edit_vocabulary.ctp
@@ -48,6 +48,7 @@ $langs = $this->loadHelper('Languages')->onlyLanguagesArray(false);
 
     <md-dialog-actions layout-margin>
         <md-button flex="33" type="submit" class="md-raised md-warn"
+                   ng-disabled="!ctrl.canDelete"
                    ng-click="ctrl.remove(ctrl.vocab)">
             <?php /* @translators: button to delete a vocabulary request */ ?>
             <?= __('Remove'); ?>

--- a/src/Template/Vocabulary/add_sentences.ctp
+++ b/src/Template/Vocabulary/add_sentences.ctp
@@ -27,6 +27,8 @@
 ?>
 <?php
 $this->Html->script('/js/vocabulary/add-sentences.ctrl.js', ['block' => 'scriptBottom']);
+$this->Html->script('/js/services/vocabulary.srv.js', ['block' => 'scriptBottom']);
+
 if (empty($langFilter)) {
     $title = __('Vocabulary that needs sentences');
 } else {
@@ -85,6 +87,12 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
                                class="md-icon-button">
                         <md-icon aria-label="Add">add</md-icon>
                     </md-button>
+                    <?php if ($item->canEdit) { ?>
+                        <md-button ng-cloak ng-click="ctrl.edit(<?= h(json_encode($item)) ?>, <?= json_encode($item->canEdit) ?>, false)"
+                                   class="md-icon-button">
+                            <md-icon aria-label="Edit">edit</md-icon>
+                        </md-button>
+                    <?php } ?>
                 </md-list-item>
                 <div ng-cloak id="sentences_<?= $id ?>" class="new-sentences"
                      ng-show="ctrl.sentencesAdded['<?= $id ?>']">

--- a/src/Template/Vocabulary/of.ctp
+++ b/src/Template/Vocabulary/of.ctp
@@ -64,10 +64,10 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
                 ?>
                 <md-list-item id="vocabulary_<?= $divId ?>">
                     <?= $this->Vocabulary->vocabulary($item); ?>
-                    <?php if ($canEdit) { ?>
-                        <md-button ng-cloak ng-click="ctrl.remove('<?= $divId ?>')"
+                    <?php if ($canDelete || $item->canEdit) { ?>
+                        <md-button ng-cloak ng-click="ctrl.edit(<?= h(json_encode($item)) ?>, <?= json_encode($item->canEdit) ?>)"
                                    class="md-icon-button">
-                            <md-icon aria-label="Remove">delete</md-icon>
+                            <md-icon aria-label="Edit">edit</md-icon>
                         </md-button>
                     <?php } ?>
                 </md-list-item>

--- a/src/Template/Vocabulary/of.ctp
+++ b/src/Template/Vocabulary/of.ctp
@@ -66,7 +66,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
                 <md-list-item id="vocabulary_<?= $divId ?>">
                     <?= $this->Vocabulary->vocabulary($item); ?>
                     <?php if ($canDelete || $item->canEdit) { ?>
-                        <md-button ng-cloak ng-click="ctrl.edit(<?= h(json_encode($item)) ?>, <?= json_encode($item->canEdit) ?>)"
+                        <md-button ng-cloak ng-click="ctrl.edit(<?= h(json_encode($item)) ?>, <?= json_encode($item->canEdit) ?>, <?= json_encode($canDelete) ?>)"
                                    class="md-icon-button">
                             <md-icon aria-label="Edit">edit</md-icon>
                         </md-button>

--- a/src/Template/Vocabulary/of.ctp
+++ b/src/Template/Vocabulary/of.ctp
@@ -27,6 +27,7 @@
 ?>
 <?php
 $this->Html->script('/js/vocabulary/of.ctrl.js', ['block' => 'scriptBottom']);
+$this->Html->script('/js/services/vocabulary.srv.js', ['block' => 'scriptBottom']);
 
 $count = $this->Paginator->param('count');
 $title = format(

--- a/src/View/Helper/VocabularyHelper.php
+++ b/src/View/Helper/VocabularyHelper.php
@@ -26,7 +26,7 @@ use App\Model\Search;
 class VocabularyHelper extends AppHelper
 {
     public $helpers = array(
-        'Html', 'Url'
+        'Html', 'Url', 'Languages'
     );
 
     /**
@@ -63,9 +63,8 @@ class VocabularyHelper extends AppHelper
                 )
             ));
         }
+        echo $this->Languages->icon($lang, ['class' => 'vocabulary-lang']);
         ?>
-        <img class="vocabulary-lang language-icon" width="30" height="20"
-             src="/img/flags/<?= $lang ?>.svg"/>
         <div class="vocabulary-text" flex><?= $text ?></div>
         <md-button ng-cloak class="md-primary" <?= isset($url) ? "href=\"$url\"" : 'ng-disabled="1"' ?>>
             <?= $numSentencesLabel ?>

--- a/tests/Fixture/UsersVocabularyFixture.php
+++ b/tests/Fixture/UsersVocabularyFixture.php
@@ -50,10 +50,24 @@ class UsersVocabularyFixture extends TestFixture
         $this->records = [
             [
                 'id' => 1,
-                'user_id' => 1,
+                'user_id' => 4,
                 'hash' => '',
                 'created' => '2019-01-07 19:50:36',
                 'vocabulary_id' => 1
+            ],
+            [
+                'id' => 2,
+                'user_id' => 7,
+                'hash' => '',
+                'created' => '2020-02-20 02:20:02',
+                'vocabulary_id' => 2
+            ],
+            [
+                'id' => 3,
+                'user_id' => 4,
+                'hash' => '',
+                'created' => '2020-09-10 11:12:13',
+                'vocabulary_id' => 2
             ],
         ];
         parent::init();

--- a/tests/Fixture/VocabularyFixture.php
+++ b/tests/Fixture/VocabularyFixture.php
@@ -51,6 +51,14 @@ class VocabularyFixture extends TestFixture
                 'numAdded' => 1,
                 'created' => '2019-01-07 19:48:18',
             ],
+            [
+                'id' => 2,
+                'lang' => 'eng',
+                'text' => 'added by 2 members',
+                'numSentences' => 1,
+                'numAdded' => 2,
+                'created' => '2020-02-20 02:20:02',
+            ],
         ];
         parent::init();
     }

--- a/tests/TestCase/Controller/VocabularyControllerTest.php
+++ b/tests/TestCase/Controller/VocabularyControllerTest.php
@@ -125,4 +125,13 @@ class VocabularyControllerTest extends IntegrationTestCase
         ]);
         $this->assertResponseCode(403);
     }
+
+    public function testEdit_asCorpusMaintainer_addedByOthersToo() {
+        $this->logInAs('corpus_maintainer');
+        $this->ajaxPost('/en/vocabulary/edit/2', [
+            'lang' => 'fra',
+            'text' => 'hélicoptère',
+        ]);
+        $this->assertResponseOk();
+    }
 }

--- a/tests/TestCase/Controller/VocabularyControllerTest.php
+++ b/tests/TestCase/Controller/VocabularyControllerTest.php
@@ -71,4 +71,58 @@ class VocabularyControllerTest extends IntegrationTestCase
         $this->saveSomething();
         $this->assertResponseOk();
     }
+
+    public function testEdit_asGuest() {
+        $this->enableCsrfToken();
+        $this->ajaxPost('/en/vocabulary/edit/1', [
+            'lang' => 'fra',
+            'text' => 'hélicoptère',
+        ]);
+        $this->assertResponseError();
+    }
+
+    public function testEdit_asMember_onlyAddedBySelf() {
+        $this->logInAs('contributor');
+        $this->ajaxPost('/en/vocabulary/edit/1', [
+            'lang' => 'fra',
+            'text' => 'hélicoptère',
+        ]);
+        $this->assertResponseOk();
+    }
+
+    public function testEdit_asMember_onlyAddedByOtherMember() {
+        $this->logInAs('kazuki');
+        $this->ajaxPost('/en/vocabulary/edit/1', [
+            'lang' => 'fra',
+            'text' => 'hélicoptère',
+        ]);
+        $this->assertResponseError();
+    }
+
+    public function testEdit_asMember_nonExisting() {
+        $this->logInAs('contributor');
+        $this->ajaxPost('/en/vocabulary/edit/999999', [
+            'lang' => 'fra',
+            'text' => 'hélicoptère',
+        ]);
+        $this->assertResponseCode(404);
+    }
+
+    public function testEdit_asMember_invalidLang() {
+        $this->logInAs('contributor');
+        $this->ajaxPost('/en/vocabulary/edit/1', [
+            'lang' => 'invalid',
+            'text' => 'hélicoptère',
+        ]);
+        $this->assertResponseCode(400);
+    }
+
+    public function testEdit_asMember_addedByOthersToo() {
+        $this->logInAs('contributor');
+        $this->ajaxPost('/en/vocabulary/edit/2', [
+            'lang' => 'fra',
+            'text' => 'hélicoptère',
+        ]);
+        $this->assertResponseCode(403);
+    }
 }

--- a/tests/TestCase/Model/Table/UsersVocabularyTableTest.php
+++ b/tests/TestCase/Model/Table/UsersVocabularyTableTest.php
@@ -29,7 +29,7 @@ class UsersVocabularyTableTest extends TestCase
 
     public function testFindFirst_returnsSomething()
     {
-        $result = $this->UsersVocabulary->findFirst(1, 1);
+        $result = $this->UsersVocabulary->findFirst(1, 4);
         $this->assertEquals(1, $result->id);
     }
 

--- a/tests/TestCase/Model/Table/VocabularyTableTest.php
+++ b/tests/TestCase/Model/Table/VocabularyTableTest.php
@@ -33,7 +33,7 @@ class VocabularyTableTest extends TestCase
 
     public function testAddItem_withExistingVocabulary()
     {
-        CurrentUser::store(['id' => 1]);
+        CurrentUser::store(['id' => 4]);
         $result = $this->Vocabulary->addItem('eng', 'out of the blue');
         $this->assertEquals(1, $result->id);
         $this->assertTrue($result->duplicate);
@@ -42,8 +42,11 @@ class VocabularyTableTest extends TestCase
     public function testAddItem_withNewVocabulary()
     {
         CurrentUser::store(['id' => 7]);
+
         $result = $this->Vocabulary->addItem('eng', 'hashtag');
-        $this->assertEquals(2, $result->id);
+
+        $this->assertEquals('eng', $result->lang);
+        $this->assertEquals('hashtag', $result->text);
     }
 
     public function testAddItem_updatesCurrentNumberOfSentences()

--- a/webroot/css/vocabulary.css
+++ b/webroot/css/vocabulary.css
@@ -1,0 +1,3 @@
+md-input-container .md-errors-spacer {
+  display: none;
+}

--- a/webroot/css/vocabulary/add.css
+++ b/webroot/css/vocabulary/add.css
@@ -43,7 +43,3 @@ md-list-item {
     margin-top: 5px;
     width: 150px;
 }
-
-.md-errors-spacer {
-    display: none;
-}

--- a/webroot/css/vocabulary/add_sentences.css
+++ b/webroot/css/vocabulary/add_sentences.css
@@ -31,10 +31,6 @@ md-list-item {
     background: #fff;
 }
 
-md-input-container .md-errors-spacer {
-    display: none;
-}
-
 .sentence-form {
     margin-bottom: 10px;
 }

--- a/webroot/css/vocabulary/of.css
+++ b/webroot/css/vocabulary/of.css
@@ -30,7 +30,3 @@ md-list-item {
     border-top: 1px solid #f1f1f1;
     background: #fff;
 }
-
-#vocab-edit .md-errors-spacer {
-   display: none;
-}

--- a/webroot/css/vocabulary/of.css
+++ b/webroot/css/vocabulary/of.css
@@ -30,3 +30,7 @@ md-list-item {
     border-top: 1px solid #f1f1f1;
     background: #fff;
 }
+
+#vocab-edit .md-errors-spacer {
+   display: none;
+}

--- a/webroot/js/services/vocabulary.srv.js
+++ b/webroot/js/services/vocabulary.srv.js
@@ -24,7 +24,7 @@
                edit: edit
             };
 
-            function edit(vocab, canEdit) {
+            function edit(vocab, canEdit, canDelete) {
                 $mdDialog.show({
                     controller: DialogController,
                     controllerAs: 'ctrl',
@@ -37,6 +37,7 @@
 
                     ctrl.vocab = vocab;
                     ctrl.canEdit = canEdit;
+                    ctrl.canDelete = canDelete;
 
                     ctrl.save = function (vocab) {
                         vocab.lang = ctrl.selected_lang.code;

--- a/webroot/js/services/vocabulary.srv.js
+++ b/webroot/js/services/vocabulary.srv.js
@@ -1,0 +1,71 @@
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+(function() {
+    'use strict';
+
+    angular
+        .module('app')
+        .factory('vocabularyService', ['$mdDialog', '$http', function($mdDialog, $http) {
+            return {
+               edit: edit
+            };
+
+            function edit(vocab, canEdit) {
+                $mdDialog.show({
+                    controller: DialogController,
+                    controllerAs: 'ctrl',
+                    clickOutsideToClose: true,
+                    templateUrl: get_tatoeba_root_url() + '/angular_templates/edit_vocabulary'
+                });
+
+                function DialogController() {
+                    var ctrl = this;
+
+                    ctrl.vocab = vocab;
+                    ctrl.canEdit = canEdit;
+
+                    ctrl.save = function (vocab) {
+                        vocab.lang = ctrl.selected_lang.code;
+                        $http.post(get_tatoeba_root_url() + '/vocabulary/edit/' + vocab.id, vocab).then(
+                            function success(response) {
+                                location.reload();
+                            },
+                            function error(response) {
+                                location.reload();
+                            }
+                        );
+                    }
+
+                    ctrl.remove = function (vocab) {
+                        $http.get(get_tatoeba_root_url() + '/vocabulary/remove/' + vocab.id).then(
+                            function success(response) {
+                                angular.element(document.querySelector('#vocabulary_' + vocab.id)).remove();
+                                $mdDialog.cancel();
+                            },
+                            function error(response) {
+                                $mdDialog.cancel();
+                            }
+                        );
+                    }
+
+                    ctrl.close = function() {
+                        $mdDialog.cancel();
+                    };
+                }
+            }
+        }]);
+})();

--- a/webroot/js/vocabulary/add-sentences.ctrl.js
+++ b/webroot/js/vocabulary/add-sentences.ctrl.js
@@ -21,15 +21,16 @@
     angular
         .module('app')
         .controller('VocabularyAddSentencesController', [
-            '$http', VocabularyAddSentencesController
+            '$http', 'vocabularyService', VocabularyAddSentencesController
         ]);
 
-    function VocabularyAddSentencesController($http) {
+    function VocabularyAddSentencesController($http, vocabularyService) {
         var vm = this;
 
         vm.showForm = showForm;
         vm.hideForm = hideForm;
         vm.saveSentence = saveSentence;
+        vm.edit = vocabularyService.edit;
 
         vm.sentencesAdded = {};
 

--- a/webroot/js/vocabulary/of.ctrl.js
+++ b/webroot/js/vocabulary/of.ctrl.js
@@ -19,21 +19,57 @@
 
     angular
         .module('app')
-        .controller('VocabularyOfController', ['$http', VocabularyOfController]);
+        .controller('VocabularyOfController', ['$http', '$mdDialog', VocabularyOfController]);
 
-    function VocabularyOfController($http) {
+    function VocabularyOfController($http, $mdDialog) {
         var vm = this;
 
-        vm.remove = remove;
+        vm.edit = edit;
 
         ///////////////////////////////////////////////////////////////////////////
 
-        function remove(id) {
-            $http.get(get_tatoeba_root_url() + '/vocabulary/remove/' + id).then(
-                function(response) {
-                    angular.element(document.querySelector('#vocabulary_' + id)).remove();
+        function edit(vocab, canEdit) {
+            $mdDialog.show({
+                controller: DialogController,
+                controllerAs: 'ctrl',
+                clickOutsideToClose: true,
+                templateUrl: get_tatoeba_root_url() + '/angular_templates/edit_vocabulary'
+            });
+
+            function DialogController() {
+                var ctrl = this;
+
+                ctrl.vocab = vocab;
+                ctrl.canEdit = canEdit;
+
+                ctrl.save = function (vocab) {
+                    vocab.lang = ctrl.selected_lang.code;
+                    $http.post(get_tatoeba_root_url() + '/vocabulary/edit/' + vocab.id, vocab).then(
+                        function success(response) {
+                            location.reload();
+                        },
+                        function error(response) {
+                            location.reload();
+                        }
+                    );
                 }
-            );
+
+                ctrl.remove = function (vocab) {
+                    $http.get(get_tatoeba_root_url() + '/vocabulary/remove/' + vocab.id).then(
+                        function success(response) {
+                            angular.element(document.querySelector('#vocabulary_' + vocab.id)).remove();
+                            $mdDialog.cancel();
+                        },
+                        function error(response) {
+                            $mdDialog.cancel();
+                        }
+                    );
+                }
+
+                ctrl.close = function() {
+                    $mdDialog.cancel();
+                };
+            }
         }
     }
 })();

--- a/webroot/js/vocabulary/of.ctrl.js
+++ b/webroot/js/vocabulary/of.ctrl.js
@@ -19,57 +19,11 @@
 
     angular
         .module('app')
-        .controller('VocabularyOfController', ['$http', '$mdDialog', VocabularyOfController]);
+        .controller('VocabularyOfController', ['vocabularyService', VocabularyOfController]);
 
-    function VocabularyOfController($http, $mdDialog) {
+    function VocabularyOfController(vocabularyService) {
         var vm = this;
 
-        vm.edit = edit;
-
-        ///////////////////////////////////////////////////////////////////////////
-
-        function edit(vocab, canEdit) {
-            $mdDialog.show({
-                controller: DialogController,
-                controllerAs: 'ctrl',
-                clickOutsideToClose: true,
-                templateUrl: get_tatoeba_root_url() + '/angular_templates/edit_vocabulary'
-            });
-
-            function DialogController() {
-                var ctrl = this;
-
-                ctrl.vocab = vocab;
-                ctrl.canEdit = canEdit;
-
-                ctrl.save = function (vocab) {
-                    vocab.lang = ctrl.selected_lang.code;
-                    $http.post(get_tatoeba_root_url() + '/vocabulary/edit/' + vocab.id, vocab).then(
-                        function success(response) {
-                            location.reload();
-                        },
-                        function error(response) {
-                            location.reload();
-                        }
-                    );
-                }
-
-                ctrl.remove = function (vocab) {
-                    $http.get(get_tatoeba_root_url() + '/vocabulary/remove/' + vocab.id).then(
-                        function success(response) {
-                            angular.element(document.querySelector('#vocabulary_' + vocab.id)).remove();
-                            $mdDialog.cancel();
-                        },
-                        function error(response) {
-                            $mdDialog.cancel();
-                        }
-                    );
-                }
-
-                ctrl.close = function() {
-                    $mdDialog.cancel();
-                };
-            }
-        }
+        vm.edit = vocabularyService.edit;
     }
 })();


### PR DESCRIPTION
This PR solves #1238 by allowing members to edit their own vocabulary items, given they are the only one who added it. If more that one user added it, normal users cannot edit the item.

This PR also provides a partial solution to #1473 by allowing corpus maintainers and admins to edit other’s vocabulary items (or to edit their own even though it has been added by more than one user).

<details>
<summary>Note that this PR does not give extra permission to corpus maintainers to "remove" vocabulary requests, because it is not clear how that may be done.</summary>

Allow me to clarify the way vocabulary items are implemented now, because it is not very clear from the UI. A vocabulary item can be "owned" by zero, one or more users. When you add a new item (a vocabulary request), if nobody ever added that specific lang/text pair, it is created. Otherwise, it is just "linked" (added) to your own list. Then, when you click the button to "remove" one of your vocabulary items, it does not really remove it, it simply "unlinks" (removes) it from your own list. When the count of users having a vocabulary item reaches zero, it is simply hidden from [the list](https://tatoeba.org/vocabulary/add_sentences). Therefore, vocabulary items are not really ever removed.
</details>

<img width="684" height="176" alt="image" src="https://github.com/user-attachments/assets/04630d33-b1f7-477c-901e-523dfdde21ed" />
