### PR TITLE
Add support for audios hosted by Commons

### DIFF
--- a/config/Migrations/20260313094320_AddAudioSource.php
+++ b/config/Migrations/20260313094320_AddAudioSource.php
@@ -1,0 +1,17 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddAudioSource extends AbstractMigration
+{
+    public function change()
+    {
+        $table = $this->table('audios');
+        $table->addColumn('source', 'enum', [
+            'after' => 'external',
+            'default' => 'tatoeba',
+            'null' => false,
+            'values' => ['tatoeba', 'commons'],
+        ]);
+        $table->update();
+    }
+}

--- a/src/Model/Behavior/ExposedOnApiBehavior.php
+++ b/src/Model/Behavior/ExposedOnApiBehavior.php
@@ -294,7 +294,7 @@ class ExposedOnApiBehavior extends Behavior
         $exposedFields = [
             'id', 'created', 'author', 'license', 'attribution_url', 'download_url', 'created', 'modified'
         ];
-        $fields = ['id', 'external', 'created', 'modified', 'sentence_id'];
+        $fields = ['id', 'external', 'source', 'created', 'modified', 'sentence_id'];
         $query
             ->find('exposedFields', compact('exposedFields'))
             ->select($fields)

--- a/src/Model/Entity/Audio.php
+++ b/src/Model/Entity/Audio.php
@@ -13,6 +13,7 @@ class Audio extends Entity
         'author',
         'attribution_url',
         'license',
+        'download_url',
     ];
 
     public static $defaultExternal = array(
@@ -131,10 +132,22 @@ class Audio extends Entity
        }
     }
 
