### PR TITLE
Add translation statistics per language

### DIFF
--- a/src/Controller/PagesController.php
+++ b/src/Controller/PagesController.php
@@ -107,6 +107,10 @@ class PagesController extends AppController
         $numSentences = $this->Languages->getTotalSentencesNumber();
         $this->set('numSentences', $numSentences);
 
+        $this->loadModel('Sentences');
+        $numTranslations = $this->Sentences->getTotalTranslations();
+        $this->set('numTranslations', $numTranslations);
+        
         $this->loadModel('Contributions');
         $contribToday = $this->Contributions->getTodayContributions();
         $this->set('contribToday', $contribToday);

--- a/src/Controller/StatsController.php
+++ b/src/Controller/StatsController.php
@@ -27,6 +27,7 @@
 namespace App\Controller;
 
 use App\Controller\AppController;
+use App\Lib\LanguagesLib;
 use Cake\Event\Event;
 
 /**
@@ -52,6 +53,34 @@ class StatsController extends AppController
         $this->set('stats', $stats);
         $this->set('audioStats', $audioStats);
         $this->set('totalSentences', $totalSentences);
+    }
+
+
+    /**
+     * Show translation statistics for a specified language.
+     *
+     * @param mixed $lang Language for which statistics should be displayed.
+     *
+     * @return void
+     */
+    function translations_by_language($lang = null)
+    {
+        if ($lang !== null && !array_key_exists($lang, LanguagesLib::languagesInTatoeba())) {
+            throw new \Cake\Http\Exception\NotFoundException();
+        }
+
+        $this->set('lang', $lang);
+
+        $this->loadModel('Sentences');
+        $stats = $this->Sentences->getTranslationStatistics($lang);
+        $this->set('stats', $stats);
+
+        $total = $this->Sentences->getTotalTranslations($lang);
+        $this->set('totalTranslations', $total);
+
+        $this->loadModel('Languages');
+        $total = $this->Languages->getTotalSentencesNumber($lang);
+        $this->set('total', $total);
     }
 
 

--- a/src/Model/Table/LanguagesTable.php
+++ b/src/Model/Table/LanguagesTable.php
@@ -240,10 +240,21 @@ class LanguagesTable extends Table
 
     }
 
-    public function getTotalSentencesNumber()
+    /**
+     * Return the total number of sentences for a certain language,
+     * or of all sentences if no language is given.
+     *
+     * @param $langCode Code of the language
+     *
+     * @return int
+     */
+    public function getTotalSentencesNumber($langCode = null)
     {
         $query = $this->find();
+        if ($langCode !== null) {
+            $query->where(['code' => $langCode]);
+        }
         $query->select(['count' => $query->func()->sum('sentences')]);
-        return $query->first()->count;
+        return $query->firstOrFail()->count;
     }
 }

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -843,7 +843,7 @@ class SentencesTable extends Table
      *
      * @return array Array of translations (direct and indirect).
      */
-    public function getTranslationsOf($id,$lang = null)
+    public function getTranslationsOf($id, $lang = null)
     {
         if ( ! is_numeric($id) ) {
             return array();
@@ -1392,5 +1392,58 @@ class SentencesTable extends Table
             ->all()
             ->extract('lang')
             ->toArray();
+    }
+
+    /**
+     * Computes a table of translation counts for a given language.
+     *
+     * @param string $lang Language for which to calculate the statistics.
+     *                     If null calculate the table for all languages.
+     *
+     * @return query object
+     */
+    public function getTranslationStatistics($lang = null)
+    {
+        $results = $this->Links->query()
+            ->select([
+                'code' => 'translation_lang',
+                'translations' => 'COUNT(*)',
+            ])
+            ->group(['code'])
+            ->order(['translations' => 'DESC',
+                     'translation_lang' => 'ASC']);
+        
+        if ($lang !== null)
+          $results = $results->where(['sentence_lang' => $lang]);
+        
+        return $results->toList();
+    }
+
+    /**
+     * Counts the number of sentences with translations for a language.
+     *
+     * @param string $lang Language for which to calculate the statistics.
+     *                     If null calculate the number of all sentences
+     *                     with a translation.
+     *
+     * @return int
+     */
+    public function getTotalTranslations($lang = null)
+    {
+        $results = $this->find()
+            ->join([
+                'table' => 'sentences_translations',
+                'alias' => 'T',
+                'type' => 'RIGHT',
+                'conditions' => 'Sentences.id = T.sentence_id',
+            ])
+            ->select([
+                'count' => 'COUNT(DISTINCT(T.sentence_id))',
+            ]);
+        
+        if ($lang !== null)
+          $results = $results->where(['Sentences.lang' => $lang]);
+            
+        return $results->firstOrFail()->count;
     }
 }

