### PR TITLE
Paginate results from API /sentences when sort=random

### DIFF
--- a/src/Controller/VHosts/Api/SentencesController.php
+++ b/src/Controller/VHosts/Api/SentencesController.php
@@ -564,7 +564,10 @@ class SentencesController extends ApiController
     public function search() {
         $api = new SearchApi();
         $api->setLimits(self::DEFAULT_RESULTS_NUMBER, self::MAX_RESULTS_NUMBER);
-        $api->readParamsForSearchSentences($this->getRequest()->getQueryParams());
+        $params = $this->getRequest()->getQueryParams();
+        $changedParams = $api->readParamsForSearchSentences($params);
+        $params = array_merge($params, $changedParams);
+        $this->setRequest($this->getRequest()->withQueryParams($params));
 
         $this->loadModel('Sentences');
         $query = $this->Sentences

--- a/src/Form/SentencesSearchForm.php
+++ b/src/Form/SentencesSearchForm.php
@@ -370,7 +370,8 @@ class SentencesSearchForm extends Form
 
     private function _newSeed() {
         /* Only use 24 bits of randomness */
-        $pseudoRand = mt_rand(0, (2<<23)-1);
+        $max = (2<<23) - 1;
+        $pseudoRand = $this->search->initRandSeed($max);
         return $this->_encodeSeed($pseudoRand);
     }
 

--- a/src/Model/Search.php
+++ b/src/Model/Search.php
@@ -84,7 +84,7 @@ class Search {
             $sphinx['sortMode'] = [
                 SPH_SORT_EXTENDED => implode(', ', array_map([$this, 'orderby_'], $this->sortOrder))
             ];
-            if ($this->computeCursor && $this->sort != 'random') {
+            if ($this->computeCursor) {
                 $sphinx['select'] .= $this->computeCursor();
             }
         }
@@ -119,7 +119,8 @@ class Search {
 
     private function computeSortAndRanking() {
         $this->sortOrder = [];
-        $randomExpr = "RAND({$this->randSeed})*16777216";
+        $seedExpr = is_null($this->randSeed) ? '' : "{$this->randSeed}*id";
+        $randomExpr = "RAND($seedExpr)*16777216";
         if (empty($this->query)) {
             // When the query is empty, Manticore does not perform any
             // ranking, so we need to rely on ordering instead

--- a/src/Model/Search.php
+++ b/src/Model/Search.php
@@ -187,6 +187,14 @@ class Search {
         return '="'.$escaped.'"';
     }
 
+    protected function generateRand($max) {
+        return mt_rand(0, $max);
+    }
+
+    public function initRandSeed($max = null) {
+        return $this->randSeed = $this->generateRand($max ?? mt_getrandmax());
+    }
+
     public function setRandSeed($seed) {
         return $this->randSeed = $seed;
     }

--- a/src/Model/SearchApi.php
+++ b/src/Model/SearchApi.php
@@ -201,20 +201,38 @@ class SearchApi
         }
     }
 
-    public function consumeSort(&$params) {
+    private function parseSortValue(string $sort, array &$newParams) {
+        // Parse '-' prefix
+        if (isset($sort[0]) && $sort[0] == '-') {
+            $this->search->reverseSort(true);
+            $sort = substr($sort, 1);
+        }
+
+        // Parse or add random seed value as sort=random:<seed>
+        $parts = explode(':', $sort);
+        if (count($parts) == 2 && $parts[0] == 'random' && ctype_digit($parts[1])) {
+            $sort = $parts[0];
+            $this->search->setRandSeed((int)$parts[1]);
+        } elseif ($sort == 'random') {
+            $newSeed = $this->search->initRandSeed();
+            $newParams = ['sort' => 'random:'.$newSeed];
+        }
+
+        return $sort;
+    }
+
+    public function consumeSort(&$params): array {
         if (isset($params['sort'])) {
             $sort = $params['sort'];
         } else {
             throw new BadRequestException('Required parameter "sort" missing');
         }
 
+        $newParams = [];
         if (is_array($sort)) {
             throw new BadRequestException("Invalid usage of parameter 'sort': cannot be provided multiple times");
         }
-        if (isset($sort[0]) && $sort[0] == '-') {
-            $this->search->reverseSort(true);
-            $sort = substr($sort, 1);
-        }
+        $sort = $this->parseSortValue($sort, $newParams);
         if (!$this->search->sort($sort)) {
             $allsorts = array_merge(
                 Search::AVAILABLE_SORTS,
@@ -223,6 +241,8 @@ class SearchApi
             throw new BadRequestException("Invalid value for parameter 'sort': must be one of: ".join(', ', $allsorts));
         }
         unset($params['sort']);
+
+        return $newParams;
     }
 
     public function consumeValue($key, &$params, $default = null) {
@@ -364,13 +384,14 @@ class SearchApi
         }
     }
 
-    public function readParamsForSearchSentences(array $params) {
+    public function readParamsForSearchSentences(array $params): array {
         $this->include = $this->consumeInclude($params);
         $this->limit = $this->consumeInt('limit', $params);
-        $this->consumeSort($params);
+        $newParams = $this->consumeSort($params);
         $this->setDefaultFilters();
         $this->consumeFilters($params);
         $this->failIfParams($params);
+        return $newParams;
     }
 
     public function readParamsForGetSentence(array $params) {

--- a/tests/TestCase/Model/SearchApiTest.php
+++ b/tests/TestCase/Model/SearchApiTest.php
@@ -44,7 +44,15 @@ class SearchApiTest extends TestCase
         parent::setUp();
         $returnedSentenceIds = [1, 2, 3];
         $this->enableMockedSearch($returnedSentenceIds);
-        $this->SearchApi = new SearchApi();
+
+        $search = $this->getMockBuilder(Search::class)
+                       ->setMethods(['generateRand'])
+                       ->getMock();
+        $search->expects($this->any())
+               ->method('generateRand')
+               ->will($this->returnValue(12345));
+
+        $this->SearchApi = new SearchApi($search);
     }
 
     public function tearDown() {
@@ -705,6 +713,36 @@ class SearchApiTest extends TestCase
         $this->SearchApi->consumeFilters($params);
 
         $this->assertEquals($expectedSearch->asSphinx(), $this->SearchApi->search->asSphinx());
+    }
+
+    public function testConsumeSort_randomWithoutSeed() {
+        $expectedSearch = new Search();
+        $expectedSearch->setFilter((new LangFilter())->anyOf(['epo']));
+        $expectedSearch->sort('random');
+        $expectedSearch->setComputeCursor(true);
+        $expectedSearch->setRandSeed(12345);
+
+        $params = ['sort' => 'random', 'lang' => 'epo'];
+        $ret = $this->SearchApi->consumeSort($params);
+        $this->SearchApi->consumeFilters($params);
+
+        $this->assertEquals($expectedSearch->asSphinx(), $this->SearchApi->search->asSphinx());
+        $this->assertEquals(['sort' => 'random:12345'], $ret);
+    }
+
+    public function testConsumeSort_randomWithSeed() {
+        $expectedSearch = new Search();
+        $expectedSearch->setFilter((new LangFilter())->anyOf(['epo']));
+        $expectedSearch->sort('random');
+        $expectedSearch->setComputeCursor(true);
+        $expectedSearch->setRandSeed(54321);
+
+        $params = ['sort' => 'random:54321', 'lang' => 'epo'];
+        $ret = $this->SearchApi->consumeSort($params);
+        $this->SearchApi->consumeFilters($params);
+
+        $this->assertEquals($expectedSearch->asSphinx(), $this->SearchApi->search->asSphinx());
+        $this->assertEquals([], $ret);
     }
 
     public function testCursorFilter_OK() {

--- a/tests/TestCase/Model/SearchTest.php
+++ b/tests/TestCase/Model/SearchTest.php
@@ -1082,7 +1082,7 @@ class SearchTest extends TestCase
         $this->Search->sort('random');
         $this->Search->setComputeCursor(true);
         $expected = $this->makeSphinxParams([
-            'select' => "*",
+            'select' => "*, CONCAT(TO_STRING(RAND()*16777216), ',', TO_STRING(id)) as cursor",
             'sortMode' => [SPH_SORT_EXTENDED => 'RAND()*16777216 DESC, id DESC'],
         ]);
 
@@ -1112,7 +1112,7 @@ class SearchTest extends TestCase
         $this->Search->setComputeCursor(true);
         $this->Search->filterByQuery('hello world');
         $expected = $this->makeSphinxParams([
-            'select' => "*",
+            'select' => "*, CONCAT(TO_STRING(WEIGHT()), ',', TO_STRING(id)) as cursor",
             'sortMode' => [SPH_SORT_EXTENDED => '@rank DESC, id DESC'],
             'query' => 'hello world',
             'rankingMode' => [SPH_RANK_EXPR => 'RAND()*16777216'],
@@ -1363,7 +1363,7 @@ class SearchTest extends TestCase
         $this->Search->filterByQuery('');
         $this->Search->setRandSeed(123456789);
         $this->assertEquals('random', $this->Search->sort('random'));
-        $this->assertSortBy('RAND(123456789)*16777216 DESC, id DESC');
+        $this->assertSortBy('RAND(123456789*id)*16777216 DESC, id DESC');
     }
 
     public function testSortByRandom_withSeed_withEmptyQuery_reversed() {
@@ -1371,14 +1371,14 @@ class SearchTest extends TestCase
         $this->Search->setRandSeed(123456789);
         $this->assertEquals('random', $this->Search->sort('random'));
         $this->Search->reverseSort(true);
-        $this->assertSortBy('RAND(123456789)*16777216 ASC, id ASC');
+        $this->assertSortBy('RAND(123456789*id)*16777216 ASC, id ASC');
     }
 
     public function testSortByRandom_withSeed_withNonEmptyQuery() {
         $this->Search->filterByQuery('comme ci comme ça');
         $this->Search->setRandSeed(123456789);
         $this->assertEquals('random', $this->Search->sort('random'));
-        $this->assertSortByRank('@rank DESC, id DESC', 'RAND(123456789)*16777216');
+        $this->assertSortByRank('@rank DESC, id DESC', 'RAND(123456789*id)*16777216');
     }
 
     public function testSortByRandom_withSeed_withNonEmptyQuery_reversed() {
@@ -1386,7 +1386,7 @@ class SearchTest extends TestCase
         $this->Search->setRandSeed(123456789);
         $this->assertEquals('random', $this->Search->sort('random'));
         $this->Search->reverseSort(true);
-        $this->assertSortByRank('@rank ASC, id ASC', 'RAND(123456789)*16777216');
+        $this->assertSortByRank('@rank ASC, id ASC', 'RAND(123456789*id)*16777216');
     }
 
     public function testRandSeed_resets() {


### PR DESCRIPTION
This PR allows to paginate results from the API `/sentences` endpoint when `sort=random` is used.

1. The initial call with `sort=random` computes a random seed value.
2. Paginated links include the seed value as `sort=random:<seed>`, e.g. `sort=random:12345`.
3. Subsequent calls read the seed value from the `sort=` parameter.

This ensures the same sentence won’t appear twice within a complete result set.