+    private function __getAudioDownloadAction() {
+        $action = 'download';
+        $request = Router::getRequest();
+        if ($request) {
+            $isApiCall = $request->getParam('prefix') == 'VHosts/Api';
+            if ($isApiCall) {
+                $action = 'file';
+            }
+        }
+        return $action;
+    }
+
     protected function _getDownloadUrl() {
         $url = [
             'controller' => 'audio',
-            'action' => 'file',
+            'action' => $this->__getAudioDownloadAction(),
             $this->id
         ];
         return Router::url($url);

--- a/src/Model/Entity/Audio.php
+++ b/src/Model/Entity/Audio.php
@@ -7,6 +7,9 @@ use Cake\Routing\Router;
 
 class Audio extends Entity
 {
+    const SOURCE_TATOEBA = 'tatoeba';
+    const SOURCE_COMMONS = 'commons';
+
     private $__wantedEnabled;
 
     protected $_virtual = [
@@ -24,8 +27,12 @@ class Audio extends Entity
 
     protected function _getExternal($external) {
         if (is_array($external)) {
-            $external = array_merge(self::$defaultExternal, $external);
-            $external = array_intersect_key($external, self::$defaultExternal);
+            $defaultExternal = self::$defaultExternal;
+            if ($this->source == self::SOURCE_COMMONS) {
+                $defaultExternal['download_url'] = '';
+            }
+            $external = array_merge($defaultExternal, $external);
+            $external = array_intersect_key($external, $defaultExternal);
         }
         return $external;
     }
@@ -145,11 +152,15 @@ class Audio extends Entity
     }
 
     protected function _getDownloadUrl() {
-        $url = [
-            'controller' => 'audio',
-            'action' => $this->__getAudioDownloadAction(),
-            $this->id
-        ];
-        return Router::url($url);
+        if ($this->source == self::SOURCE_COMMONS) {
+            return $this->external['download_url'] ?? null;
+        } else {
+            $url = [
+                'controller' => 'audio',
+                'action' => $this->__getAudioDownloadAction(),
+                $this->id
+            ];
+            return Router::url($url);
+        }
     }
 }

--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -690,7 +690,7 @@ class SentencesTable extends Table
     public function contain($what = [])
     {
         $audioContainment = function (Query $q) use ($what) {
-            $audioFields = ['id', 'external', 'sentence_id'];
+            $audioFields = ['id', 'external', 'source', 'sentence_id'];
             $usersFields = ['username'];
             if (isset($what['sentenceDetails'])) {
                 $audioFields[] = 'created';

--- a/src/View/Helper/SentenceButtonsHelper.php
+++ b/src/View/Helper/SentenceButtonsHelper.php
@@ -196,11 +196,7 @@ class SentenceButtonsHelper extends AppHelper
                 }
                 echo $this->Html->Link(
                     null,
-                    $this->Url->build([
-                        'controller' => 'audio',
-                        'action' => 'download',
-                        $audio->id
-                    ]),
+                    $audio->download_url,
                     array(
                         'title' => $title,
                         'class' => $class,

--- a/tests/Fixture/AudiosFixture.php
+++ b/tests/Fixture/AudiosFixture.php
@@ -111,6 +111,21 @@ class AudiosFixture extends TestFixture
                 'created' => '2023-03-03 13:42:42',
                 'modified' => '2023-03-03 13:42:42'
             ],
+            [
+                'id' => 8,
+                'sentence_id' => 66,
+                'sentence_lang' => 'uzb',
+                'user_id' => NULL,
+                'external' => [
+                    'username' => 'External Contributor',
+                    'attribution_url' => 'https://commons.wikimedia.example.org/wiki/File:LL-Q9264_%28uzb%29-Contributor-%D0%98%D1%88%D0%B8%D0%BD%D0%B3%D0%BD%D0%B8%20%D2%9B%D0%B8%D0%BB%21.wav',
+                    'license' => 'CC BY 4.0',
+                    'download_url' => 'https://upload.wikimedia.example.org/wikipedia/commons/the-file.mp3',
+                ],
+                'source' => 'commons',
+                'created' => '2026-02-03 21:00:01',
+                'modified' => '2026-02-03 21:00:01'
+            ],
         ];
         parent::init();
     }

--- a/tests/Fixture/AudiosFixture.php
+++ b/tests/Fixture/AudiosFixture.php
@@ -14,6 +14,7 @@ class AudiosFixture extends TestFixture
         'sentence_lang' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 4, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'],
         'user_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
         'external' => ['type' => 'json', 'length' => 500, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'source' => ['type' => 'string', 'length' => null, 'null' => false, 'default' => 'tatoeba', 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
         'created' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         'modified' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         '_indexes' => [
@@ -37,6 +38,7 @@ class AudiosFixture extends TestFixture
                 'sentence_lang' => 'spa',
                 'user_id' => 4,
                 'external' => NULL,
+                'source' => 'tatoeba',
                 'created' => '2014-01-20 09:23:49',
                 'modified' => '2014-01-21 21:01:21'
             ],
@@ -46,6 +48,7 @@ class AudiosFixture extends TestFixture
                 'sentence_lang' => 'fra',
                 'user_id' => NULL,
                 'external' => [ 'username' => 'Philippe Petit' ],
+                'source' => 'tatoeba',
                 'created' => '2001-12-02 06:47:30',
                 'modified' => '2001-12-12 06:47:30'
             ],
@@ -59,6 +62,7 @@ class AudiosFixture extends TestFixture
                     'attribution_url' => 'https://example.fr/petit',
                     'license' => 'CC BY-NC 4.0',
                 ],
+                'source' => 'tatoeba',
                 'created' => '2001-12-02 06:47:30',
                 'modified' => '2001-12-12 06:47:30'
             ],
@@ -72,6 +76,7 @@ class AudiosFixture extends TestFixture
                 'sentence_lang' => 'spa',
                 'user_id' => 2,
                 'external' => NULL,
+                'source' => 'tatoeba',
                 'created' => '2022-01-20 09:23:49',
                 'modified' => '2022-01-21 21:01:21'
             ],
