### PR TITLE
Handle duplicate vocabulary submissions (#3292)

### DIFF
--- a/src/Model/Table/VocabularyTable.php
+++ b/src/Model/Table/VocabularyTable.php
@@ -124,10 +124,24 @@ class VocabularyTable extends Table
         }
 
         if ($vocable) {
-            try {
-                $this->UsersVocabulary->add($vocable->id, CurrentUser::get('id'));
-            } catch (\PDOException $e) {
+            $alreadyAdded = $this->UsersVocabulary->findFirst(
+                $vocable->id,
+                CurrentUser::get('id')
+            );
+            if ($alreadyAdded) {
                 $vocable->duplicate = true;
+            } else {
+                try {
+                    $added = $this->UsersVocabulary->add(
+                        $vocable->id,
+                        CurrentUser::get('id')
+                    );
+                    if (!$added) {
+                        $vocable->duplicate = true;
+                    }
+                } catch (\PDOException $e) {
+                    $vocable->duplicate = true;
+                }
             }
 
             if (Configure::read('Search.enabled')) {

--- a/templates/Vocabulary/add.php
+++ b/templates/Vocabulary/add.php
@@ -106,6 +106,10 @@ $this->set('title_for_layout', $this->Pages->formatTitle($title));
             </div>
         <?= $this->Form->end() ?>
 
+        <p ng-if="ctrl.error" role="alert">
+            <?= h(__('An error occurred while adding the vocabulary item.')) ?>
+        </p>
+
     </section>
 
     <section class="md-whiteframe-1dp">

--- a/tests/TestCase/Controller/VocabularyControllerTest.php
+++ b/tests/TestCase/Controller/VocabularyControllerTest.php
@@ -74,6 +74,18 @@ class VocabularyControllerTest extends IntegrationTestCase
         $this->assertResponseOk();
     }
 
+    public function testSave_asMember_duplicate() {
+        $this->logInAs('contributor');
+        $this->ajaxPost('/en/vocabulary/save', [
+            'lang' => 'eng',
+            'text' => 'out of the blue',
+        ]);
+
+        $this->assertResponseOk();
+        $response = json_decode((string)$this->_response->getBody(), true);
+        $this->assertTrue($response['duplicate']);
+    }
+
     public function testEdit_asGuest() {
         $this->enableCsrfToken();
         $this->ajaxPost('/en/vocabulary/edit/1', [

--- a/webroot/js/vocabulary/add.ctrl.js
+++ b/webroot/js/vocabulary/add.ctrl.js
@@ -47,6 +47,7 @@
 
         vm.data = {};
         vm.vocabularyAdded = [];
+        vm.error = false;
 
         vm.add = add;
         vm.remove = remove;
@@ -57,6 +58,7 @@
 
         function add() {
             vm.isAdding = true;
+            vm.error = false;
 
             var req = {
                 method: 'POST',
@@ -80,6 +82,10 @@
                     vm.data.text = '';
                     vm.isAdding = false;
                     $scope.focusInput = true;
+                },
+                function() {
+                    vm.isAdding = false;
+                    vm.error = true;
                 }
             );
         }


### PR DESCRIPTION
Fixes #3292

Handle duplicate vocabulary submissions as a normal response and clear the loading state with a visible error when the save request fails. This keeps the vocabulary form responsive after a duplicate entry.

Validation:
- PHP syntax checks passed for changed PHP files
- node --check passed for the changed JavaScript
- git diff --check
- targeted PHPUnit was not run because this checkout has no installed Composer test runner