### PR TITLE
New "is sentence owned by native speaker" filters

### DIFF
--- a/src/Controller/VHosts/Api/SentencesController.php
+++ b/src/Controller/VHosts/Api/SentencesController.php
@@ -243,6 +243,10 @@ class SentencesController extends ApiController
      *     description="Limit to sentences having orphan translations (if value is yes) or translations owned by someone (if value is no). Make sure to combine with <code>trans:owner</code> filter in a way that makes sense.",
      *     @OA\Schema(ref="#/components/schemas/Boolean")
      *   ),
+     *   @OA\Parameter(name="trans:is_native", in="query",
+     *     description="Limit to sentences having translations owned by a self-identified native speaker (if value is yes) or not owned by a self-identified native speaker (if the value is no). Tip: combine <code>trans:is_native=no</code> with <code>trans:is_orphan=no</code> to limit to sentences having translations owned by a self-identified non-native speaker.",
+     *     @OA\Schema(ref="#/components/schemas/Boolean")
+     *   ),
      *   @OA\Parameter(name="trans:has_audio", in="query",
      *     description="Limit to sentences having translation(s) having one or more audio recordings (if value is yes) or no audio recording (if value is no).",
      *     @OA\Schema(ref="#/components/schemas/Boolean")

--- a/src/Controller/VHosts/Api/SentencesController.php
+++ b/src/Controller/VHosts/Api/SentencesController.php
@@ -205,7 +205,7 @@ class SentencesController extends ApiController
      *     @OA\Schema(ref="#/components/schemas/NegatableListIdList")
      *   ),
      *   @OA\Parameter(name="is_native", in="query",
-     *     description="Limit to sentences owned by a self-identified native speaker (if value is yes) or a self-identified non-native speaker (if the value is no).",
+     *     description="Limit to sentences owned by a self-identified native speaker (if value is yes) or not owned by a self-identified native speaker (if the value is no). Tip: combine <code>is_native=no</code> with <code>is_orphan=no</code> to limit to sentences owned by a self-identified non-native speaker.",
      *     @OA\Schema(ref="#/components/schemas/Boolean")
      *   ),
      *   @OA\Parameter(name="origin", in="query",

--- a/src/Controller/VHosts/Api/SentencesController.php
+++ b/src/Controller/VHosts/Api/SentencesController.php
@@ -205,7 +205,7 @@ class SentencesController extends ApiController
      *     @OA\Schema(ref="#/components/schemas/NegatableListIdList")
      *   ),
      *   @OA\Parameter(name="is_native", in="query",
-     *     description="Limit to sentences owned by a self-identified native speaker (if value is yes) or a self-identified non-native speaker (if the value is no). This parameter can only be used when searching in a single language (not several).",
+     *     description="Limit to sentences owned by a self-identified native speaker (if value is yes) or a self-identified non-native speaker (if the value is no).",
      *     @OA\Schema(ref="#/components/schemas/Boolean")
      *   ),
      *   @OA\Parameter(name="origin", in="query",

--- a/src/Controller/VHosts/Api/SentencesController.php
+++ b/src/Controller/VHosts/Api/SentencesController.php
@@ -183,6 +183,10 @@ class SentencesController extends ApiController
      *     description="Limit to <a href=""https://en.wiki.tatoeba.org/articles/show/faq#why-are-some-sentences-in-red?"">unapproved sentences</a> (if value is yes) or exclude unapproved sentences (if value is no).",
      *     @OA\Schema(ref="#/components/schemas/Boolean")
      *   ),
