### PR TITLE
"Filter by language" field doesn't show the language when changing it

### DIFF
--- a/src/View/Helper/CommonModulesHelper.php
+++ b/src/View/Helper/CommonModulesHelper.php
@@ -85,7 +85,7 @@ class CommonModulesHelper extends AppHelper
             }
 
             $lang = 'und' ;
-            if (isset($params[$maxNumberOfParams-1]) && $this->Languages->languageExists($lang)) {
+            if (isset($params[$maxNumberOfParams-1]) && $this->Languages->languageExists($params[$maxNumberOfParams-1])) {
                 $lang  = $params[$maxNumberOfParams-1];
             }
 


### PR DESCRIPTION
This pull request addresses issue #{3230}.