### PR TITLE
Index sentence owner nativeness

### DIFF
--- a/src/Event/SentencesReindexListener.php
+++ b/src/Event/SentencesReindexListener.php
@@ -17,22 +17,34 @@ class SentencesReindexListener implements EventListenerInterface {
 
     public function implementedEvents() {
         return [
-            'Model.afterSave' => 'reindexNativeSpeakerSentences',
+            'Model.afterSave' => 'onSave',
+            'Model.afterDelete' => 'onDelete',
         ];
     }
 
-    public function reindexNativeSpeakerSentences(Event $event, EntityInterface $entity, ArrayObject $options) {
+    private function reindexNativeSpeakerSentences(UsersLanguage $entity) {
+       $sentenceIds = $this->Sentences
+           ->find('list', ['valueField' => 'id'])
+           ->where([
+               'user_id' => $entity->of_user_id,
+               'lang' => $entity->language_code,
+           ])
+           ->toList();
+       $this->Sentences->flagSentenceAndTranslationsToReindex($sentenceIds);
+    }
+
+    public function onSave(Event $event, EntityInterface $entity, ArrayObject $options) {
         if ($entity instanceOf UsersLanguage
             && $entity->has('language_code') && $entity->has('of_user_id') && $entity->isDirty('level')
             && ($entity->getOriginal('level') == 5 xor $entity->level == 5)) {
-            $sentenceIds = $this->Sentences
-                ->find('list', ['valueField' => 'id'])
-                ->where([
-                    'user_id' => $entity->of_user_id,
-                    'lang' => $entity->language_code,
-                ])
-                ->toList();
-            $this->Sentences->flagSentenceAndTranslationsToReindex($sentenceIds);
+            $this->reindexNativeSpeakerSentences($entity);
+        }
+    }
+
+    public function onDelete(Event $event, EntityInterface $entity, ArrayObject $options) {
+        if ($entity instanceOf UsersLanguage
+            && $entity->has('language_code') && $entity->has('of_user_id') && $entity->level == 5) {
+            $this->reindexNativeSpeakerSentences($entity);
         }
     }
 }

--- a/src/Event/SentencesReindexListener.php
+++ b/src/Event/SentencesReindexListener.php
@@ -1,0 +1,38 @@
+<?php
+namespace App\Event;
+
+use App\Model\Entity\UsersLanguage;
+use ArrayObject;
+use Cake\Event\Event;
+use Cake\Event\EventListenerInterface;
+use Cake\Datasource\EntityInterface;
+use Cake\ORM\TableRegistry;
+
+class SentencesReindexListener implements EventListenerInterface {
+    public $Sentences;
+
+    public function __construct() {
+        $this->Sentences = TableRegistry::get('Sentences');
+    }
+
+    public function implementedEvents() {
+        return [
+            'Model.afterSave' => 'reindexNativeSpeakerSentences',
+        ];
+    }
+
+    public function reindexNativeSpeakerSentences(Event $event, EntityInterface $entity, ArrayObject $options) {
+        if ($entity instanceOf UsersLanguage
+            && $entity->has('language_code') && $entity->has('of_user_id') && $entity->isDirty('level')
+            && ($entity->getOriginal('level') == 5 xor $entity->level == 5)) {
+            $sentenceIds = $this->Sentences
+                ->find('list', ['valueField' => 'id'])
+                ->where([
+                    'user_id' => $entity->of_user_id,
+                    'lang' => $entity->language_code,
+                ])
+                ->toList();
+            $this->Sentences->flagSentenceAndTranslationsToReindex($sentenceIds);
+        }
+    }
+}

--- a/src/Event/SentencesReindexListener.php
+++ b/src/Event/SentencesReindexListener.php
@@ -36,7 +36,11 @@ class SentencesReindexListener implements EventListenerInterface {
     public function onSave(Event $event, EntityInterface $entity, ArrayObject $options) {
         if ($entity instanceOf UsersLanguage
             && $entity->has('language_code') && $entity->has('of_user_id') && $entity->isDirty('level')
-            && ($entity->getOriginal('level') == 5 xor $entity->level == 5)) {
+            && (
+                 $entity->isNew() && $entity->level == 5
+              || !$entity->isNew() && ($entity->getOriginal('level') == 5 xor $entity->level == 5)
+            ))
+        {
             $this->reindexNativeSpeakerSentences($entity);
         }
     }

--- a/src/Model/Table/LinksTable.php
+++ b/src/Model/Table/LinksTable.php
@@ -215,7 +215,7 @@ class LinksTable extends Table
         return !empty($ids) ? $ids : array();
     }
 
-    public function findDirectAndIndirectTranslationsIds($sentenceId) {
+    public function findDirectAndIndirectTranslationsIds($sentenceIds) {
         $links = $this->find('all')
             ->join([
                 [
@@ -225,14 +225,14 @@ class LinksTable extends Table
                     'conditions' => ['Links.translation_id = Translation.sentence_id']
                 ]
             ])
-            ->where(['Links.sentence_id' => $sentenceId])
+            ->where(['Links.sentence_id IN' => (array)$sentenceIds])
             ->select([
                 'sentence_id' => 'DISTINCT(Links.sentence_id)',
                 'translation_id' => 'IF(Links.sentence_id = Translation.translation_id, Translation.sentence_id, Translation.translation_id)'
             ])
             ->toList();
         $links = Hash::extract($links, '{n}.translation_id');
-        return is_null($links) ? array() : $links;
+        return is_null($links) ? array() : array_unique($links);
     }
 
     public function updateLanguage($sentenceId, $lang)

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -308,9 +308,10 @@ class SentencesTable extends Table
         }
     }
 