--- a/src/Template/Element/stats/homepage_stats.ctp
+++ b/src/Template/Element/stats/homepage_stats.ctp
@@ -3,6 +3,10 @@ $statsUrl = $this->Url->build([
     'controller' => 'stats',
     'action' => 'sentences_by_language'
 ]);
+$statsTransUrl = $this->Url->build([
+    'controller' => 'stats',
+    'action' => 'translations_by_language'
+]);
 $activityUrl = $this->Url->build([
     'controller' => 'contributions',
     'action' => 'activity_timeline'
@@ -32,6 +36,24 @@ $activityUrl = $this->Url->build([
         <div layout="row" layout-align="center center">
             <md-button class="md-primary" href="<?= $statsUrl ?>">
                 <?= __('Stats per languages') ?>
+                <md-icon ng-cloak>keyboard_arrow_right</md-icon>
+            </md-button>
+        </div>
+    </div>
+
+    <div class="category">
+        <div>
+        <?= format(
+            __n('{number} sentence with translations',
+                '{number} sentences with translations',
+                $numTranslations,
+                true),
+            ['number' => $this->Html->tag('strong', $this->Number->format($numTranslations))]
+        ) ?>
+        </div>
+        <div layout="row" layout-align="center center">
+            <md-button class="md-primary" href="<?= $statsTransUrl ?>">
+                <?= __('Translation statistics') ?>
                 <md-icon ng-cloak>keyboard_arrow_right</md-icon>
             </md-button>
         </div>

--- a/src/Template/Pages/index_for_guests.ctp
+++ b/src/Template/Pages/index_for_guests.ctp
@@ -78,6 +78,18 @@ $registerUrl = $this->Url->build(
                 <?php echo __('Join the community'); ?>
             </md-button>
         </div>
+        <p>
+        <?= __(
+            'To operate this website we need some money. '.
+            'So you can also help us with a donation.', true
+        ); ?>
+        <div layout="row" layout-align="center center">
+            <md-button class="md-primary" href="<?= $this->Url->build(
+                array('controller' => 'pages', 'action' => 'donate')
+            ) ?>">
+                <?php echo __('Donate'); ?>
+            </md-button>
+        </div>
     </div>
     
     <div class="stats annexe-menu md-whiteframe-1dp" layout="column" flex>

--- a/src/Template/Stats/translations_by_language.ctp
+++ b/src/Template/Stats/translations_by_language.ctp
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2026 Bernhard Seckinger <kumakyoo@kumakyoo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Tatoeba
+ * @author   Bernhard Seckinger <kumakyoo@kumakyoo.de>
+ * @license  Affero General Public License
+ * @link     https://tatoeba.org
+ */
+
+if (empty($lang)) {
+    $title = __('Translation statistics for all languages');
+} else {
+    $title = format(
+        __('Translation statistics for {language}'),
+        array('language' => $this->Languages->codeToNameToFormat($lang))
+    );
+}
+
+$this->set('title_for_layout', $this->Pages->formatTitle($title));
+
+?>
+<div id="annexe_content">
+    <?php $this->CommonModules->createFilterByLangMod(); ?>
+</div>
+
+<div id="main_content">
+<div class="section md-whiteframe-1dp">
+    <h2><?= $title; ?></h2>
+
+    <p>
+    <?php
+        if (empty($lang)) {
+            echo '<p>'.format(
+                __n('There is one sentence in the corpus.',
+                'There are {total}&nbsp;sentences in the corpus.',
+                $total),
+                array('total' => $total)
+            );
+        }
+        else {
+            echo '<p>'.format(
+                __n('There is one sentence in {language}.',
+                'There are {total}&nbsp;sentences in {language}.',
+                $total),
+                array('language' => $this->Languages->codeToNameToFormat($lang),
+                      'total' => $total)
+            );
+       }
+    ?>                          
+
+    <?php 
+    if (empty($stats)) {
+        echo __('There are no sentences with translations.');
+        return;
+    }
+    echo format(
+        __n('One sentence has at least one translation.',
+            '{total}&nbsp;sentences have at least one translation.',
+            $totalTranslations),
+        array('total' => $totalTranslations)
+    );
+    ?>
+
+    <table class="language-stats">
+    <tr>
+        <th colspan="3">
+        <?php /* @translators: table header text in "Translation statistics for language" page */ ?>
+        <th><?php echo __('Language'); ?></th>
+        <?php /* @translators: table header text in "Translation statistics for language" page */ ?>
+        <th><?php echo __('Translations'); ?></th>
+    </tr>
+
+    <?php
+    $rank = 1;
+    foreach ($stats as $language) {
+        $langCode = $language['code'];
+        $numSentences = $language['translations'];
+        
+        if (!isset($max)) {
+            // table is sorted by $numSentences, thus the first entry is the maximum
+            $max = $numSentences;
+        }
+        
+        if ($max == 0) {
+            $percent = 0;
+        } else {
+            $percent = ($numSentences / $max) * 100;
+        }
+        $numSentencesDiv  = '<div class="bar" style="width:'.$percent.'%"></div>';
+        $numSentencesDiv .= $this->Number->format($numSentences);
+
+        $languageIcon = $this->Languages->icon($langCode);
+
+        if (empty($lang)) {
+            $from = $langCode;
+            $to = '';
+        } else {
+            $from = $lang;
+            $to = $langCode;
+        }
+
+        $langName = $this->Languages->codeToNameAlone($langCode);
+        if (empty($langCode)) {
+            $langCode = 'unknown';
+            $languageLink = 'unknown';
+        }
+        else
+        {
+            $languageLink = $this->Html->link(
+                $langName,
+                [
+                  'controller' => 'sentences',
+                  'action' => 'search',
+                  '?' => [
+                    'from' => $from,
+                    'to' => $to,
+                    'trans_to' => $to,
+                    'sort' => 'created',
+                    'trans_filter' => 'limit',
+                    'trans_link' => 'direct'
+                  ]
+               ]
+            );
+        }
+
+        echo '<tr>';
+
+        echo $this->Html->tag('td', $this->Number->format($rank));
+        echo $this->Html->tag('td', $languageIcon);
+        echo $this->Html->tag('td', $langCode);
+        echo $this->Html->tag('td', $languageLink);
+        echo $this->Html->tag('td', $numSentencesDiv, array('class' => 'num-sentences'));
+
+        echo '</tr>'.PHP_EOL;
+
+        $rank++;
+    }
+    ?>
+    </table>
+</div>
+</div>

--- a/tests/TestCase/Controller/StatsControllerTest.php
+++ b/tests/TestCase/Controller/StatsControllerTest.php
@@ -25,6 +25,8 @@ class StatsControllerTest extends IntegrationTestCase
             [ '/en/stats/users_languages', 'contributor', true ],
             [ '/en/stats/native_speakers', null, true ],
             [ '/en/stats/native_speakers', 'contributor', true ],
+            [ '/en/stats/translations_by_language', null, true ],
+            [ '/en/stats/translations_by_language', 'contributor', true ],
         ];
     }
 

--- a/tests/TestCase/Model/Table/LanguagesTableTest.php
+++ b/tests/TestCase/Model/Table/LanguagesTableTest.php
@@ -74,6 +74,15 @@ class LanguagesTableTest extends TestCase {
         $expected = 56;
         $n = $this->Languages->getTotalSentencesNumber();
         $this->assertEquals($expected, $n);
+        $n = $this->Languages->getTotalSentencesNumber(null);
+        $this->assertEquals($expected, $n);
+
+        $expected = 21;
+        $n = $this->Languages->getTotalSentencesNumber('eng');
+        $this->assertEquals($expected, $n);
+
+        $n = $this->Languages->getTotalSentencesNumber('und');
+        $this->assertNull($n);
     }
 
     function testGetMilestonedStatistics() {

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -1626,4 +1626,45 @@ class SentencesTableTest extends TestCase {
 
         Time::setTestNow();
     }
+
+    function testGetTranslationStatistics()
+    {
+        $expected = 7;
+        $table = $this->Sentence->getTranslationStatistics();
+        $this->assertEquals(count($table),$expected);
+        $this->assertLessThanOrEqual($table[0]['translations'],
+                                     $table[count($table)-1]['translations']);
+        
+        $table = $this->Sentence->getTranslationStatistics(null);
+        $this->assertEquals(count($table),$expected);
+        $this->assertLessThanOrEqual($table[0]['translations'],
+                                     $table[count($table)-1]['translations']);
+        
+        $expected = 4;
+        $table = $this->Sentence->getTranslationStatistics('eng');
+        $this->assertEquals(count($table),$expected);
+        $this->assertLessThanOrEqual($table[0]['translations'],
+                                     $table[count($table)-1]['translations']);
+
+        $table = $this->Sentence->getTranslationStatistics('und');
+        $this->assertEmpty($table);
+    }
+
+    function testGetTotalTranslations()
+    {
+        $expected = 18;
+        $n = $this->Sentence->getTotalTranslations();
+        $this->assertEquals($n, $expected);
+
+        $n = $this->Sentence->getTotalTranslations(null);
+        $this->assertEquals($n, $expected);
+        
+        $expected = 8;
+        $n = $this->Sentence->getTotalTranslations('eng');
+        $this->assertEquals($n, $expected);
+
+        $expected = 0;
+        $n = $this->Sentence->getTotalTranslations('und');
+        $this->assertEquals($n, $expected);
+    }
 }

--- a/webroot/css/pages/index.css
+++ b/webroot/css/pages/index.css
@@ -90,7 +90,7 @@
 }
 
 .join-us > div {
-    padding: 10px;
+    padding: 0px;
 }
 .join-us p {
     padding: 0px 16px;

--- a/webroot/css/stats/translations_by_language.css
+++ b/webroot/css/stats/translations_by_language.css
@@ -1,0 +1,46 @@
+/**
+ * Tatoeba Project, free collaborative creation of multilingual corpuses project
+ * Copyright (C) 2026 Bernhard Seckinger <kumakyoo@kumakyoo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http: //www.gnu.org/licenses/>.
+ */
+
+
+/*
+ * Stats for language
+ */
+.language-stats .bar {
+    background: #4caf50;
+    height: 4px;
+}
+
+.language-stats {
+    text-align: center;
+}
+
+.language-stats tr {
+    border-bottom: 1px solid #f1f1f1;
+}
+
+.language-stats td {
+    padding: 5px 10px;
+}
+
+.language-stats img {
+    display: block;
+}
+
+.language-stats .num-sentences {
+    width: 300px;
+}


### PR DESCRIPTION
When I visited [sentences by language](https://tatoeba.org/de/stats/sentences_by_language) for the first time and clicked on a language, I expected some statistics for that language (you get a list of all sentences of that language instead). As this sort of statistics is not available I thought it might be a good idea to add it.

From my experience as a PR reviewer I know it's better to keep PRs small. Hence, this is only part of the work - I did not yet add what will happen when no language is given, or when the language given does not exist. I plan to add this in future PRs. (If you prefere larger all at once PRs, please tell me!)

As this change isn't complete, I didn't change the above mentioned links yet, so for testing you need to point your browser to .../stats/statistics_for_language/eng. 

There is one issue about translations, I couldn't solve yet. Maybe you can help me out here: The sentence above the table "There are 9 sentences in Deutsch, 7 of them have at least one translation." contains two numbers which would change the sentence when being the value 1. As there are two numbers, I can't use `__n()` here or at least I'm not aware of how to do this. Any ideas?

And one more thing: My editor automatically removes trailing spaces and I don't know, how to stop it from doing so. Hence there are a few unrelated minor changes in this PR. Hope this doesn't hurt.
