### PR TITLE
Add language badge to sentence page. Fixes #2611

### DIFF
--- a/templates/Sentences/show.php
+++ b/templates/Sentences/show.php
@@ -80,9 +80,11 @@ echo $this->element('/sentences/navigation', [
                 <h2 flex style="display: flex; align-items: center; margin: 0;">
                     <?= format(__('Sentence #{number}'), array('number' => $sentenceId)); ?>
                     
+                    <?php if (!empty($languageName)): ?>
                     <span style="background-color: rgba(255, 255, 255, 0.2); color: #ffffff; border-radius: 12px; padding: 2px 10px; font-size: 0.6em; font-weight: bold; margin-left: 12px; border: 1px solid rgba(255, 255, 255, 0.4); text-transform: uppercase; cursor: default; display: inline-block; line-height: 1.4;">
                         <?= h($languageName) ?>
                     </span>
+                    <?php endif; ?>
                 </h2>
 
                 <md-button hide-gt-sm ng-controller="SidenavController" ng-click="toggle('metadata')">

--- a/templates/Sentences/show.php
+++ b/templates/Sentences/show.php
@@ -77,25 +77,7 @@ echo $this->element('/sentences/navigation', [
     <section>
         <md-toolbar class="md-hue-2">
             <div class="md-toolbar-tools">
-                <h2 flex style="display: flex; align-items: center; margin: 0;">
-                    <?= format(__('Sentence #{number}'), array('number' => $sentenceId)); ?>
-                    
-                    <?php if (!empty($languageName)): ?>
-                    <style>
-                        <?php /* language badge, shows only ISO code for small screen devices */ ?>
-                        .lang-badge .lang-code { display: none; }
-                        @media (max-width: 599px) {
-                            .lang-badge .lang-name { display: none; }
-                            .lang-badge .lang-code { display: inline; }
-                        }
-                    </style>
-                    <span class="lang-badge" style="background-color: rgba(255, 255, 255, 0.2); color: #ffffff; border-radius: 12px; padding: 2px 10px; font-size: 0.6em; font-weight: bold; margin-left: 12px; border: 1px solid rgba(255, 255, 255, 0.4); text-transform: uppercase; cursor: default; display: inline-block; line-height: 1.4;">
-                        <span class="lang-name"><?= h($languageName) ?></span>
-                        <span class="lang-code"><?= h($sentenceLang) ?></span>
-                    </span>
-                    <?php endif; ?>
-                </h2>
-
+                <h2 flex><?= format(__('Sentence #{number}'), array('number' => $sentenceId)); ?></h2>
                 <md-button hide-gt-sm ng-controller="SidenavController" ng-click="toggle('metadata')">
                     <md-icon>info_outline</md-icon>
                     <?php /* @translators: button to open the sidebar on the sentence page on mobile */ ?>
@@ -241,6 +223,7 @@ echo $this->element('/sentences/navigation', [
                 'sentenceId' => $sentenceId,
                 'license' => $sentence->license,
                 'canEdit' => CurrentUser::canEditLicenseOfSentence($sentence),
+                'languageName' => $languageName,
             )
         );
 

--- a/templates/Sentences/show.php
+++ b/templates/Sentences/show.php
@@ -81,8 +81,17 @@ echo $this->element('/sentences/navigation', [
                     <?= format(__('Sentence #{number}'), array('number' => $sentenceId)); ?>
                     
                     <?php if (!empty($languageName)): ?>
-                    <span style="background-color: rgba(255, 255, 255, 0.2); color: #ffffff; border-radius: 12px; padding: 2px 10px; font-size: 0.6em; font-weight: bold; margin-left: 12px; border: 1px solid rgba(255, 255, 255, 0.4); text-transform: uppercase; cursor: default; display: inline-block; line-height: 1.4;">
-                        <?= h($languageName) ?>
+                    <style>
+                        <?php /* language badge, shows only ISO code for small screen devices */ ?>
+                        .lang-badge .lang-code { display: none; }
+                        @media (max-width: 599px) {
+                            .lang-badge .lang-name { display: none; }
+                            .lang-badge .lang-code { display: inline; }
+                        }
+                    </style>
+                    <span class="lang-badge" style="background-color: rgba(255, 255, 255, 0.2); color: #ffffff; border-radius: 12px; padding: 2px 10px; font-size: 0.6em; font-weight: bold; margin-left: 12px; border: 1px solid rgba(255, 255, 255, 0.4); text-transform: uppercase; cursor: default; display: inline-block; line-height: 1.4;">
+                        <span class="lang-name"><?= h($languageName) ?></span>
+                        <span class="lang-code"><?= h($sentenceLang) ?></span>
                     </span>
                     <?php endif; ?>
                 </h2>

--- a/templates/Sentences/show.php
+++ b/templates/Sentences/show.php
@@ -87,6 +87,7 @@ echo $this->element('/sentences/navigation', [
 
                 <md-button hide-gt-sm ng-controller="SidenavController" ng-click="toggle('metadata')">
                     <md-icon>info_outline</md-icon>
+                    <?php /* @translators: button to open the sidebar on the sentence page on mobile */ ?>
                     <?= __('Metadata') ?>
                 </md-button>
             </div>

--- a/templates/Sentences/show.php
+++ b/templates/Sentences/show.php
@@ -77,10 +77,16 @@ echo $this->element('/sentences/navigation', [
     <section>
         <md-toolbar class="md-hue-2">
             <div class="md-toolbar-tools">
-                <h2 flex><?= format(__('Sentence #{number}'), array('number' => $sentenceId)); ?></h2>
+                <h2 flex style="display: flex; align-items: center; margin: 0;">
+                    <?= format(__('Sentence #{number}'), array('number' => $sentenceId)); ?>
+                    
+                    <span style="background-color: rgba(255, 255, 255, 0.2); color: #ffffff; border-radius: 12px; padding: 2px 10px; font-size: 0.6em; font-weight: bold; margin-left: 12px; border: 1px solid rgba(255, 255, 255, 0.4); text-transform: uppercase; cursor: default; display: inline-block; line-height: 1.4;">
+                        <?= h($languageName) ?>
+                    </span>
+                </h2>
+
                 <md-button hide-gt-sm ng-controller="SidenavController" ng-click="toggle('metadata')">
                     <md-icon>info_outline</md-icon>
-                    <?php /* @translators: button to open the sidebar on the sentence page on mobile */ ?>
                     <?= __('Metadata') ?>
                 </md-button>
             </div>

--- a/templates/element/sentences/license.php
+++ b/templates/element/sentences/license.php
@@ -31,6 +31,11 @@ use App\Model\CurrentUser;
     <h2><?php echo __('Sentence text') ?></h2>
 
 <?php
+/* Language name of the sentence text */
+echo '<div style="margin-bottom: 12px;">' . format(
+    __('Language') . ': {}',
+    $languageName
+) . '</div>';
 echo format(
     /* @translators: placeholder is the name of the license
        of the sentence text, could be CC BY 2.0 FR or CC0 */


### PR DESCRIPTION
<img width="1950" height="940" alt="image" src="https://github.com/user-attachments/assets/0ab76bc7-256a-4aa1-953d-6bf82b7ad9b2" />
Adding language name badge in sentence page.

Fixes #2611