### PR TITLE
Added list of recent contributors (and skill levels) to for_language user list page

### DIFF
--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -557,6 +557,9 @@ class UsersController extends AppController
         $this->loadModel('LastContributions');
         $currentContributors = $this->LastContributions->getCurrentContributorsInLang($lang);
         $totalContributors = $this->LastContributions->getTotal($currentContributors);
+        foreach($currentContributors as $contributor) {
+            $contributor->user->rating = $this->UsersLanguages->getLanguageInfoOfUser($lang, $contributor->user->id)->level;
+        }
 
         if (empty($lang)) {
             $lang = $usersLanguages[0]->language_code;

--- a/src/Model/Table/LastContributionsTable.php
+++ b/src/Model/Table/LastContributionsTable.php
@@ -73,7 +73,7 @@ class LastContributionsTable extends Table
             ->contain([
                 'Users' => [
                     'fields' => [
-                        'username', 'role', 'image'
+                        'id', 'username', 'role', 'image'
                     ]
                 ]
             ])

--- a/src/Template/Element/currently_active_lang_members.ctp
+++ b/src/Template/Element/currently_active_lang_members.ctp
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2010  HO Ngoc Phuong Trang <tranglich@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Tatoeba
+ * @author   HO Ngoc Phuong Trang <tranglich@gmail.com>
+ * @license  Affero General Public License
+ * @link     https://tatoeba.org
+ */
+?>
+
+<md-list class="annexe-menu md-whiteframe-1dp">
+<md-subheader><?php echo __('Currently contributing') ?></md-subheader>
+
+<p class="hint" style="padding: 0 10px">
+<?php 
+echo format(
+    __n('User who did the last contribution.','Users who participated in the last {n}&nbsp;contributions.', $total),
+    array('n' => $this->Number->format($total))
+);
+?>
+</p>
+
+<?php
+$highestNumberOfContributions = $currentContributors ? $currentContributors[0]->total : 0;
+foreach($currentContributors as $i=>$currentContributor){
+    $numberOfContributions = $currentContributor->total;
+    $percentage = ($numberOfContributions/$total)*100;
+    $username = $currentContributor->user->username;
+    $url = $this->Url->build([
+        'controller' => 'contributions',
+        'action' => 'of_user',
+        $username
+    ]);
+    ?>
+    <md-list-item class="md-2-line" href="<?= $url ?>">
+        <?= $this->Members->image($currentContributor->user, array('class' => 'md-avatar')); ?>
+        <div class="md-list-item-text usernameAndLevel" layout="column">
+            <h3><?= $username ?></h3>
+            <?php
+            echo $this->Members->displayLanguageLevel($currentContributor->user->rating);
+            ?>
+        </div>
+
+        <div class="activityBar">
+            <?php
+            $maxActivity = 5;
+            $relativeScore = $numberOfContributions/$highestNumberOfContributions;
+            $activity = ceil($relativeScore*$maxActivity);
+            for ($j = $activity; $j < $maxActivity; $j++) {
+                echo '<div class="level0 box"></div>';
+            }
+            for ($k = $activity; $k > 0; $k--) {
+                echo '<div class="level'.$k.' box"></div>';
+            }
+            // The contributor who has contributed the most in the last contributions
+            // will have a level 5 activity. The activity of all other people will be
+            // relative to that number one contributor.
+            // For instance if the top contributor for the last contributions has made
+            // 100 contributions, and I have made 31 contributions, my activity would
+            // be 2 (0.31*5 = 1.55).
+            ?>
+        </div>
+    </md-list-item>
+    <?php
+}
+?>
+</md-list>

--- a/src/Template/Users/for_language.ctp
+++ b/src/Template/Users/for_language.ctp
@@ -57,7 +57,7 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
 
         <?php
         echo $this->element(
-            'currently_active_members',
+            'currently_active_lang_members',
             array(
                 'currentContributors' => $currentContributors
             )


### PR DESCRIPTION
This pull request addresses issue #3075.

It removes the list of language statistics on the for_language user list page and adds a "currently contributing" widget similar to the one on the "list of all members" page, except that the recent contributions are limited to contributions in that language.

In theory, this allows users to quickly identify users who both have a high skill level in a language, and have recently contributed in that language.

To try out this feature:
- open the homepage
- navigate to Community -> Languages of members
- click on one of the language links on that page
- on the right, you should now see a list of recent contributors in that language, and their skill levels