-    public function flagSentenceAndTranslationsToReindex($id) {
-        $this->needsReindex($id);
-        $this->flagTranslationsToReindex($id);
+    public function flagSentenceAndTranslationsToReindex($ids) {
+        $ids = (array)$ids;
+        $transIds = $this->Links->findDirectAndIndirectTranslationsIds($ids);
+        $this->needsReindex(array_unique(array_merge($ids, $transIds)));
     }
 
     private function flagTranslationsToReindex($id)

--- a/src/Model/Table/UsersLanguagesTable.php
+++ b/src/Model/Table/UsersLanguagesTable.php
@@ -18,6 +18,7 @@
  */
 namespace App\Model\Table;
 
+use App\Event\SentencesReindexListener;
 use App\Lib\LanguagesLib;
 use App\Model\Entity\Language;
 use App\Model\Entity\User;
@@ -44,6 +45,8 @@ class UsersLanguagesTable extends Table
         $this->belongsTo('Languages', ['foreignKey' => 'language_code']);
 
         $this->addBehavior('Timestamp');
+
+        $this->getEventManager()->on(new SentencesReindexListener());
     }
 
     public function validationDefault(Validator $validator)

--- a/src/Shell/SphinxConfShell.php
+++ b/src/Shell/SphinxConfShell.php
@@ -626,7 +626,7 @@ EOT;
         sql_query = \
             select \
                 r.id, r.text, r.created, r.modified, r.user_id, r.ucorrectness, r.has_audio, \
-                r.origin_known, r.is_original, \
+                r.origin_known, r.is_original, r.owner_is_native, \
                 GROUP_CONCAT(distinct tags.tag_id) as tags_id, \
                 GROUP_CONCAT(distinct lists.sentences_list_id) as lists_id, \
                 CONCAT('[', COALESCE(GROUP_CONCAT(distinct r.trans),''), ']') as trans \
@@ -641,13 +641,15 @@ EOT;
                     (COUNT(audios_sent_start.id) > 0) as has_audio, \
                     (sent_start.based_on_id IS NOT NULL) as origin_known, \
                     (sent_start.based_on_id = 0) as is_original, \
+                    COALESCE(ul_sent_start.level = 5, 0) as owner_is_native, \
                     \
                     CONCAT('{', \
                         'l:\"',sent_end.lang,'\",', \
                         'd:',MIN( IF(trans.sentence_id = transtrans.translation_id,1,2) ),',', \
                         'u:',COALESCE(sent_end.user_id, 0),',', \
                         'c:',sent_end.correctness + 1,',', \
-                        'a:',COUNT(audios_sent_end.id) > 0, \
+                        'a:',COUNT(audios_sent_end.id) > 0,',', \
+                        'n:',ul_sent_end.level = 5, \
                     '}') as trans \
                 from \
                     sentences sent_start \
@@ -667,6 +669,12 @@ EOT;
                     audios audios_sent_end ON sent_end.id = audios_sent_end.sentence_id \
                 left join \
                     audios audios_sent_start ON sent_start.id = audios_sent_start.sentence_id \
