### PR TITLE
Allow furigana above a single kana

### DIFF
--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -590,7 +590,7 @@
                 var punct = '　-〄〇-〠・'; // 。、「」etc.
                 punct += '！＂＃＇（），．／：；？［＼］＾｀～｟｠'; // fullwitdh forms
                 punct += ' '; // space
-                var regex = '([^｝' + hiragana + katakana + punct + ']*)｛([^｝]*)｝';
+                var regex = '([^｝' + hiragana + katakana + punct + ']{1,}|[ヶ])｛([^｝]*)｝';
                 text = text.replace(uniRegExp(regex, 'g'), '[$1|$2]');
                 text = text.replace(uniRegExp('｜', 'g'),  '|');
             }


### PR DESCRIPTION
This pull request addresses issue #3145 

In the current implementation furigana can only be placed above non-kana symbols. But there are some cases where a furigana above a kana makes sense, see https://en.wiktionary.org/wiki/%E3%83%B6 for an explanation. I extended the regex to accept either a non-empty series of non-kana symbols or a single kana symbol.

I excluded the empty sequence, because it will make for a better error message when the user tries to add a furigana to a punctuation symbol (_furigana sentences differs from the original_ vs. _unexpected [ symbol_).