### PR TITLE
Fix internal error when saving profile image with no file selected

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -134,11 +134,15 @@ class UserController extends AppController
             $image = $data['image'];
         }
 
-        // We first check if a file has been correctly uploaded
-        $tmpName = $image->getStream()->getMetadata('uri');
-        $redirect = (empty($data) || empty($image)) ||
-                    ($image->getError() != UPLOAD_ERR_OK) ||
-                    !is_uploaded_file($tmpName);
+        // We first check if a file has been correctly uploaded. The stream is
+        // only inspected once we know an actual file was uploaded, otherwise
+        // getStream() throws (or $image is null) when no file was selected.
+        $redirect = empty($data) || empty($image) ||
+                    ($image->getError() != UPLOAD_ERR_OK);
+        if (!$redirect) {
+            $tmpName = $image->getStream()->getMetadata('uri');
+            $redirect = !is_uploaded_file($tmpName);
+        }
         if ($redirect) {
             $this->Flash->set(
                 __('Failed to upload image')

--- a/tests/TestCase/Controller/UserControllerTest.php
+++ b/tests/TestCase/Controller/UserControllerTest.php
@@ -316,6 +316,28 @@ class UserControllerTest extends IntegrationTestCase
         $this->assertProfilePictureUploaded($username);
     }
 
+    public function testSaveImageWithNoFile() {
+        $username = 'contributor';
+        $this->logInAs($username);
+        // A form submitted without selecting a file yields an upload with
+        // UPLOAD_ERR_NO_FILE whose stream cannot be read; the controller must
+        // report it gracefully rather than raising an internal error.
+        $image = new \Laminas\Diactoros\UploadedFile(
+            '',
+            0,
+            \UPLOAD_ERR_NO_FILE,
+            '',
+            '',
+        );
+        $files = compact('image');
+        $this->configRequest(compact('files'));
+
+        $this->post('/en/user/save_image', $files);
+
+        $this->assertFlashMessage('Failed to upload image');
+        $this->assertRedirect("/en/user/profile/$username");
+    }
+
     public function testRemoveImage() {
         $users = $this->fetchTable('Users');
         $contributor = $users->get(4);


### PR DESCRIPTION
## Problem

`save_image()` raises an internal error when the profile-image form is submitted without selecting a file (#3322). It reads the uploaded file's stream *before* validating that a file was actually uploaded:

```php
$tmpName = $image->getStream()->getMetadata('uri');   // runs first
$redirect = (empty($data) || empty($image)) || ...     // guard runs after
```

When no file is selected, either `$image` is `null` (the field is absent) or it is an `UPLOAD_ERR_NO_FILE` upload whose `getStream()` throws a `RuntimeException`. Both crash before the guard that was meant to show the "Failed to upload image" flash.

## Fix

Move the `getStream()` / `is_uploaded_file()` check so it only runs once the upload is known to be a successful file. The validation is otherwise unchanged: a valid upload behaves exactly as before, while a missing/errored upload now redirects to the profile with the "Failed to upload image" flash — the expected behavior described in the issue.

## Test

Adds `testSaveImageWithNoFile()` to `UserControllerTest`, which posts an `UPLOAD_ERR_NO_FILE` upload and asserts the flash message + redirect (this fails on the old code, which raised the internal error). Both changed files pass `php -l`; I don't have a local CakePHP + DB setup to run the full PHPUnit suite, so I'm relying on CI for that.

Closes #3322

---
AI disclosure: prepared with AI assistance (Claude Code); the fix and test were written and verified against the code before submitting.