+                left join \
+                    users_languages ul_sent_start ON sent_start.user_id = ul_sent_start.of_user_id \
+                                                 AND sent_start.lang = ul_sent_start.language_code \
+                left join \
+                    users_languages ul_sent_end ON sent_end.user_id = ul_sent_end.of_user_id \
+                                               AND sent_end.lang = ul_sent_end.language_code \
                 where \
                     sent_start.lang = '$lang' \
                     and sent_start.id >= \$start and sent_start.id <= \$end \
@@ -694,6 +702,7 @@ EOT;
         sql_attr_multi = uint lists_id from field; SELECT id FROM sentences_lists ;
         sql_attr_bool = origin_known
         sql_attr_bool = is_original
+        sql_attr_bool = owner_is_native
         sql_attr_json = trans
 
         sql_joined_field = \

--- a/src/Shell/Task/QueueSentencesReindexTask.php
+++ b/src/Shell/Task/QueueSentencesReindexTask.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2025 Gilles Bedel
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\Shell\Task;
+
+use Cake\Datasource\ModelAwareTrait;
+use Queue\Shell\Task\QueueTask;
+
+class QueueSentencesReindexTask extends QueueTask {
+
+    use ModelAwareTrait;
+
+    public $retries = 0;
+
+    private function reindexNativeSpeakerSentences(int $user_id, string $lang) {
+        $this->loadModel('Sentences');
+        $sentenceIds = $this->Sentences
+            ->find('list', ['valueField' => 'id'])
+            ->where(compact('user_id', 'lang'))
+            ->toList();
+        $this->Sentences->flagSentenceAndTranslationsToReindex($sentenceIds);
+    }
+
+    public function run(array $config, $jobId) {
+        $this->reindexNativeSpeakerSentences($config['user_id'], $config['lang']);
+        return true;
+    }
+}

--- a/tests/TestCase/Model/Table/LinksTableTest.php
+++ b/tests/TestCase/Model/Table/LinksTableTest.php
@@ -124,6 +124,16 @@ class LinksTableTest extends TestCase {
 		$this->assertEquals($result, $filteredResult);
 	}
 
+	function testFindDirectAndIndirectTranslationsIds_worksWithMultipleSentences() {
+		$sentenceIds = array(1, 6, 65);
+		$expectedLinkedSentences = array(1, 2, 3, 4, 5, 6, 10, 55, 56, 57);
+
+		$result = $this->Link->findDirectAndIndirectTranslationsIds($sentenceIds);
+		sort($result, SORT_NUMERIC);
+
+		$this->assertEquals($result, $expectedLinkedSentences);
+	}
+
 	function testFindDirectAndIndirectTranslationsIds_walksWholeGraph() {
 		$sentenceId = 2;
 		$expectedLinkedSentences = array(1, 3, 4, 5, 6);

--- a/tests/TestCase/Model/Table/UsersLanguagesTableTest.php
+++ b/tests/TestCase/Model/Table/UsersLanguagesTableTest.php
@@ -303,4 +303,36 @@ class UsersLanguagesTableTest extends TestCase {
 
         $this->assertSentencesFlaggedForReindex([]);
     }
+
+    function testSaveUserLanguage_reindexSentencesOnNewNativeLanguage() {
+        $this->loadFixtures();
+        $nativeFra = $this->UsersLanguages->newEntity([
+            'language_code' => 'fra',
+            'level' => 5,
+            'details' => '',
+            'of_user_id' => 2,
+            'by_user_id' => 2,
+        ]);
+
+        $this->UsersLanguages->save($nativeFra);
+
+        // should reindex sentence 55
+        // along with all direct and indirect translations
+        $this->assertSentencesFlaggedForReindex([55, 56, 57, 65]);
+    }
+
+    function testSaveUserLanguage_noReindexSentencesOnNewLearningLanguage() {
+        $this->loadFixtures();
+        $learningFra = $this->UsersLanguages->newEntity([
+            'language_code' => 'fra',
+            'level' => 4,
+            'details' => '',
+            'of_user_id' => 2,
+            'by_user_id' => 2,
+        ]);
+
+        $this->UsersLanguages->save($learningFra);
+
+        $this->assertSentencesFlaggedForReindex([]);
+    }
 }

