### PR TITLE
Fix disabling audio having unknown creation date

### DIFF
--- a/config/Migrations/20251023072511_AllowUnknownDateAudios.php
+++ b/config/Migrations/20251023072511_AllowUnknownDateAudios.php
@@ -1,0 +1,35 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AllowUnknownDateAudios extends AbstractMigration
+{
+    private function set_nullable_datetime(bool $nullable)
+    {
+        foreach (['audios', 'disabled_audios'] as $table) {
+            foreach (['created', 'modified'] as $column) {
+                $this->table($table)
+                    ->changeColumn($column, 'datetime', [
+                        'null' => $nullable,
+                    ])
+                    ->update();
+                if ($nullable) {
+                    $this->getQueryBuilder()
+                        ->update($table)
+                        ->set($column, null)
+                        ->where([$column => '0000-00-00 00:00:00'])
+                        ->execute();
+                }
+            }
+        }
+    }
+
+    public function up()
+    {
+        $this->set_nullable_datetime(true);
+    }
+
+    public function down()
+    {
+        $this->set_nullable_datetime(false);
+    }
+}

--- a/src/Model/Entity/Audio.php
+++ b/src/Model/Entity/Audio.php
@@ -42,6 +42,10 @@ class Audio extends Entity
     }
 
     protected function _setEnabled($enabled) {
+        // set the modified field to dirty as a way to prevent
+        // the TimestampBehavior from updating the modified field
+        // when an audio is enabled or disabled
+        $this->setDirty('modified');
         return $this->__wantedEnabled = $enabled;
     }
 

--- a/src/Model/Table/AudiosTable.php
+++ b/src/Model/Table/AudiosTable.php
@@ -69,9 +69,11 @@ class AudiosTable extends Table
             ->allowEmptyString('user_id');
 
         $validator
+            ->allowEmpty('created')
             ->dateTime('created');
 
         $validator
+            ->allowEmpty('modified')
             ->dateTime('modified');
 
         $validator

--- a/tests/Fixture/AudiosFixture.php
+++ b/tests/Fixture/AudiosFixture.php
@@ -14,8 +14,8 @@ class AudiosFixture extends TestFixture
         'sentence_lang' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 4, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'],
         'user_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
         'external' => ['type' => 'json', 'length' => 500, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'created' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'modified' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         '_indexes' => [
             'sentence_id' => ['type' => 'index', 'columns' => ['sentence_id'], 'length' => []],
         ],

--- a/tests/Fixture/DisabledAudiosFixture.php
+++ b/tests/Fixture/DisabledAudiosFixture.php
@@ -14,8 +14,8 @@ class DisabledAudiosFixture extends TestFixture
         'sentence_lang' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 4, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'],
         'user_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
         'external' => ['type' => 'json', 'length' => 500, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'created' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'modified' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         '_indexes' => [
             'sentence_id' => ['type' => 'index', 'columns' => ['sentence_id'], 'length' => []],
         ],

--- a/tests/TestCase/Model/Table/AudiosTableTest.php
+++ b/tests/TestCase/Model/Table/AudiosTableTest.php
@@ -291,8 +291,9 @@ class AudiosTableTest extends TestCase {
         }
 
         $this->assertFalse($result);
-        $DisabledAudios = TableRegistry::getTableLocator()->get('DisabledAudios');
-        $this->assertFalse($DisabledAudios->get(1)->enabled);
+        $disabledAudio = TableRegistry::getTableLocator()->get('DisabledAudios')->get(1);
+        $this->assertFalse($disabledAudio->enabled);
+        $this->assertEquals($disabledAudio->modified, $audio->modified);
     }
 
     function testEdit_enable_fails() {

--- a/tests/TestCase/Model/Table/AudiosTableTest.php
+++ b/tests/TestCase/Model/Table/AudiosTableTest.php
@@ -97,15 +97,15 @@ class AudiosTableTest extends TestCase {
         $this->assertTrue($result);
     }
 
-    function testCreatedCantBeEmpty() {
-        $this->_assertInvalidRecordWith(0, array('created' => ''));
+    function testCreatedCanBeNull() {
+        $this->_assertValidRecordWith(0, array('created' => null));
     }
     function testCreatedIsAutomaticallySet() {
         $this->_assertValidRecordWithout(0, array('created'));
     }
 
-    function testModifiedCantBeEmpty() {
-        $this->_assertInvalidRecordWith(0, array('modified' => ''));
+    function testModifiedCanBeNull() {
+        $this->_assertValidRecordWith(0, array('modified' => null));
     }
     function testModifiedIsAutomaticallySet() {
         $this->_assertValidRecordWithout(0, array('modified'));

--- a/tests/TestCase/Model/Table/DisabledAudiosTableTest.php
+++ b/tests/TestCase/Model/Table/DisabledAudiosTableTest.php
@@ -46,7 +46,8 @@ class DisabledAudiosTableTest extends TestCase
         }
 
         $this->assertFalse($result);
-        $Audios = TableRegistry::getTableLocator()->get('Audios');
-        $this->assertTrue($Audios->get(4)->enabled);
+        $reenabledAudio = TableRegistry::getTableLocator()->get('Audios')->get(4);
+        $this->assertTrue($reenabledAudio->enabled);
+        $this->assertEquals($reenabledAudio->modified, $audio->modified);
     }
 }


### PR DESCRIPTION
Solves #2947.

Changes:
* Explicitly allow fields `audios.created` and `audios.modified` to be null, instead of letting MariaDB cast null dates into a zero date 0000-00-00 00:00:00.
* Stop updating the `modified` field when an audio record is moved between the tables `audios` and `disabled_audios`. 