@@ -82,6 +87,7 @@ class AudiosFixture extends TestFixture
                 'sentence_lang' => 'fra',
                 'user_id' => 3,
                 'external' => NULL,
+                'source' => 'tatoeba',
                 'created' => '2023-02-01 02:23:33',
                 'modified' => '2023-02-01 02:23:33'
             ],
@@ -91,6 +97,7 @@ class AudiosFixture extends TestFixture
                 'sentence_lang' => 'eng',
                 'user_id' => 3,
                 'external' => NULL,
+                'source' => 'tatoeba',
                 'created' => '2023-02-02 02:23:33',
                 'modified' => '2023-02-02 02:23:33'
             ],
@@ -100,6 +107,7 @@ class AudiosFixture extends TestFixture
                 'sentence_lang' => 'jpn',
                 'user_id' => 7,
                 'external' => NULL,
+                'source' => 'tatoeba',
                 'created' => '2023-03-03 13:42:42',
                 'modified' => '2023-03-03 13:42:42'
             ],

--- a/tests/TestCase/Controller/VHosts/Api/AudioControllerTest.php
+++ b/tests/TestCase/Controller/VHosts/Api/AudioControllerTest.php
@@ -47,6 +47,12 @@ class AudioControllerTest extends TestCase
         $this->deleteAudioStorageDir();
     }
 
+    public function testDownload_audioUsingCommonsSource()
+    {
+        $this->get("http://api.example.com/unstable/audios/8/file");
+        $this->assertResponseCode(404);
+    }
+
     public function testDownload_nonExistingAudio()
     {
         $this->get("http://api.example.com/unstable/audios/9999999999/file");

--- a/tests/TestCase/Controller/VHosts/Api/SentencesControllerTest.php
+++ b/tests/TestCase/Controller/VHosts/Api/SentencesControllerTest.php
@@ -261,6 +261,22 @@ class SentencesControllerTest extends TestCase
         $this->assertJsonDocumentMatches($actual, $expected);
     }
 
