### PR TITLE
Prevent saving whitespace-only sentences

### DIFF
--- a/src/Model/Table/SentencesTable.php
+++ b/src/Model/Table/SentencesTable.php
@@ -125,7 +125,7 @@ class SentencesTable extends Table
     public function validationDefault(Validator $validator): \Cake\Validation\Validator
     {
         $validator
-            ->notEmptyString('text');
+            ->notBlank('text');
 
         $sentenceLicenses = array_keys(Licenses::getSentenceLicenses());
         $validator

--- a/tests/TestCase/Model/Table/SentencesTableTest.php
+++ b/tests/TestCase/Model/Table/SentencesTableTest.php
@@ -242,6 +242,16 @@ class SentencesTableTest extends TestCase {
         $this->assertTrue((bool)$result);
     }
 
+    function testSave_sentenceContainingOnlySpace() {
+        $sentence = $this->Sentence->newEntity([
+            'text' => ' ',
+        ]);
+
+        $result = $this->Sentence->save($sentence);
+
+        $this->assertFalse((bool)$result);
+    }
+
     function testSave_checksValidLicense() {
         $data = $this->Sentence->newEntity([
             'text' => 'Trying to save a sentence with an invalid license.',


### PR DESCRIPTION
## Summary

Prevent sentences containing only whitespace from being saved.

## Issue

A sentence containing only spaces passes `notEmptyString()` validation before the entity mutator removes whitespace, allowing an empty sentence to be saved.

## Changes

- Replace `notEmptyString('text')` with `notBlank('text')`.
- Add a regression test covering space-only sentence input.

## Testing

Not run locally because PHP/PHPUnit environment is not installed.