+     *   @OA\Parameter(name="is_native", in="query",
+     *     description="Limit to sentences owned by a self-identified native speaker (if value is yes) or not owned by a self-identified native speaker (if the value is no). Tip: combine <code>is_native=no</code> with <code>is_orphan=no</code> to limit to sentences owned by a self-identified non-native speaker.",
+     *     @OA\Schema(ref="#/components/schemas/Boolean")
+     *   ),
      *   @OA\Parameter(name="has_audio", in="query",
      *     description="Limit to sentences having one or more audio recordings (if value is yes) or no audio recording (if value is no).",
      *     @OA\Schema(ref="#/components/schemas/Boolean")
@@ -203,10 +207,6 @@ class SentencesController extends ApiController
      *     @OA\Examples(example="3", value="!123",     summary="exclude sentences on list 123"),
      *     @OA\Examples(example="4", value="!123,456", summary="exclude sentences on list 123 or list 456 (or both)"),
      *     @OA\Schema(ref="#/components/schemas/NegatableListIdList")
-     *   ),
-     *   @OA\Parameter(name="is_native", in="query",
-     *     description="Limit to sentences owned by a self-identified native speaker (if value is yes) or not owned by a self-identified native speaker (if the value is no). Tip: combine <code>is_native=no</code> with <code>is_orphan=no</code> to limit to sentences owned by a self-identified non-native speaker.",
-     *     @OA\Schema(ref="#/components/schemas/Boolean")
      *   ),
      *   @OA\Parameter(name="origin", in="query",
      *     description="Limit according to sentence origin. All sentences fall in two sets: <em>unknown</em> and <em>known</em>. The set <em>known</em> is composed of two subsets: <em>original</em> + <em>translation</em>.",

--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -491,17 +491,6 @@ class SentencesSearchForm extends Form
             $this->_data['trans_orphan'] = $this->setDataTransOrphan('');
         }
 
-        if ($this->_data['native'] === 'yes' && $this->_data['from'] === '') {
-            $this->ignored[] = __(
-                /* @translators: This string will be preceded by “Warning: the
-                   following criteria have been ignored:” */
-                "“owned by a self-identified native”, because “sentence ".
-                "language” is set to “any”",
-                true
-            );
-            $this->_data['native'] = $this->setDataNative('');
-        }
-
         if ($this->_data['native'] === 'yes' && $this->ownerId) {
             $this->loadModel('UsersLanguages');
             $natives = $this->UsersLanguages->find()

--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -18,6 +18,7 @@ use App\Model\Search\TagFilter;
 use App\Model\Search\TranslationCountFilter;
 use App\Model\Search\TranslationHasAudioFilter;
 use App\Model\Search\TranslationIsDirectFilter;
+use App\Model\Search\TranslationIsNativeFilter;
 use App\Model\Search\TranslationIsOrphanFilter;
 use App\Model\Search\TranslationIsUnapprovedFilter;
 use App\Model\Search\TranslationLangFilter;
@@ -59,6 +60,7 @@ class SentencesSearchForm extends Form
         'trans_user' => '',
         'trans_orphan' => '',
         'trans_unapproved' => '',
+        'trans_native' => '',
         'trans_has_audio' => '',
         'trans_filter' => 'limit',
         'sort' => 'relevance',
@@ -223,6 +225,14 @@ class SentencesSearchForm extends Form
         return $this->setBoolFilter(
             TranslationIsUnapprovedFilter::class,
             $trans_unapproved,
+            $this->search->getTranslationFilters()
+        );
+    }
+
+    protected function setDataTransNative(string $trans_native) {
+        return $this->setBoolFilter(
+            TranslationIsNativeFilter::class,
+            $trans_native,
             $this->search->getTranslationFilters()
         );
     }