+    public function testGetSentence_returnsLocalAudioFileURL()
+    {
+        $this->get("http://api.example.com/v1/sentences/57?include=audios");
+        $actual = $this->_getBodyAsString();
+        $expected = 'http://api.example.com/v1/audio/7/file';
+        $this->assertJsonValueEquals($actual, '$.data.audios[0].download_url', $expected);
+    }
+
+    public function testGetSentence_returnsCommonsAudioFileURL()
+    {
+        $this->get("http://api.example.com/v1/sentences/66?include=audios");
+        $actual = $this->_getBodyAsString();
+        $expected = 'https://upload.wikimedia.example.org/wikipedia/commons/the-file.mp3';
+        $this->assertJsonValueEquals($actual, '$.data.audios[0].download_url', $expected);
+    }
+
     public function testSearch_requiresLangAndSortParam()
     {
         $this->get("http://api.example.com/unstable/sentences?q=hello");

--- a/tests/TestCase/Model/Table/AudiosTableTest.php
+++ b/tests/TestCase/Model/Table/AudiosTableTest.php
@@ -343,40 +343,42 @@ class AudiosTableTest extends TestCase {
     function testSentencesFinder() {
         $result = $this->Audio->find('sentences')->all()->toList();
 
-        $this->assertEquals(5, count($result));
+        $expected = [
+            [66, 1],  // sentence id, audio count
+            [57, 1],
+            [15, 1],
+            [4,  2],
+            [12, 1],
+            [3,  1],
+        ];
 
-        $this->assertEquals(57, $result[0]->id);
-        $this->assertEquals(1, count($result[0]->audios));
+        $this->assertEquals(count($expected), count($result));
 
-        $this->assertEquals(15, $result[1]->id);
-        $this->assertEquals(1, count($result[1]->audios));
-
-        $this->assertEquals(4, $result[2]->id);
-        $this->assertEquals(2, count($result[2]->audios));
-
-        $this->assertEquals(12, $result[3]->id);
-        $this->assertEquals(1, count($result[3]->audios));
-
-        $this->assertEquals(3, $result[4]->id);
-        $this->assertEquals(1, count($result[4]->audios));
+        foreach ($result as $audio) {
+            list($expectedSentenceId, $expectedAudioCount) = array_shift($expected);
+            $this->assertEquals($expectedSentenceId, $audio->id);
+            $this->assertEquals($expectedAudioCount, count($audio->audios));
+        }
     }
 
     function testSentencesFinder_maxResults() {
         $result = $this->Audio->find('sentences', ['maxResults' => 5])->all()->toList();
 
-        $this->assertEquals(4, count($result));
+        $expected = [
+            [66, 1],  // sentence id, audio count
+            [57, 1],
+            [15, 1],
+            [4,  2],
+            [12, 1],
+        ];
 
-        $this->assertEquals(57, $result[0]->id);
-        $this->assertEquals(1, count($result[0]->audios));
+        $this->assertEquals(count($expected), count($result));
 
-        $this->assertEquals(15, $result[1]->id);
-        $this->assertEquals(1, count($result[1]->audios));
-
-        $this->assertEquals(4, $result[2]->id);
-        $this->assertEquals(2, count($result[2]->audios));
-
-        $this->assertEquals(12, $result[3]->id);
-        $this->assertEquals(1, count($result[3]->audios));
+        foreach ($result as $audio) {
+            list($expectedSentenceId, $expectedAudioCount) = array_shift($expected);
+            $this->assertEquals($expectedSentenceId, $audio->id);
+            $this->assertEquals($expectedAudioCount, count($audio->audios));
+        }
     }
 
     function testSentencesFinder_lang() {
@@ -451,7 +453,7 @@ class AudiosTableTest extends TestCase {
     function testSentencesCountFinder() {
         $result = $this->Audio->find('sentencesCount');
 
-        $this->assertEquals(5, $result);
+        $this->assertEquals(6, $result);
     }
 
     function testSentencesCountFinder_withLang() {

--- a/tests/TestCase/Model/Table/AudiosTableTest.php
+++ b/tests/TestCase/Model/Table/AudiosTableTest.php
@@ -527,4 +527,16 @@ class AudiosTableTest extends TestCase {
         $this->assertEquals('', $audio->license);
         $this->assertEquals('Philippe Petit', $audio->author);
     }
+
+    function testGetAudio_virtualFields_downloadUrl_localFile() {
+        $audio = $this->Audio->findById(1)->first();
+
+        $this->assertEquals('/audio/download/1', $audio->download_url);
+    }
+
+    function testGetAudio_virtualFields_downloadUrl_onCommons() {
+        $audio = $this->Audio->findById(8)->first();
+
+        $this->assertEquals('https://upload.wikimedia.example.org/wikipedia/commons/the-file.mp3', $audio->download_url);
+    }
 }

--- a/webroot/js/directives/audio-button.dir.js
+++ b/webroot/js/directives/audio-button.dir.js
@@ -57,7 +57,7 @@
         
                 function getAudioUrl(audios, playIndex = undefined) {
                     playIndex = (typeof playIndex !== 'undefined') ? playIndex : getNextPlayAudioIndex(audios);
-                    return rootUrl + '/audio/download/' + audios[playIndex].id;
+                    return audios[playIndex].download_url;
                 }
 
                 function playAudio(audios) {


### PR DESCRIPTION
This PR is a first step towards allowing to use Lingua Libre to record Tatoeba sentences #3183 . It changes the Audio model to allow storing audios that are mere references to audio files hosted by Wikimedia Commons.

Such audios have an associated `download_url` that points to an external URL, while audios hosted by Tatoeba have an associated `download_url` that is simply an internal URL that serves the audio file. This `download_url` is used by both front-end and API access actual audio files.