### PR TITLE
Resynchronize sentence state after transcription save (#3262)

### DIFF
--- a/webroot/js/directives/sentence-and-translations.dir.js
+++ b/webroot/js/directives/sentence-and-translations.dir.js
@@ -577,7 +577,10 @@
             }).finally(function() {
                 sentence.transcriptions.splice(i, 1);
                 sentence.transcriptions.push(transcription);
-                initTranscriptions(sentence);
+                // Keep the editable model and its baseline in sync with the
+                // transcription returned by the server. Otherwise the next
+                // edit is compared with the pre-save transcription.
+                initSentence(sentence);
                 vm.inProgress = false;
             });
         }


### PR DESCRIPTION
Fixes #3262

After saving a transcription, refresh the editable sentence model and its comparison baseline from the server response. This keeps consecutive transcription edits aligned with the latest persisted state instead of comparing against stale client data.

Validation:
- node --check webroot/js/directives/sentence-and-translations.dir.js
- git diff --check
- targeted browser test not run because this checkout has no configured frontend test runner