--- a/tests/TestCase/Model/Table/UsersLanguagesTableTest.php
+++ b/tests/TestCase/Model/Table/UsersLanguagesTableTest.php
@@ -283,4 +283,24 @@ class UsersLanguagesTableTest extends TestCase {
 
         $this->assertSentencesFlaggedForReindex([]);
     }
+
+    function testSaveUserLanguage_reindexSentencesOnLanguageDeletion() {
+        $this->loadFixtures();
+        $nativeJpn = $this->UsersLanguages->get(3);
+
+        $this->UsersLanguages->delete($nativeJpn);
+
+        // should reindex sentences 6, 10, 56 and 57
+        // along with all direct and indirect translations
+        $this->assertSentencesFlaggedForReindex([1, 2, 4, 6, 10, 55, 56, 57, 65]);
+    }
+
+    function testSaveUserLanguage_noReindexSentencesOnLearningLanguageDeletion() {
+        $this->loadFixtures();
+        $learnerFra = $this->UsersLanguages->get(5);
+
+        $this->UsersLanguages->delete($learnerFra);
+
+        $this->assertSentencesFlaggedForReindex([]);
+    }
 }

--- a/tests/TestCase/Shell/Task/QueueSentencesReindexTaskTest.php
+++ b/tests/TestCase/Shell/Task/QueueSentencesReindexTaskTest.php
@@ -1,0 +1,58 @@
+<?php
+namespace App\Test\TestCase\Shell\Task;
+
+use App\Shell\Task\QueueSentencesReindexTask;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class QueueSentencesReindexTaskTest extends TestCase
+{
+    public $fixtures = [
+        'app.reindex_flags',
+        'app.sentences',
+        'app.links',
+    ];
+    public $io;
+    public $task;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
+        $this->task = new QueueSentencesReindexTask($this->io);
+    }
+
+    public function tearDown()
+    {
+        unset($this->task);
+        parent::tearDown();
+    }
+
+    private function assertSentencesFlaggedForReindex($expected)
+    {
+        $result = TableRegistry::getTableLocator()->get('ReindexFlags')
+            ->find('list', ['valueField' => 'sentence_id'])
+            ->select(['sentence_id'])
+            ->order('sentence_id')
+            ->toList();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testRun_userLanguageLevelUp()
+    {
+        $this->task->run(['user_id' => 7, 'lang' => 'fra'], null);
+
+        // should reindex sentences 4, 8, 12 and 35
+        // along with all direct and indirect translations
+        $this->assertSentencesFlaggedForReindex([1, 2, 3, 4, 5, 6, 8, 10, 12, 35]);
+    }
+
+    public function testRun_userLanguageLevelDrop()
+    {
+        $this->task->run(['user_id' => 7, 'lang' => 'jpn'], null);
+
+        // should reindex sentences 6, 10, 56 and 57
+        // along with all direct and indirect translations
+        $this->assertSentencesFlaggedForReindex([1, 2, 4, 6, 10, 55, 56, 57, 65]);
+    }
+}

--- a/tests/TestCase/Shell/Task/QueueSentencesReindexTaskTest.php
+++ b/tests/TestCase/Shell/Task/QueueSentencesReindexTaskTest.php
@@ -55,4 +55,10 @@ class QueueSentencesReindexTaskTest extends TestCase
         // along with all direct and indirect translations
         $this->assertSentencesFlaggedForReindex([1, 2, 4, 6, 10, 55, 56, 57, 65]);
     }
+
+    public function testRun_userLanguageLevelUp_batched()
+    {
+        $this->task->batchOperationSize = 2;
+        $this->testRun_userLanguageLevelUp();
+    }
 }


### PR DESCRIPTION
The "sentence is owned by a self-identified native" filter relies on checking the sentence owner against a list of known natives. This approach has limitations, and has brought maintenance burden:

* need to use a hack to work around the maximum limit of 4096 values in Manticore filter #2166
* need to have only one source language filter selected: cannot work with no source language, or two or more source languages (allowed by the API)
* cannot be combined with "sentence owner" filter when using two or more owners, or when using a boolean negation on the owner filter (allowed by API)
* does not allow to filter translations #3203 (unless willing to implement it given the above caveats)

To get rid of all the above limitations, this PR indexes the "nativeness" information directly into Manticore. To ease deployment, my idea is to merge the indexation part first, and to later update the search filtering code to make use of it.