--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -306,14 +306,7 @@ class SentencesSearchForm extends Form
     }
 
     protected function setDataNative(string $native) {
-        $native = $native === 'yes' ? true : null;
-        if ($native) {
-            $filter = new IsNativeFilter();
-            $this->search->setFilter($filter);
-        } else {
-            $this->search->unsetFilter(IsNativeFilter::class);
-        }
-        return $native ? 'yes' : '';
+        return $this->setBoolFilter(IsNativeFilter::class, $native, $this->search);
     }
 
     private function _setDataWordCountFilter(string $value, $before, $after) {

--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -310,7 +310,6 @@ class SentencesSearchForm extends Form
         if ($native) {
             $filter = new IsNativeFilter();
             $this->search->setFilter($filter);
-            $filter->setSearch($this->search);
         } else {
             $this->search->unsetFilter(IsNativeFilter::class);
         }

--- a/src/Model/Search/IsNativeFilter.php
+++ b/src/Model/Search/IsNativeFilter.php
@@ -2,79 +2,8 @@
 
 namespace App\Model\Search;
 
-use App\Model\Exception\InvalidValueException;
-use App\Model\Search;
-use Cake\Database\Expression\QueryExpression;
-use Cake\Datasource\ModelAwareTrait;
-use Cake\Utility\Hash;
-
 class IsNativeFilter extends BoolFilter {
-    use NeedsSearchRefTrait;
-    use ModelAwareTrait;
-
-    private $sphinxFilterArrayLimit = 4096;
-
     protected function getAttributeName() {
-        return 'user_id';
-    }
-
-    private function getSearchLang() {
-        if (is_null($this->search)) {
-            throw new \RuntimeException("Precondition failed: setSearch() was not called first");
-        }
-        $filter = $this->search->getFilter(LangFilter::class);
-        $langs = $filter ? $filter->getAllValues() : [];
-        if (count($langs) == 0) {
-            throw new \App\Model\Exception\InvalidFilterUsageException("must be used with a language (no language were provided to the language filter)");
-        } elseif (count($langs) > 1) {
-            $langList = implode(' ', $langs);
-            throw new \App\Model\Exception\InvalidFilterUsageException("must be used with a single language (multiple languages were provided to the language filter: $langList)");
-        }
-        return $langs[0];
-    }
-
-    protected function calcFilter() {
-        $lang = $this->getSearchLang();
-        $this->loadModel('UsersLanguages');
-        $natives = $this->UsersLanguages->find()
-            ->where([
-                'language_code' => $lang,
-                'level' => 5,
-            ])
-            ->select(['of_user_id'])
-            ->enableHydration(false)
-            ->toList();
-        $natives = Hash::extract($natives, '{n}.of_user_id');
-
-        if (count($natives) == 0) {
-            // There are no native speakers in this language, so no sentences should
-            // match at all. But if we set the filter with an empty array, it won't do
-            // any filtering at all, so we use the dummy value of -1 to force a non-match.
-            $this->anyOf([-1]);
-        } elseif (count($natives) <= $this->sphinxFilterArrayLimit) {
-            $this->anyOf($natives);
-        } else {
-            if (!$this->exclude) {
-                $natives = $this->UsersLanguages->find()
-                    ->where(function (QueryExpression $exp) use ($lang) {
-                        $isNonNative = $exp->or(['level is' => null])->notEq('level', 5);
-                        return $exp->add($isNonNative)
-                                   ->eq('language_code', $lang);
-                    })
-                    ->select(['of_user_id'])
-                    ->enableHydration(false)
-                    ->toList();
-                $natives = Hash::extract($natives, '{n}.of_user_id');
-            }
-            $filter = [];
-            while (count($natives)) {
-                $excludedIds = array_splice($natives, 0, $this->sphinxFilterArrayLimit);
-                $this->not()->anyOf($excludedIds)->_and();
-            }
-        }
-    }
-
-    public function setSphinxFilterArrayLimit($limit) {
-        $this->sphinxFilterArrayLimit = $limit;
+        return 'owner_is_native';
     }
 }

--- a/src/Model/Search/TranslationIsNativeFilter.php
+++ b/src/Model/Search/TranslationIsNativeFilter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Model\Search;
+
+class TranslationIsNativeFilter extends BoolFilter {
+    use TranslationFilterTrait;
+
+    protected function getAttributeName() {
+        return 'n';
+    }
+}

--- a/src/Model/SearchApi.php
+++ b/src/Model/SearchApi.php
@@ -113,6 +113,7 @@ class SearchApi
                 'count'         => Search\TranslationCountFilter::class,
                 'has_audio'     => Search\TranslationHasAudioFilter::class,
                 'is_direct'     => Search\TranslationIsDirectFilter::class,
+                'is_native'     => Search\TranslationIsNativeFilter::class,
                 'is_orphan'     => Search\TranslationIsOrphanFilter::class,
                 'is_unapproved' => Search\TranslationIsUnapprovedFilter::class,
                 'lang'          => Search\TranslationLangFilter::class,

--- a/src/Template/Element/advanced_search_form.ctp
+++ b/src/Template/Element/advanced_search_form.ctp
@@ -224,6 +224,28 @@ echo $this->Form->create('AdvancedSearch', [
                 </div>
             </div>
 
+            <div class="param">
+                <div layout="row" layout-align="center">
+                    <label for="native" flex><?= __('Is owned by a native:') ?></label>
+                    <?php
+                    echo $this->Form->input('native', array(
+                        'label' => '',
+                        'options' => array(
+                            /* @translators: dropdown option of "Is owned by a native:" field in search form */
+                            '' => __x('native', 'Any'),
+                            'no' => __('No'),
+                            'yes' => __('Yes'),
+                        ),
+                        'ng-model' => 'filters.native',
+                        'ng-model-init' => $native,
+                    ));
+                    ?>
+                </div>
+                <div class="hint">
+                    <?= __('Native speakers are self-identified.') ?>
+                </div>
+            </div>
+
             <div class="param" layout="row" layout-align="center">
                 <label for="has-audio" flex><?= __('Has audio:') ?></label>
                 <?php
@@ -272,17 +294,6 @@ echo $this->Form->create('AdvancedSearch', [
                 ]);
                 ?>
                 </div>
-            </div>
-
-            <div class="param" layout="row">
-                <md-checkbox
-                    ng-false-value="''"
-                    ng-true-value="'yes'"
-                    ng-model="filters.native"
-                    ng-model-init="<?= h($native) ?>"
-                    class="md-primary">
-                    <?= __('Owned by a self-identified native') ?>
-                </md-checkbox>
             </div>
         </div>
         </div>

--- a/src/Template/Element/advanced_search_form.ctp
+++ b/src/Template/Element/advanced_search_form.ctp
@@ -417,6 +417,28 @@ echo $this->Form->create('AdvancedSearch', [
                     </div>
                 </div>
 
+                <div class="param">
+                    <div layout="row" layout-align="center">
+                        <label for="trans-native" flex><?= __('Is owned by a native:') ?></label>
+                        <?php
+                        echo $this->Form->input('native', array(
+                            'label' => '',
+                            'options' => array(
+                                /* @translators: dropdown option of "Is owned by a native:" field in search form */
+                                '' => __x('native', 'Any'),
+                                'no' => __('No'),
+                                'yes' => __('Yes'),
+                            ),
+                            'ng-model' => 'filters.trans_native',
+                            'ng-model-init' => $trans_native,
+                        ));
+                        ?>
+                    </div>
+                    <div class="hint">
+                        <?= __('Native speakers are self-identified.') ?>
+                    </div>
+                </div>
+
                 <div class="param" layout="row" layout-align="center">
                     <label for="trans-has-audio" flex><?= __('Has audio:') ?></label>
                     <?php

--- a/tests/TestCase/Form/SentencesSearchFormTest.php
+++ b/tests/TestCase/Form/SentencesSearchFormTest.php
@@ -431,14 +431,6 @@ class SentencesSearchFormTest extends TestCase
         $this->assertEquals('', $this->Form->getData()['trans_orphan']);
     }
 
-    public function testCheckUnwantedCombinations_nativeWithoutLanguage() {
-        $this->Form->setData(['from' => '', 'native' => 'yes']);
-        $this->Form->checkUnwantedCombinations();
-
-        $this->assertCount(1, $this->Form->getIgnoredFields());
-        $this->assertEquals('', $this->Form->getData()['native']);
-    }
-
     public function testCheckUnwantedCombinations_userNotNative() {
         $this->Form->setData([
             'user' => 'contributor',

--- a/tests/TestCase/Form/SentencesSearchFormTest.php
+++ b/tests/TestCase/Form/SentencesSearchFormTest.php
@@ -137,8 +137,7 @@ class SentencesSearchFormTest extends TestCase
             [ ['list' => '3'],       ['ListFilter' => new ListFilter()],               '', 1 ],
             [ ['list' => 'invalid'], ['ListFilter' => null],                           '',   ],
 
-            [ ['native' => 'yes', 'from' => 'eng'],     ['IsNativeFilter' => new IsNativeFilter()], 'yes'],
-            [ ['native' => 'yes', 'from' => 'invalid'], ['IsNativeFilter' => null],                 'yes'],
+            [ ['native' => 'yes'],     ['IsNativeFilter' => new IsNativeFilter()], 'yes'],
             [ ['native' => 'no'],      ['IsNativeFilter' => null], '' ],
             [ ['native' => 'invalid'], ['IsNativeFilter' => null], '' ],
             [ ['native' => ''],        ['IsNativeFilter' => null], '' ],
@@ -442,7 +441,6 @@ class SentencesSearchFormTest extends TestCase
 
     public function testCheckUnwantedCombinations_userNotNative() {
         $this->Form->setData([
-            'from' => 'eng',
             'user' => 'contributor',
             'native' => 'yes',
         ]);

--- a/tests/TestCase/Form/SentencesSearchFormTest.php
+++ b/tests/TestCase/Form/SentencesSearchFormTest.php
@@ -137,8 +137,8 @@ class SentencesSearchFormTest extends TestCase
             [ ['list' => '3'],       ['ListFilter' => new ListFilter()],               '', 1 ],
             [ ['list' => 'invalid'], ['ListFilter' => null],                           '',   ],
 
-            [ ['native' => 'yes'],     ['IsNativeFilter' => new IsNativeFilter()], 'yes'],
-            [ ['native' => 'no'],      ['IsNativeFilter' => null], '' ],
+            [ ['native' => 'yes'],     ['IsNativeFilter' => new IsNativeFilter(true)],  'yes' ],
+            [ ['native' => 'no'],      ['IsNativeFilter' => new IsNativeFilter(false)], 'no'  ],
             [ ['native' => 'invalid'], ['IsNativeFilter' => null], '' ],
             [ ['native' => ''],        ['IsNativeFilter' => null], '' ],
 

--- a/tests/TestCase/Form/SentencesSearchFormTest.php
+++ b/tests/TestCase/Form/SentencesSearchFormTest.php
@@ -14,6 +14,7 @@ use App\Model\Search\TranslationCountFilter;
 use App\Model\Search\TranslationFilterGroup;
 use App\Model\Search\TranslationHasAudioFilter;
 use App\Model\Search\TranslationIsDirectFilter;
+use App\Model\Search\TranslationIsNativeFilter;
 use App\Model\Search\TranslationIsOrphanFilter;
 use App\Model\Search\TranslationIsUnapprovedFilter;
 use App\Model\Search\TranslationLangFilter;
@@ -63,6 +64,7 @@ class SentencesSearchFormTest extends TestCase
             'trans_has_audio' => '',
             'trans_unapproved' => '',
             'trans_orphan' => '',
+            'trans_native' => '',
             'trans_user' => '',
             'sort' => 'relevance',
             'sort_reverse' => '',
@@ -188,6 +190,11 @@ class SentencesSearchFormTest extends TestCase
             [ ['trans_orphan' => 'no'],      ['tf' => (new TranslationFilterGroup())->setFilter(new TranslationIsOrphanFilter(false))], 'no'  ],
             [ ['trans_orphan' => 'invalid'], ['tf' => new TranslationFilterGroup()],  '' ],
             [ ['trans_orphan' => ''],        ['tf' => new TranslationFilterGroup()],  '' ],
+
+            [ ['trans_native' => 'yes'],     ['tf' => (new TranslationFilterGroup())->setFilter(new TranslationIsNativeFilter(true))],  'yes' ],
+            [ ['trans_native' => 'no'],      ['tf' => (new TranslationFilterGroup())->setFilter(new TranslationIsNativeFilter(false))], 'no'  ],
+            [ ['trans_native' => 'invalid'], ['tf' => new TranslationFilterGroup()],  '' ],
+            [ ['trans_native' => ''],        ['tf' => new TranslationFilterGroup()],  '' ],
 
             [ ['trans_user' => 'contributor'], ['tf' => (new TranslationFilterGroup())->setFilter(
                                                                (new TranslationOwnerFilter())->anyOf(['contributor'])

--- a/tests/TestCase/Model/SearchApiTest.php
+++ b/tests/TestCase/Model/SearchApiTest.php
@@ -283,10 +283,6 @@ class SearchApiTest extends TestCase
                 [ 'lang' => 'epo', 'is_native' => ['yes', 'yes'] ],
                 new BadRequestException("Invalid usage of parameter 'is_native': cannot be provided multiple times")
             ],
-            'is_native with multiple langs' => [
-                [ 'lang' => 'epo,sun', 'is_native' => 'yes' ],
-                new BadRequestException("Invalid usage of parameter 'is_native': must be used with a single language (multiple languages were provided to the language filter: epo sun)")
-            ],
 
             'valid origin' => [
                 [ 'lang' => 'epo', 'origin' => 'original' ],

--- a/tests/TestCase/Model/SearchTest.php
+++ b/tests/TestCase/Model/SearchTest.php
@@ -23,6 +23,7 @@ use App\Model\Search\TranslationFilterGroup;
 use App\Model\Search\TranslationHasAudioFilter;
 use App\Model\Search\TranslationLangFilter;
 use App\Model\Search\TranslationIsDirectFilter;
+use App\Model\Search\TranslationIsNativeFilter;
 use App\Model\Search\TranslationIsOrphanFilter;
 use App\Model\Search\TranslationIsUnapprovedFilter;
 use App\Model\Search\TranslationOwnerFilter;
@@ -707,6 +708,28 @@ class SearchTest extends TestCase
         } catch (InvalidValueException $e) {
             $this->assertTrue(true);
         }
+    }
+
+    public function testfilterTranslationIsNative_true() {
+        $this->Search->setTranslationFilter(new TranslationIsNativeFilter(true));
+
+        $expected = $this->makeSphinxParams([
+            'select' => '*, ANY(t.n=1 FOR t IN trans) as tf',
+            'filter' => [['tf', 1]],
+        ]);
+        $result = $this->Search->asSphinx();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testfilterTranslationIsNative_false() {
+        $this->Search->setTranslationFilter(new TranslationIsNativeFilter(false));
+
+        $expected = $this->makeSphinxParams([
+            'select' => '*, ANY(not (t.n=1) FOR t IN trans) as tf',
+            'filter' => [['tf', 1]],
+        ]);
+        $result = $this->Search->asSphinx();
+        $this->assertEquals($expected, $result);
     }
 
     public function testfilterByTranslationAudio_true() {

--- a/tests/TestCase/Model/SearchTest.php
+++ b/tests/TestCase/Model/SearchTest.php
@@ -417,107 +417,23 @@ class SearchTest extends TestCase
         $this->testfilterByListId_empty();
     }
 
-    public function testfilterIsNativeSpeaker_true_fra() {
-        $this->Search->setFilter((new LangFilter())->anyOf(['fra']));
-        $this->Search->setFilter((new IsNativeFilter(true))->setSearch($this->Search));
+    public function testfilterIsNativeSpeaker_true() {
+        $this->Search->setFilter(new IsNativeFilter(true));
 
         $expected = $this->makeSphinxParams([
-            'index' => ['fra_main_index', 'fra_delta_index'],
-            'filter' => [['user_id', [4, 3], false]],
+            'filter' => [['owner_is_native', [1], false]],
         ]);
         $result = $this->Search->asSphinx();
         $this->assertEquals($expected, $result);
     }
 
-    public function testfilterIsNativeSpeaker_false_fra() {
-        $this->Search->setFilter((new LangFilter())->anyOf(['fra']));
-        $this->Search->setFilter((new IsNativeFilter(false))->setSearch($this->Search));
+    public function testfilterIsNativeSpeaker_false() {
+        $this->Search->setFilter(new IsNativeFilter(false));
 
         $expected = $this->makeSphinxParams([
-            'index' => ['fra_main_index', 'fra_delta_index'],
-            'filter' => [['user_id', [4, 3], true]],
+            'filter' => [['owner_is_native', [1], true]],
         ]);
         $result = $this->Search->asSphinx();
-        $this->assertEquals($expected, $result);
-    }
-
-    public function testfilterIsNativeSpeaker_true_butNoNativeSpeakers() {
-        $this->Search->setFilter((new LangFilter())->anyOf(['fro']));
-        $this->Search->setFilter((new IsNativeFilter(true))->setSearch($this->Search));
-
-        $expected = $this->makeSphinxParams([
-            'index' => ['fro_main_index', 'fro_delta_index'],
-            'filter' => [['user_id', [-1], false]],
-        ]);
-        $result = $this->Search->asSphinx();
-        $this->assertEquals($expected, $result);
-    }
-
-    public function testfilterIsNativeSpeaker_false_butNoNativeSpeakers() {
-        $this->Search->setFilter((new LangFilter())->anyOf(['fro']));
-        $this->Search->setFilter((new IsNativeFilter(false))->setSearch($this->Search));
-
-        $expected = $this->makeSphinxParams([
-            'index' => ['fro_main_index', 'fro_delta_index'],
-            'filter' => [['user_id', [-1], true]],
-        ]);
-        $result = $this->Search->asSphinx();
-        $this->assertEquals($expected, $result);
-    }
-
-    public function testfilterIsNativeSpeaker_no_setSearch() {
-        $this->Search->setFilter(new IsNativeFilter());
-        try {
-            $this->Search->compile();
-            $this->fail("IsNativeFilter did not generate excepted RuntimeException");
-        } catch (\RuntimeException $e) {
-            $this->assertEquals('Precondition failed: setSearch() was not called first', $e->getMessage());
-        }
-    }
-
-    public function testfilterIsNativeSpeaker_unset() {
-        $this->Search->setFilter((new LangFilter())->anyOf(['fra']));
-        $this->Search->unsetFilter(IsNativeFilter::class);
-
-        $expected = $this->makeSphinxParams([
-            'index' => ['fra_main_index', 'fra_delta_index'],
-        ]);
-        $result = $this->Search->asSphinx();
-        $this->assertEquals($expected, $result);
-    }
-
-    public function testfilterIsNativeSpeaker_resets() {
-        $this->testfilterIsNativeSpeaker_true_fra();
-        $this->testfilterIsNativeSpeaker_unset();
-    }
-
-    public function testfilterIsNativeSpeaker_withLimit_true() {
-        $this->Search->setFilter((new LangFilter())->anyOf(['fra']));
-        $filter = (new IsNativeFilter(true))->setSearch($this->Search);
-        $filter->setSphinxFilterArrayLimit(1);
-        $this->Search->setFilter($filter);
-        $expected = $this->makeSphinxParams([
-            'index' => ['fra_main_index', 'fra_delta_index'],
-            'filter' => [['user_id', [7], true]],
-        ]);
-
-        $result = $this->Search->asSphinx();
-
-        $this->assertEquals($expected, $result);
-    }
-
-    public function testfilterIsNativeSpeaker_withLimit_false() {
-        $this->Search->setFilter((new LangFilter())->anyOf(['fra']));
-        $filter = (new IsNativeFilter(false))->setSearch($this->Search);
-        $filter->setSphinxFilterArrayLimit(1);
-        $this->Search->setFilter($filter);
-        $expected = $this->makeSphinxParams([
-            'index' => ['fra_main_index', 'fra_delta_index'],
-            'filter' => [['user_id', [4], true], ['user_id', [3], true]],
-        ]);
-
-        $result = $this->Search->asSphinx();
-
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
* solves #3203
* allows "owner is native" to be used without filtering by language
* changes the "owner is native" checkbox into a Yes/No/Any dropdown:
    * "Yes" is the same as ticking the checkbox
    * "Any" is the same as leaving the checkbox empty
    * "No" allows to limit to sentences not owned by natives (which includes orphans too, unless "is orphan" is also set to "no", which happens to be the default).
* similarly allows `is_native=no` filter on the API endpoint `/sentences`
* similarly adds filter `trans:is_native=yes/no` to the API endpoint `/sentences`

Related: #3211

<img width="971" height="953" alt="image" src="https://github.com/user-attachments/assets/78592215-0030-498c-8522-4de31f3aebba" />
