### PR TITLE
Add function isCorrectLastCharacter

### DIFF
--- a/src/Model/Entity/Sentence.php
+++ b/src/Model/Entity/Sentence.php
@@ -155,4 +155,82 @@ class Sentence extends Entity
     {
         return $this->correctness == \App\Model\Table\SentencesTable::MIN_CORRECTNESS;
     }
+    
+    /**
+     * Checks if the last character of a sentence is a typical character in
+     * that sentence's language. Assumes that the sentence is not empty.
+     * 
+     * @param string $sentence The sentence to be checked.
+     * @param string $lang Three-letter-code of the language of the sentence.
+     * 
+     * @return true|string Returns true, if the last character is judged to be OK,
+     *                     and the offending character in all other cases.
+     */
+    public function isCorrectLastCharacter() 
+    {
+        $sentence = $this->sentence;
+        $lang = $this->lang;
+        
+        $last = mb_substr($sentence, -1);
+
+        if (in_array($lang, ['eng', 'rus', 'ita', 'epo', 'kab', 'deu', 'tur', 'fra',
+                             'ber', 'por', 'spa', 'hun', 'heb', 'nld', 'ukr', 'fin',
+                             'lit', 'pol', 'ces', 'mar', 'tat', 'mkd', 'tgl', 'tok',
+                             'dan', 'swe', 'lat', 'srp', 'ina', 'tlh', 'ron', 'lfn',
+                             'vie', 'slk', 'ind', 'bul', 'oci', 'swc', 'shi', 'hau',
+                             'nds', 'nob', 'lvs', 'kor', 'bel', 'ido', 'nnb', 'isl',
+                             'aze', 'ile', 'gos', 'nno', 'cat', 'kmr'])) {
+            if (mb_strpos(".?!\"”':…)»“", $last) !== false) return true;
+            return $last;
+        }
+    
+        if (in_array($lang, ['jpn', 'cmn', 'yue'])) {
+            if (mb_strpos("。？！」…）：", $last) !== false) return true;
+            return $last;
+        }
+    
+        if (in_array($lang, ['ara', 'pes', 'ckb'])) {
+            if (mb_strpos(".؟!\")", $last) !== false) return true;
+            return $last;
+        }
+
+        if (in_array($lang, ['hin', 'ben', 'asm'])) {
+            if (mb_strpos("।?!.\"", $last) !== false) return true;
+            return $last;
+        }
+
+        if ($lang == 'tig') {
+            if (mb_strpos("።:?.!፧፥፡", $last) !== false) return true;
+            return $last;
+        }
+    
+        if ($lang == 'hye') {
+            if (mb_strpos("։:", $last) !== false) return true;
+            return $last;
+        }
+      
+        if ($lang == 'ell') {
+            if (mb_strpos(".;!\"'”“»:…)", $last) !== false) return true;
+            return $last;
+        }
+      
+        if ($lang == 'yid') {
+            if (mb_strpos(".?!״”‟\":", $last) !== false) return true;
+            return $last;
+        }
+    
+        if ($lang == 'zgh') {
+            if (mb_strpos(".?!\"", $last) !== false) return true;
+            return $last;
+        }
+
+        if ($lang == 'jbo') {
+            if (mb_strpos("aeiou.", $last) !== false) return true;
+            return $last;
+        }
+        
+        // accept everything for languages that are not yet checked
+        return true;
+    }
+    
 }

--- a/tests/TestCase/Model/Entity/SentenceTest.php
+++ b/tests/TestCase/Model/Entity/SentenceTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace App\Test\TestCase\Model\Entity;
+
+use App\Model\Entity\Sentence;
+use Cake\TestSuite\TestCase;
+
+class SentenceTest extends TestCase
+{
+    public function testIsCorrectLastCharacter() 
+    {
+        $langs = ['epo', 'cmn', 'ara', 'asm', 'tig', 'hye', 'ell',
+                  'yid', 'zgh', 'jbo', 'hax', 'und', 'unknown'];
+        $sentences = ['no', 'OK.', 'Good?', 'Bad!', 'トムは人だ。',
+                      'Κρυώνετε;', '""', 'and now:', 'last…' ];
+        $expected = [
+            ['o',  true, true, true, '。', ';',  true, true, true], // epo
+            ['o',  '.',  '?',  '!',  true, ';',  '"',  ':',  true], // cmn
+            ['o',  true, '?',  true, '。', ';',  true, ':',  '…' ], // ara
+            ['o',  true, true, true, '。', ';',  true, ':',  '…' ], // asm
+            ['o',  true, true, true, '。', ';',  '"',  true, '…' ], // tig
+            ['o',  '.',  '?',  '!',  '。', ';',  '"',  true, '…' ], // hye
+            ['o',  true, '?',  true, '。', true, true, true, true], // ell
+            ['o',  true, true, true, '。', ';',  true, true, '…' ], // yid
+            ['o',  true, true, true, '。', ';',  true, ':',  '…' ], // zgh
+            [true, true, '?',  '!',  '。', ';',  '"',  ':',  '…' ], // jbo
+            [true, true, true, true, true, true, true, true, true], // hax
+            [true, true, true, true, true, true, true, true, true], // und
+            [true, true, true, true, true, true, true, true, true], // unknown
+        ];
+        
+        foreach ($langs as $i=>$lang) {
+            foreach ($sentences as $j=>$sentence) {
+                $entity = new Sentence(['lang' => $lang, 'sentence' => $sentence]);
+                $result = $entity->isCorrectLastCharacter($sentence, $lang);
+                $this->assertEquals($result, $expected[$i][$j]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a start on issue #3264.

I thought it might be a good idea to add this one already, although it is not used yet. I plan to add some more of such functions (checking the first symbol, checking all symbols of a sentence, checking some typical mistakes like space before comma and so on). Eventually they can be used to implement the real check.

I changed the function a little bit compared to the function given in the issue: It now returns the offending character instead of false. This might be useful in warning messages.

I'm unsure if the place I've choosen (`Model/Table/SentenceTable`) is a good place for these functions. If you prefere some other place, please just tell me.