### PR TITLE
The "permanently delete" function for email massages gets a NOT FOUND message

### DIFF
--- a/src/View/Helper/PrivateMessagesHelper.php
+++ b/src/View/Helper/PrivateMessagesHelper.php
@@ -80,7 +80,7 @@ class PrivateMessagesHelper extends AppHelper
                 'text' => __('Permanently delete'),
                 'icon' => 'delete_forever',
                 'url' => array(
-                    'action' => 'delete_forever',
+                    'action' => 'delete',
                     $messageId
                 ),
                 'confirm' => __('Are you sure?')


### PR DESCRIPTION
This pull request addresses issue #{2621}.

Seems like someone confused the `delete_forever` icon with the `delete` action. This action is smart enough to distinguish between messages in the trash and elsewhere, so there is no need for a `delete_forever` action.